### PR TITLE
Implements mods on GridCharacter

### DIFF
--- a/app/blueprints/api/v1/error_blueprint.rb
+++ b/app/blueprints/api/v1/error_blueprint.rb
@@ -14,6 +14,10 @@ module Api
       field :errors, if: ->(_field_name, _error, options) { options.key?(:exception) } do |_, options|
         options[:exception]
       end
+
+      field :errors, if: ->(_field_name, object, options) { options.key?(:errors) } do |_, options|
+        options[:errors]
+      end
     end
   end
 end

--- a/app/blueprints/api/v1/grid_character_blueprint.rb
+++ b/app/blueprints/api/v1/grid_character_blueprint.rb
@@ -11,35 +11,30 @@ module Api
       view :nested do
         fields :position, :uncap_level, :perpetuity
 
-        field :transcendence_step, if: ->(_fn, obj, _opt) {
+        field :transcendence_step, if: lambda { |_fn, obj, _opt|
           obj.character.ulb
         } do |c|
           c.transcendence_step
         end
 
-        field :awakening, if: ->(_fn, obj, _opt) {
-          !obj[:awakening].nil?
-        } do |c|
-          {
-            type: c.awakening[:type],
-            level: c.awakening[:level]
-          }
+        field :awakening do |c|
+          c.awakening
         end
 
-        field :over_mastery, if: ->(_fn, obj, _opt) {
+        field :over_mastery, if: lambda { |_fn, obj, _opt|
           !obj.ring1['modifier'].nil? && !obj.ring2['modifier'].nil?
         } do |c|
           rings = []
 
-          rings.push(c.ring1) if !c.ring1['modifier'].nil?
-          rings.push(c.ring2) if !c.ring2['modifier'].nil?
-          rings.push(c.ring3) if !c.ring3['modifier'].nil?
-          rings.push(c.ring4) if !c.ring4['modifier'].nil?
+          rings.push(c.ring1) unless c.ring1['modifier'].nil?
+          rings.push(c.ring2) unless c.ring2['modifier'].nil?
+          rings.push(c.ring3) unless c.ring3['modifier'].nil?
+          rings.push(c.ring4) unless c.ring4['modifier'].nil?
 
           rings
         end
 
-        field :aetherial_mastery, if: ->(_fn, obj, _opt) {
+        field :aetherial_mastery, if: lambda { |_fn, obj, _opt|
           !obj.earring['modifier'].nil?
         } do |c|
           c.earring
@@ -51,6 +46,10 @@ module Api
       view :full do
         include_view :nested
         association :party, blueprint: PartyBlueprint, view: :minimal
+      end
+
+      view :destroyed do
+        fields :position, :created_at, :updated_at
       end
     end
   end

--- a/app/blueprints/api/v1/grid_character_blueprint.rb
+++ b/app/blueprints/api/v1/grid_character_blueprint.rb
@@ -11,11 +11,38 @@ module Api
       view :nested do
         fields :position, :uncap_level, :perpetuity
 
-        field :awakening do |c|
+        field :transcendence_step, if: ->(_fn, obj, _opt) {
+          obj.character.ulb
+        } do |c|
+          c.transcendence_step
+        end
+
+        field :awakening, if: ->(_fn, obj, _opt) {
+          !obj[:awakening].nil?
+        } do |c|
           {
-            type: c.awakening_type,
-            level: c.awakening_level
+            type: c.awakening[:type],
+            level: c.awakening[:level]
           }
+        end
+
+        field :over_mastery, if: ->(_fn, obj, _opt) {
+          !obj.ring1['modifier'].nil? && !obj.ring2['modifier'].nil?
+        } do |c|
+          rings = []
+
+          rings.push(c.ring1) if !c.ring1['modifier'].nil?
+          rings.push(c.ring2) if !c.ring2['modifier'].nil?
+          rings.push(c.ring3) if !c.ring3['modifier'].nil?
+          rings.push(c.ring4) if !c.ring4['modifier'].nil?
+
+          rings
+        end
+
+        field :aetherial_mastery, if: ->(_fn, obj, _opt) {
+          !obj.earring['modifier'].nil?
+        } do |c|
+          c.earring
         end
 
         association :character, name: :object, blueprint: CharacterBlueprint

--- a/app/blueprints/api/v1/grid_weapon_blueprint.rb
+++ b/app/blueprints/api/v1/grid_weapon_blueprint.rb
@@ -43,6 +43,10 @@ module Api
         include_view :nested
         association :party, blueprint: PartyBlueprint, view: :minimal
       end
+
+      view :destroyed do
+        fields :mainhand, :position, :created_at, :updated_at
+      end
     end
   end
 end

--- a/app/controllers/api/v1/grid_characters_controller.rb
+++ b/app/controllers/api/v1/grid_characters_controller.rb
@@ -21,16 +21,15 @@ module Api
           conflict_view = render_conflict_view(conflict_characters, incoming_character, character_params[:position])
           render json: conflict_view
         else
-          # Replace the grid character in the position if it is already filled
+          # Destroy the grid character in the position if it is already filled
           if GridCharacter.where(party_id: party.id, position: character_params[:position]).exists?
             character = GridCharacter.where(party_id: party.id, position: character_params[:position]).limit(1)[0]
-            character.character_id = incoming_character.id
-
-            # Otherwise, create a new grid character
-          else
-            character = GridCharacter.create!(character_params.merge(party_id: party.id,
-                                                                     character_id: incoming_character.id))
+            character.destroy
           end
+
+          # Then, create a new grid character
+          character = GridCharacter.create!(character_params.merge(party_id: party.id,
+                                                                   character_id: incoming_character.id))
 
           if character.save!
             grid_character_view = render_grid_character_view(character)

--- a/app/controllers/api/v1/grid_weapons_controller.rb
+++ b/app/controllers/api/v1/grid_weapons_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class GridWeaponsController < Api::V1::ApiController
-      before_action :set, except: %w[create update_uncap_level destroy]
+      before_action :set, except: %w[create update_uncap_level]
 
       attr_reader :party, :incoming_weapon
 
@@ -56,7 +56,10 @@ module Api
       end
 
       # TODO: Implement removing characters
-      def destroy; end
+      def destroy
+        render_unauthorized_response if @weapon.party.user != current_user
+        return render json: GridCharacterBlueprint.render(@weapon, view: :destroyed) if @weapon.destroy
+      end
 
       def update_uncap_level
         weapon = GridWeapon.find(weapon_params[:id])
@@ -115,15 +118,15 @@ module Api
       # Render the conflict view as a string
       def render_conflict_view(conflict_weapon, incoming_weapon, incoming_position)
         ConflictBlueprint.render(nil, view: :weapons,
-                                 conflict_weapon: conflict_weapon,
-                                 incoming_weapon: incoming_weapon,
-                                 incoming_position: incoming_position)
+                                      conflict_weapon: conflict_weapon,
+                                      incoming_weapon: incoming_weapon,
+                                      incoming_position: incoming_position)
       end
 
       def render_grid_weapon_view(grid_weapon, conflict_position)
         GridWeaponBlueprint.render(grid_weapon, view: :full,
-                                   root: :grid_weapon,
-                                   meta: { replaced: conflict_position })
+                                                root: :grid_weapon,
+                                                meta: { replaced: conflict_position })
       end
 
       def save_weapon(weapon)

--- a/app/models/grid_character.rb
+++ b/app/models/grid_character.rb
@@ -3,11 +3,57 @@
 class GridCharacter < ApplicationRecord
   belongs_to :party
 
+  validate :awakening_level, on: :update
+  validate :transcendence, on: :update
+  validate :over_mastery_attack, on: :update
+  validate :over_mastery_hp, on: :update
+  validate :over_mastery_attack_matches_hp, on: :update
+
+  def awakening_level
+    unless awakening.nil?
+      errors.add(:awakening, 'awakening level too low') if awakening["level"] < 1
+      errors.add(:awakening, 'awakening level too high') if awakening["level"] > 9
+    end
+  end
+
+  def transcendence
+    errors.add(:transcendence_step, 'character has no transcendence') if transcendence_step > 0 && !character.ulb
+    errors.add(:transcendence_step, 'transcendence step too high') if transcendence_step > 5 && character.ulb
+    errors.add(:transcendence_step, 'transcendence step too low') if transcendence_step < 0 && character.ulb
+
+  end
+
+  def over_mastery_attack
+    errors.add(:ring1, 'invalid value') unless ring1["modifier"].nil? || atk_values.include?(ring1["strength"])
+  end
+
+  def over_mastery_hp
+    unless ring2["modifier"].nil?
+      errors.add(:ring2, 'invalid value') unless hp_values.include?(ring2["strength"])
+    end
+  end
+
+  def over_mastery_attack_matches_hp
+    unless ring1[:modifier].nil? && ring2[:modifier].nil?
+      errors.add(:over_mastery, 'over mastery attack and hp values do not match') unless ring2[:strength] == (ring1[:strength] / 2)
+    end
+  end
+
   def character
     Character.find(character_id)
   end
 
   def blueprint
     GridCharacterBlueprint
+  end
+
+  private
+
+  def atk_values
+    [300, 600, 900, 1200, 1500, 1800, 2100, 2400, 2700, 3000]
+  end
+
+  def hp_values
+    [150, 300, 450, 600, 750, 900, 1050, 1200, 1350, 1500]
   end
 end

--- a/app/models/grid_character.rb
+++ b/app/models/grid_character.rb
@@ -5,38 +5,58 @@ class GridCharacter < ApplicationRecord
 
   validate :awakening_level, on: :update
   validate :transcendence, on: :update
-  validate :over_mastery_attack, on: :update
-  validate :over_mastery_hp, on: :update
+  validate :validate_over_mastery_values, on: :update
+  validate :validate_aetherial_mastery_value, on: :update
   validate :over_mastery_attack_matches_hp, on: :update
 
   def awakening_level
-    unless awakening.nil?
-      errors.add(:awakening, 'awakening level too low') if awakening["level"] < 1
-      errors.add(:awakening, 'awakening level too high') if awakening["level"] > 9
-    end
+    return if awakening.nil?
+
+    errors.add(:awakening, 'awakening level too low') if awakening['level'] < 1
+    errors.add(:awakening, 'awakening level too high') if awakening['level'] > 9
   end
 
   def transcendence
-    errors.add(:transcendence_step, 'character has no transcendence') if transcendence_step > 0 && !character.ulb
+    errors.add(:transcendence_step, 'character has no transcendence') if transcendence_step.positive? && !character.ulb
     errors.add(:transcendence_step, 'transcendence step too high') if transcendence_step > 5 && character.ulb
-    errors.add(:transcendence_step, 'transcendence step too low') if transcendence_step < 0 && character.ulb
-
+    errors.add(:transcendence_step, 'transcendence step too low') if transcendence_step.negative? && character.ulb
   end
 
   def over_mastery_attack
-    errors.add(:ring1, 'invalid value') unless ring1["modifier"].nil? || atk_values.include?(ring1["strength"])
+    errors.add(:ring1, 'invalid value') unless ring1['modifier'].nil? || atk_values.include?(ring1['strength'])
   end
 
   def over_mastery_hp
-    unless ring2["modifier"].nil?
-      errors.add(:ring2, 'invalid value') unless hp_values.include?(ring2["strength"])
-    end
+    return if ring2['modifier'].nil?
+
+    errors.add(:ring2, 'invalid value') unless hp_values.include?(ring2['strength'])
   end
 
   def over_mastery_attack_matches_hp
-    unless ring1[:modifier].nil? && ring2[:modifier].nil?
-      errors.add(:over_mastery, 'over mastery attack and hp values do not match') unless ring2[:strength] == (ring1[:strength] / 2)
+    return if ring1[:modifier].nil? && ring2[:modifier].nil?
+
+    return if ring2[:strength] == (ring1[:strength] / 2)
+
+    errors.add(:over_mastery,
+               'over mastery attack and hp values do not match')
+  end
+
+  def validate_over_mastery_values
+    [ring1, ring2, ring3, ring4].each_with_index do |ring, index|
+      next if ring['modifier'].nil?
+
+      modifier = over_mastery_modifiers[ring['modifier']]
+      check_value({ "ring#{index}": { ring[modifier] => ring['strength'] } },
+                  'over_mastery')
     end
+  end
+
+  def validate_aetherial_mastery_value
+    return if earring['modifier'].nil?
+
+    modifier = aetherial_mastery_modifiers[earring['modifier']].to_sym
+    check_value({ "earring": { modifier => earring['strength'] } },
+                'aetherial_mastery')
   end
 
   def character
@@ -48,6 +68,124 @@ class GridCharacter < ApplicationRecord
   end
 
   private
+
+  def check_value(property, type)
+    # Input format
+    # { ring1: { atk: 300 } }
+
+    key = property.keys.first
+    modifier = property[key].keys.first
+
+    return if modifier.nil?
+
+    case type
+    when 'over_mastery'
+      errors.add(key, 'invalid value') unless over_mastery_values.include?(key['strength'])
+    when 'aetherial_mastery'
+      errors.add(key, 'value too low') if aetherial_mastery_values[modifier][:min] > self[key]['strength']
+      errors.add(key, 'value too high') if aetherial_mastery_values[modifier][:max] < self[key]['strength']
+    end
+  end
+
+  def over_mastery_modifiers
+    {
+      1 => 'atk',
+      2 => 'hp',
+      3 => 'debuff_success',
+      4 => 'skill_cap',
+      5 => 'ca_dmg',
+      6 => 'ca_cap',
+      7 => 'stamina',
+      8 => 'enmity',
+      9 => 'crit',
+      10 => 'da',
+      11 => 'ta',
+      12 => 'def',
+      13 => 'heal',
+      14 => 'debuff_resist',
+      15 => 'dodge'
+    }
+  end
+
+  def over_mastery_values
+    {
+      atk: [300, 600, 900, 1200, 1500, 1800, 2100, 2400, 2700, 3000],
+      hp: [150, 300, 450, 600, 750, 900, 1050, 1200, 1350, 1500],
+      debuff_success: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+      skill_cap: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+      ca_dmg: [10, 12, 14, 16, 18, 20, 22, 24, 27, 30],
+      ca_cap: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+      crit: [10, 12, 14, 16, 18, 20, 22, 24, 27, 30],
+      enmity: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      stamina: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      def: [6, 7, 8, 9, 10, 12, 14, 16, 18, 20],
+      heal: [3, 6, 9, 12, 15, 18, 21, 24, 27, 30],
+      debuff_resist: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+      dodge: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      da: [6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+      ta: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    }
+  end
+
+  def aetherial_mastery_modifiers
+    {
+      1 => 'da',
+      2 => 'ta',
+      3 => 'ele_atk',
+      4 => 'ele_resist',
+      5 => 'stamina',
+      6 => 'enmity',
+      7 => 'supplemental',
+      8 => 'crit',
+      9 => 'counter_dodge',
+      10 => 'counter_dmg'
+    }
+  end
+
+  def aetherial_mastery_values
+    {
+      da: {
+        min: 10,
+        max: 17
+      },
+      ta: {
+        min: 5,
+        max: 12
+      },
+      ele_atk: {
+        min: 15,
+        max: 22
+      },
+      ele_resist: {
+        min: 5,
+        max: 12
+      },
+      stamina: {
+        min: 5,
+        max: 12
+      },
+      enmity: {
+        min: 5,
+        max: 12
+      },
+      supplemental: {
+        min: 5,
+        max: 12
+      },
+      crit: {
+        min: 18,
+        max: 35
+      },
+      counter_dodge: {
+        min: 5,
+        max: 12
+      },
+      counter_dmg: {
+        min: 10,
+        max: 17
+      }
+    }
+  end
 
   def atk_values
     [300, 600, 900, 1200, 1500, 1800, 2100, 2400, 2700, 3000]

--- a/app/models/grid_character.rb
+++ b/app/models/grid_character.rb
@@ -54,6 +54,8 @@ class GridCharacter < ApplicationRecord
   def validate_aetherial_mastery_value
     return if earring['modifier'].nil?
 
+    return unless earring['modifier'].positive?
+
     modifier = aetherial_mastery_modifiers[earring['modifier']].to_sym
     check_value({ "earring": { modifier => earring['strength'] } },
                 'aetherial_mastery')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :parties, only: %i[index create update destroy]
       resources :users, only: %i[create update show]
-      resources :grid_weapons, only: [:update]
-      resources :grid_characters, only: [:update]
+      resources :grid_weapons, only: %i[update destroy]
+      resources :grid_characters, only: %i[update destroy]
       resources :favorites, only: [:create]
 
       get 'users/info/:id', to: 'users#info'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       resources :parties, only: %i[index create update destroy]
       resources :users, only: %i[create update show]
       resources :grid_weapons, only: [:update]
+      resources :grid_characters, only: [:update]
       resources :favorites, only: [:create]
 
       get 'users/info/:id', to: 'users#info'

--- a/db/migrate/20230106023753_change_awakening_type_default_value.rb
+++ b/db/migrate/20230106023753_change_awakening_type_default_value.rb
@@ -1,0 +1,5 @@
+class ChangeAwakeningTypeDefaultValue < ActiveRecord::Migration[7.0]
+  def change
+    change_column :grid_characters, :awakening_type, :integer, null: false, default: 1
+  end
+end

--- a/db/migrate/20230107121520_change_mastery_columns_to_jsonb.rb
+++ b/db/migrate/20230107121520_change_mastery_columns_to_jsonb.rb
@@ -1,0 +1,22 @@
+class ChangeMasteryColumnsToJsonb < ActiveRecord::Migration[7.0]
+  def change
+    # Remove old columns
+    remove_column :grid_characters, :ring_modifier1, :integer
+    remove_column :grid_characters, :ring_modifier2, :integer
+    remove_column :grid_characters, :ring_modifier3, :integer
+    remove_column :grid_characters, :ring_modifier4, :integer
+    remove_column :grid_characters, :ring_strength1, :integer
+    remove_column :grid_characters, :ring_strength2, :integer
+    remove_column :grid_characters, :ring_strength3, :integer
+    remove_column :grid_characters, :ring_strength4, :integer
+    remove_column :grid_characters, :earring_modifier, :integer
+    remove_column :grid_characters, :earring_strength, :integer
+
+    # Add new columns
+    add_column :grid_characters, :ring1, :jsonb, default: { modifier: nil, strength: nil }
+    add_column :grid_characters, :ring2, :jsonb, default: { modifier: nil, strength: nil }
+    add_column :grid_characters, :ring3, :jsonb, default: { modifier: nil, strength: nil }
+    add_column :grid_characters, :ring4, :jsonb, default: { modifier: nil, strength: nil }
+    add_column :grid_characters, :earring, :jsonb, default: { modifier: nil, strength: nil }
+  end
+end

--- a/db/migrate/20230107150547_change_awakening_columns_to_jsonb.rb
+++ b/db/migrate/20230107150547_change_awakening_columns_to_jsonb.rb
@@ -1,0 +1,10 @@
+class ChangeAwakeningColumnsToJsonb < ActiveRecord::Migration[7.0]
+  def change
+    # Remove old columns
+    remove_column :grid_characters, :awakening_type, :integer
+    remove_column :grid_characters, :awakening_level, :integer
+
+    # Add new column
+    add_column :grid_characters, :awakening, :jsonb, default: { type: 1, level: 1 }
+  end
+end

--- a/db/migrate/20230107153724_make_mastery_columns_not_nullable.rb
+++ b/db/migrate/20230107153724_make_mastery_columns_not_nullable.rb
@@ -1,0 +1,10 @@
+class MakeMasteryColumnsNotNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column :grid_characters, :ring1, :jsonb, null: false
+    change_column :grid_characters, :ring2, :jsonb, null: false
+    change_column :grid_characters, :ring3, :jsonb, null: false
+    change_column :grid_characters, :ring4, :jsonb, null: false
+    change_column :grid_characters, :earring, :jsonb, null: false
+    change_column :grid_characters, :awakening, :jsonb, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_03_180458) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_07_121520) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -67,19 +67,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_03_180458) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "perpetuity", default: false, null: false
-    t.integer "awakening_type", default: 0, null: false
+    t.integer "awakening_type", default: 1, null: false
     t.integer "awakening_level", default: 1, null: false
     t.integer "transcendence_step", default: 0, null: false
-    t.integer "ring_modifier1"
-    t.float "ring_strength1"
-    t.integer "ring_modifier2"
-    t.float "ring_strength2"
-    t.integer "ring_modifier3"
-    t.float "ring_strength3"
-    t.integer "ring_modifier4"
-    t.float "ring_strength4"
-    t.integer "earring_modifier"
-    t.float "earring_strength"
+    t.jsonb "ring1", default: {"modifier"=>nil, "strength"=>nil}
+    t.jsonb "ring2", default: {"modifier"=>nil, "strength"=>nil}
+    t.jsonb "ring3", default: {"modifier"=>nil, "strength"=>nil}
+    t.jsonb "ring4", default: {"modifier"=>nil, "strength"=>nil}
+    t.jsonb "earring", default: {"modifier"=>nil, "strength"=>nil}
     t.index ["character_id"], name: "index_grid_characters_on_character_id"
     t.index ["party_id"], name: "index_grid_characters_on_party_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_07_121520) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_07_153724) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -67,14 +67,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_07_121520) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "perpetuity", default: false, null: false
-    t.integer "awakening_type", default: 1, null: false
-    t.integer "awakening_level", default: 1, null: false
     t.integer "transcendence_step", default: 0, null: false
-    t.jsonb "ring1", default: {"modifier"=>nil, "strength"=>nil}
-    t.jsonb "ring2", default: {"modifier"=>nil, "strength"=>nil}
-    t.jsonb "ring3", default: {"modifier"=>nil, "strength"=>nil}
-    t.jsonb "ring4", default: {"modifier"=>nil, "strength"=>nil}
-    t.jsonb "earring", default: {"modifier"=>nil, "strength"=>nil}
+    t.jsonb "ring1", default: {"modifier"=>nil, "strength"=>nil}, null: false
+    t.jsonb "ring2", default: {"modifier"=>nil, "strength"=>nil}, null: false
+    t.jsonb "ring3", default: {"modifier"=>nil, "strength"=>nil}, null: false
+    t.jsonb "ring4", default: {"modifier"=>nil, "strength"=>nil}, null: false
+    t.jsonb "earring", default: {"modifier"=>nil, "strength"=>nil}, null: false
+    t.jsonb "awakening", default: {"type"=>1, "level"=>1}, null: false
     t.index ["character_id"], name: "index_grid_characters_on_character_id"
     t.index ["party_id"], name: "index_grid_characters_on_party_id"
   end


### PR DESCRIPTION
This PR implements mods on `GridCharacter` as they exist on `GridWeapon`.

Currently, Awakenings, Rings, Earrings and Transcendence are supported.

## Tasks
- [x] Modify database to accept character mod values on the `GridCharacter` table
- [ ] Add new properties to Controller so it accepts new values
- [ ] Add new properties to Blueprint so it prints new values to JSON
- [ ] Ensure that values are valid before saving `GridCharacter` model