### PR TITLE
Better search

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -1,28 +1,42 @@
 class Api::V1::SearchController < Api::V1::ApiController
     def characters
+        locale = params[:locale] || 'en'
+
         if params[:query].present?
-            excludes = params[:excludes] ? 
-                params[:excludes].split(',').map { |e| "%#{e.gsub(/\([^()]*\)/, '').strip}%" } : ''
-            
-            @characters = Character.where("name_en ILIKE ? AND name_en NOT ILIKE ALL(ARRAY[?])", "%#{params[:query]}%", excludes).limit(10)
-            # @characters = Character.search(query).limit(10)
+            if locale == 'ja'
+                @characters = Character.jp_search(params[:query]).limit(10)
+            else
+                # @characters = Character.where("name_en ILIKE ? AND name_en NOT ILIKE ALL(ARRAY[?])", "%#{params[:query]}%", excludes).limit(10)
+                @characters = Character.en_search(params[:query]).limit(10)
+            end
         else
             @characters = Character.all
         end
     end
 
     def weapons
+        locale = params[:locale] || 'en'
+
         if params[:query].present?
-            @weapons = Weapon.search(params[:query]).limit(10)
+            if locale == 'ja'
+                @weapons = Weapon.jp_search(params[:query]).limit(10)
+            else
+                @weapons = Weapon.en_search(params[:query]).limit(10)
+            end
         else
             @weapons = Weapon.all
         end
     end
 
     def summons
+        locale = params[:locale] || 'en'
+
         if params[:query].present?
-            excludes = params[:excludes] ? params[:excludes].split(',').each { |e| "!#{e}" }.join(' ') : ''
-            @summons = Summon.search(params[:query]).limit(10)
+            if locale == 'ja'
+                @summons = Summon.jp_search(params[:query]).limit(10)
+            else
+                @summons = Summon.en_search(params[:query]).limit(10)
+            end
         else
             @summons = Summon.all
         end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -1,12 +1,20 @@
 class Character < ApplicationRecord
     include PgSearch::Model
 
-    pg_search_scope :search, 
-        against: [:name_en, :name_jp],
+    pg_search_scope :en_search, 
+        against: :name_en,
+        using: {
+            trigram: {
+                threshold: 0.18
+            }
+        }
+
+    pg_search_scope :jp_search, 
+        against: :name_jp,
         using: {
             tsearch: {
-                negation: true,
-                prefix: true
+                prefix: true,
+                dictionary: "simple"
             }
         }
 

--- a/app/models/summon.rb
+++ b/app/models/summon.rb
@@ -1,11 +1,20 @@
 class Summon < ApplicationRecord
     include PgSearch::Model
 
-    pg_search_scope :search, 
-        against: [:name_en, :name_jp],
+    pg_search_scope :en_search, 
+        against: :name_en,
+        using: {
+            trigram: {
+                threshold: 0.18
+            }
+        }
+
+    pg_search_scope :jp_search, 
+        against: :name_jp,
         using: {
             tsearch: {
-                prefix: true
+                prefix: true,
+                dictionary: "simple"
             }
         }
 

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -1,11 +1,20 @@
 class Weapon < ApplicationRecord
     include PgSearch::Model
 
-    pg_search_scope :search, 
-        against: [:name_en, :name_jp],
+    pg_search_scope :en_search, 
+        against: :name_en,
+        using: {
+            trigram: {
+                threshold: 0.18
+            }
+        }
+
+    pg_search_scope :jp_search, 
+        against: :name_jp,
         using: {
             tsearch: {
-                prefix: true
+                prefix: true,
+                dictionary: "simple"
             }
         }
 

--- a/db/migrate/20220308101922_add_gin_index_to_weapons.rb
+++ b/db/migrate/20220308101922_add_gin_index_to_weapons.rb
@@ -1,0 +1,7 @@
+class AddGinIndexToWeapons < ActiveRecord::Migration[6.1]
+    def change
+        enable_extension "pg_trgm"
+        enable_extension "btree_gin"
+        add_index :weapons, :name_en, using: :gin, opclass: :gin_trgm_ops
+    end
+end

--- a/db/migrate/20220309013333_add_gin_index_to_summons_and_characters.rb
+++ b/db/migrate/20220309013333_add_gin_index_to_summons_and_characters.rb
@@ -1,0 +1,6 @@
+class AddGinIndexToSummonsAndCharacters < ActiveRecord::Migration[6.1]
+    def change
+        add_index :summons, :name_en, using: :gin, opclass: :gin_trgm_ops
+        add_index :characters, :name_en, using: :gin, opclass: :gin_trgm_ops
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_06_131942) do
+ActiveRecord::Schema.define(version: 2022_03_09_013333) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "btree_gin"
+  enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
@@ -42,6 +44,7 @@ ActiveRecord::Schema.define(version: 2022_03_06_131942) do
     t.boolean "ulb", default: false, null: false
     t.integer "max_hp_ulb"
     t.integer "max_atk_ulb"
+    t.index ["name_en"], name: "index_characters_on_name_en", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "favorites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -178,6 +181,7 @@ ActiveRecord::Schema.define(version: 2022_03_06_131942) do
     t.integer "max_atk_ulb"
     t.boolean "subaura", default: false, null: false
     t.integer "limit"
+    t.index ["name_en"], name: "index_summons_on_name_en", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -225,6 +229,7 @@ ActiveRecord::Schema.define(version: 2022_03_06_131942) do
     t.boolean "extra", default: false, null: false
     t.integer "limit"
     t.integer "ax"
+    t.index ["name_en"], name: "index_weapons_on_name_en", opclass: :gin_trgm_ops, using: :gin
   end
 
   add_foreign_key "grid_weapons", "weapon_keys", column: "weapon_key3_id"


### PR DESCRIPTION
This marginally improves search performance to get better results. For English searches, it uses postgresql's trigram search. Japanese search has been added, and uses normal tsearch. 

Search is still very far from perfect because search is hard.

In doing this, we removed the very little duplicate item protection we had. We will re-implement another way later.