### PR TITLE
Discover Teams

### DIFF
--- a/app/controllers/api/v1/grid_weapons_controller.rb
+++ b/app/controllers/api/v1/grid_weapons_controller.rb
@@ -17,6 +17,12 @@ class Api::V1::GridWeaponsController < Api::V1::ApiController
         end
 
         @weapon = GridWeapon.create!(weapon_params.merge(party_id: party.id, weapon_id: canonical_weapon.id))
+
+        if (@weapon.position == -1)
+            party.element = @weapon.weapon.element
+            party.save!
+        end
+
         render :show, status: :created if @weapon.save!
     end
 

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::PartiesController < Api::V1::ApiController
-    before_action :set_from_slug, except: ['create', 'update']
+    before_action :set_from_slug, except: ['create', 'update', 'index']
     before_action :set, only: ['update', 'destroy']
 
     def create
@@ -50,12 +50,15 @@ class Api::V1::PartiesController < Api::V1::ApiController
     end
 
     def index
-        element = request.params['element']
-        raid = request.params['raid']
-        recency = request.params['recency'] ? Time.at(request.params['recency']).to_datetime.beginning_of_day : nil
         now = DateTime.current
+        start_time = (now - params['recency'].to_i.seconds).to_datetime.beginning_of_day unless request.params['recency'].blank?
 
-        @parties = Party.where(element: element, raid_id: raid, created_at: recency..now)
+        conditions = {}
+        conditions[:element] = request.params['element'] unless request.params['element'].blank?
+        conditions[:raid] = request.params['raid'] unless request.params['raid'].blank?
+        conditions[:created_at] = start_time..now unless request.params['recency'].blank? 
+
+        @parties = Party.where(conditions)
 
         render :all, status: :ok
     end

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -2,10 +2,6 @@ class Api::V1::PartiesController < Api::V1::ApiController
     before_action :set_from_slug, except: ['create', 'update']
     before_action :set, only: ['update', 'destroy']
 
-    def index
-        parties = Party.all
-    end
-
     def create
         @party = Party.new(shortcode: random_string)
         @party.extra = party_params['extra']
@@ -53,8 +49,14 @@ class Api::V1::PartiesController < Api::V1::ApiController
         render :characters, status: :ok
     end
 
-    def all
-        @parties = Party.all()
+    def index
+        element = request.params['element']
+        raid = request.params['raid']
+        recency = request.params['recency'] ? Time.at(request.params['recency']).to_datetime.beginning_of_day : nil
+        now = DateTime.current
+
+        @parties = Party.where(element: element, raid_id: raid, created_at: recency..now)
+
         render :all, status: :ok
     end
 

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -53,6 +53,11 @@ class Api::V1::PartiesController < Api::V1::ApiController
         render :characters, status: :ok
     end
 
+    def all
+        @parties = Party.all()
+        render :all, status: :ok
+    end
+
     private
 
     def random_string

--- a/app/views/api/v1/parties/all.json.rabl
+++ b/app/views/api/v1/parties/all.json.rabl
@@ -1,0 +1,3 @@
+collection @parties
+
+extends 'parties/base'

--- a/app/views/api/v1/parties/base.json.rabl
+++ b/app/views/api/v1/parties/base.json.rabl
@@ -1,6 +1,6 @@
 object :party
 
-attributes :id, :user_id, :name, :description, :shortcode, :created_at, :updated_at
+attributes :id, :user_id, :name, :description, :element, :shortcode, :created_at, :updated_at
 
 node :is_extra do |p|
     p.extra

--- a/app/views/api/v1/parties/base.json.rabl
+++ b/app/views/api/v1/parties/base.json.rabl
@@ -1,9 +1,13 @@
 object :party
 
-attributes :id, :user_id, :name, :description, :element, :shortcode, :created_at, :updated_at
+attributes :id, :name, :description, :element, :shortcode, :created_at, :updated_at
 
 node :is_extra do |p|
     p.extra
+end
+
+node :user do |p|
+    partial('users/base', :object => p.user)
 end
 
 node :raid do |p|

--- a/app/views/api/v1/parties/characters.json.rabl
+++ b/app/views/api/v1/parties/characters.json.rabl
@@ -1,6 +1,10 @@
 object @party
 
-attributes :id, :user_id, :name, :description, :shortcode
+attributes :id, :name, :description, :shortcode
+
+node :user do |p|
+    partial('users/base', :object => p.user)
+end
 
 node :raid do |p|
     partial('raids/base', :object => p.raid)

--- a/app/views/api/v1/parties/summons.json.rabl
+++ b/app/views/api/v1/parties/summons.json.rabl
@@ -1,6 +1,10 @@
 object @party
 
-attributes :id, :user_id, :name, :description, :shortcode
+attributes :id, :name, :description, :shortcode
+
+node :user do |p|
+    partial('users/base', :object => p.user)
+end
 
 node :raid do |p|
     partial('raids/base', :object => p.raid)

--- a/app/views/api/v1/parties/weapons.json.rabl
+++ b/app/views/api/v1/parties/weapons.json.rabl
@@ -1,6 +1,10 @@
 object @party
 
-attributes :id, :user_id, :name, :description, :shortcode
+attributes :id, :name, :description, :shortcode
+
+node :user do |p|
+    partial('users/base', :object => p.user)
+end
 
 node :raid do |p|
     partial('raids/base', :object => p.raid)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
             get 'parties/:id/weapons', to: 'parties#weapons'
             get 'parties/:id/summons', to: 'parties#summons'
             get 'parties/:id/characters', to: 'parties#characters'
+            get 'parties/all', to: 'parties#all'
 
             post 'check/email', to: 'users#check_email'
             post 'check/username', to: 'users#check_username'

--- a/db/migrate/20220227042147_add_element_to_parties.rb
+++ b/db/migrate/20220227042147_add_element_to_parties.rb
@@ -1,0 +1,5 @@
+class AddElementToParties < ActiveRecord::Migration[6.1]
+    def change
+        add_column :parties, :element, :integer
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_25_014523) do
+ActiveRecord::Schema.define(version: 2022_02_27_042147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
-  enable_extension "timescaledb"
 
   create_table "characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name_en"
@@ -132,6 +131,7 @@ ActiveRecord::Schema.define(version: 2022_02_25_014523) do
     t.string "name"
     t.text "description"
     t.uuid "raid_id"
+    t.integer "element"
     t.index ["user_id"], name: "index_parties_on_user_id"
   end
 


### PR DESCRIPTION
This PR adds the Discover Teams page.

Users can see all the teams on the site, sorted in reverse chronological order, and filter them down based on raid, element, or recency.

This does not add pagination or automatic filtering of low quality teams yet, we'll add that in a future PR.