### PR TITLE
Support for saving and reading uncap level on user objects

### DIFF
--- a/app/controllers/api/v1/grid_characters_controller.rb
+++ b/app/controllers/api/v1/grid_characters_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::GridCharactersController < Api::V1::ApiController
     end
 
     def update_uncap_level
-        @character = GridCharacter.find(weapon_params[:id])
+        @character = GridCharacter.find(character_params[:id])
 
         if current_user
             if @character.party.user != current_user
@@ -40,6 +40,6 @@ class Api::V1::GridCharactersController < Api::V1::ApiController
 
     # Specify whitelisted properties that can be modified.
     def character_params
-        params.require(:character).permit(:party_id, :character_id, :position, :uncap_level)
+        params.require(:character).permit(:id, :party_id, :character_id, :position, :uncap_level)
     end
 end

--- a/app/controllers/api/v1/grid_characters_controller.rb
+++ b/app/controllers/api/v1/grid_characters_controller.rb
@@ -20,6 +20,19 @@ class Api::V1::GridCharactersController < Api::V1::ApiController
         render :show, status: :created if @character.save!
     end
 
+    def update_uncap_level
+        @character = GridCharacter.find(weapon_params[:id])
+
+        if current_user
+            if @character.party.user != current_user
+                render_unauthorized_response
+            end
+        end
+
+        @character.uncap_level = character_params[:uncap_level]
+        render :show, status: :ok if @character.save!
+    end
+
     def destroy
     end
 
@@ -27,6 +40,6 @@ class Api::V1::GridCharactersController < Api::V1::ApiController
 
     # Specify whitelisted properties that can be modified.
     def character_params
-        params.require(:character).permit(:party_id, :character_id, :position)
+        params.require(:character).permit(:party_id, :character_id, :position, :uncap_level)
     end
 end

--- a/app/controllers/api/v1/grid_summons_controller.rb
+++ b/app/controllers/api/v1/grid_summons_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::GridSummonsController < Api::V1::ApiController
     end
     
     def update_uncap_level
-        @summon = GridSummon.find@summon_params[:id])
+        @summon = GridSummon.find(summon_params[:id])
 
         if current_user
             if @summon.party.user != current_user
@@ -40,6 +40,6 @@ class Api::V1::GridSummonsController < Api::V1::ApiController
 
     # Specify whitelisted properties that can be modified.
     def summon_params
-        params.require(:summon).permit(:party_id, :summon_id, :position, :main, :friend, :uncap_level)
+        params.require(:summon).permit(:id, :party_id, :summon_id, :position, :main, :friend, :uncap_level)
     end
 end

--- a/app/controllers/api/v1/grid_summons_controller.rb
+++ b/app/controllers/api/v1/grid_summons_controller.rb
@@ -19,6 +19,19 @@ class Api::V1::GridSummonsController < Api::V1::ApiController
         @summon = GridSummon.create!(summon_params.merge(party_id: party.id, summon_id: canonical_summon.id))
         render :show, status: :created if @summon.save!
     end
+    
+    def update_uncap_level
+        @summon = GridSummon.find@summon_params[:id])
+
+        if current_user
+            if @summon.party.user != current_user
+                render_unauthorized_response
+            end
+        end
+
+        @summon.uncap_level = summon_params[:uncap_level]
+        render :show, status: :ok if @summon.save!
+    end
 
     def destroy
     end
@@ -27,6 +40,6 @@ class Api::V1::GridSummonsController < Api::V1::ApiController
 
     # Specify whitelisted properties that can be modified.
     def summon_params
-        params.require(:summon).permit(:party_id, :summon_id, :position, :main, :friend)
+        params.require(:summon).permit(:party_id, :summon_id, :position, :main, :friend, :uncap_level)
     end
 end

--- a/app/controllers/api/v1/grid_weapons_controller.rb
+++ b/app/controllers/api/v1/grid_weapons_controller.rb
@@ -20,6 +20,19 @@ class Api::V1::GridWeaponsController < Api::V1::ApiController
         render :show, status: :created if @weapon.save!
     end
 
+    def update_uncap_level
+        @weapon = GridWeapon.find(weapon_params[:id])
+
+        if current_user
+            if @weapon.party.user != current_user
+                render_unauthorized_response
+            end
+        end
+
+        @weapon.uncap_level = weapon_params[:uncap_level]
+        render :show, status: :ok if @weapon.save!
+    end
+
     def destroy
     end
 
@@ -27,6 +40,6 @@ class Api::V1::GridWeaponsController < Api::V1::ApiController
 
     # Specify whitelisted properties that can be modified.
     def weapon_params
-        params.require(:weapon).permit(:party_id, :weapon_id, :position, :mainhand)
+        params.require(:weapon).permit(:id, :party_id, :weapon_id, :position, :mainhand, :uncap_level)
     end
 end

--- a/app/views/api/v1/characters/base.json.rabl
+++ b/app/views/api/v1/characters/base.json.rabl
@@ -5,7 +5,8 @@ attributes :id,
     :rarity,
     :element,
     :gender,
-    :max_level
+    :max_level,
+    :special
 
 node :name do |w|
     {

--- a/app/views/api/v1/characters/base.json.rabl
+++ b/app/views/api/v1/characters/base.json.rabl
@@ -17,7 +17,8 @@ end
 
 node :uncap do |w|
     {
-        :flb => w.flb
+        :flb => w.flb,
+        :ulb => w.ulb
     }
 end
 

--- a/app/views/api/v1/grid_characters/base.json.rabl
+++ b/app/views/api/v1/grid_characters/base.json.rabl
@@ -1,6 +1,7 @@
 attributes :id,
     :party_id,
-    :position
+    :position,
+    :uncap_level
 
 node :character do |c|
     partial("characters/base", :object => c.character)

--- a/app/views/api/v1/grid_summons/base.json.rabl
+++ b/app/views/api/v1/grid_summons/base.json.rabl
@@ -2,7 +2,8 @@ attributes :id,
     :party_id,
     :main,
     :friend,
-    :position
+    :position,
+    :uncap_level
 
 node :summon do |s|
     partial('summons/base', :object => s.summon)

--- a/app/views/api/v1/grid_weapons/base.json.rabl
+++ b/app/views/api/v1/grid_weapons/base.json.rabl
@@ -1,7 +1,8 @@
 attributes :id,
     :party_id,
     :mainhand,
-    :position
+    :position,
+    :uncap_level
 
 node :weapon do |w|
     partial("weapons/base", :object => w.weapon)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -8,7 +8,7 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     # origins ENV.fetch("CORS_ORIGIN","").split(",")
-    origins ["127.0.0.1:3000", "app.granblue.team", "hensei-web-production.up.railway.app"]
+    origins ["127.0.0.1:1234", "app.granblue.team", "hensei-web-production.up.railway.app"]
     resource '*',
       headers: :any,
       methods: [:get, :post, :put, :patch, :delete, :options, :head]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,12 +17,15 @@ Rails.application.routes.draw do
             get 'search/summons', to: 'search#summons'
 
             post 'characters', to: 'grid_characters#create'
+            post 'characters/update_uncap', to: 'grid_characters#update_uncap_level'
             delete 'characters', to: 'grid_characters#destroy'
 
             post 'weapons', to: 'grid_weapons#create'
+            post 'weapons/update_uncap', to: 'grid_weapons#update_uncap_level'
             delete 'weapons', to: 'grid_weapons#destroy'
 
             post 'summons', to: 'grid_summons#create'
+            post 'summons/update_uncap', to: 'grid_summons#update_uncap_level'
             delete 'summons', to: 'grid_summons#destroy'
         end
     end

--- a/db/migrate/20220202005218_add_special_to_characters.rb
+++ b/db/migrate/20220202005218_add_special_to_characters.rb
@@ -1,0 +1,10 @@
+class AddSpecialToCharacters < ActiveRecord::Migration[6.1]
+    def up
+        add_column :characters, :special, :boolean, :default => false
+        change_column_null :characters, :special, false
+    end
+    
+    def down
+        remove_column :characters, :special, :boolean
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_28_183534) do
+ActiveRecord::Schema.define(version: 2022_02_02_005218) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
-  enable_extension "timescaledb"
 
   create_table "characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name_en"
@@ -28,8 +27,7 @@ ActiveRecord::Schema.define(version: 2022_01_28_183534) do
     t.integer "gender"
     t.integer "race1"
     t.integer "race2"
-    t.boolean "flb"
-    t.boolean "max_level"
+    t.boolean "flb", default: false, null: false
     t.integer "min_hp"
     t.integer "max_hp"
     t.integer "max_hp_flb"
@@ -40,6 +38,10 @@ ActiveRecord::Schema.define(version: 2022_01_28_183534) do
     t.integer "base_ta"
     t.float "ougi_ratio"
     t.float "ougi_ratio_flb"
+    t.boolean "ulb", default: false, null: false
+    t.integer "max_atk_ulb"
+    t.integer "max_hp_ulb"
+    t.boolean "special", default: false, null: false
   end
 
   create_table "grid_characters", force: :cascade do |t|
@@ -147,7 +149,6 @@ ActiveRecord::Schema.define(version: 2022_01_28_183534) do
     t.integer "max_atk"
     t.integer "max_atk_flb"
     t.integer "max_atk_ulb"
-    t.boolean "subaura", default: false, null: false
     t.integer "limit"
   end
 
@@ -177,8 +178,8 @@ ActiveRecord::Schema.define(version: 2022_01_28_183534) do
     t.integer "element"
     t.integer "proficiency"
     t.string "series"
-    t.boolean "flb"
-    t.boolean "ulb"
+    t.boolean "flb", default: false, null: false
+    t.boolean "ulb", default: false, null: false
     t.integer "max_level"
     t.integer "max_skill_level"
     t.integer "min_hp"
@@ -192,6 +193,10 @@ ActiveRecord::Schema.define(version: 2022_01_28_183534) do
     t.boolean "extra", default: false, null: false
     t.integer "limit"
     t.integer "ax"
+  end
+
+  create_table "weapons_import", id: false, force: :cascade do |t|
+    t.json "doc"
   end
 
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"


### PR DESCRIPTION
`GridCharacter`, `GridWeapon`, and `GridSummon` will now expose their `uncap_level`.

`uncap_level` can be updated with the `/[object]/update_uncap` route.