### PR TITLE
Adds support for Granblue IDs on Jobs

### DIFF
--- a/app/blueprints/api/v1/job_blueprint.rb
+++ b/app/blueprints/api/v1/job_blueprint.rb
@@ -17,7 +17,7 @@ module Api
         ]
       end
 
-      fields :row, :ml, :order
+      fields :granblue_id, :row, :ml, :order
     end
   end
 end

--- a/db/migrate/20230123055508_add_granblue_id_to_jobs.rb
+++ b/db/migrate/20230123055508_add_granblue_id_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddGranblueIdToJobs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :jobs, :granblue_id, :string
+  end
+end

--- a/db/migrate/20230123055508_add_slug_to_jobs.rb
+++ b/db/migrate/20230123055508_add_slug_to_jobs.rb
@@ -1,5 +1,0 @@
-class AddSlugToJobs < ActiveRecord::Migration[7.0]
-  def change
-    add_column :jobs, :slug, :string
-  end
-end

--- a/db/migrate/20230123055508_add_slug_to_jobs.rb
+++ b/db/migrate/20230123055508_add_slug_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddSlugToJobs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :jobs, :slug, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -137,7 +137,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_055508) do
     t.boolean "ml", default: false
     t.integer "order"
     t.uuid "base_job_id"
-    t.string "slug"
+    t.string "granblue_id"
     t.index ["base_job_id"], name: "index_jobs_on_base_job_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_23_035602) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_23_055508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -137,6 +137,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_035602) do
     t.boolean "ml", default: false
     t.integer "order"
     t.uuid "base_job_id"
+    t.string "slug"
     t.index ["base_job_id"], name: "index_jobs_on_base_job_id"
   end
 

--- a/lib/tasks/export_all.rake
+++ b/lib/tasks/export_all.rake
@@ -32,7 +32,11 @@ namespace :granblue do
       Rake::Task['granblue:export:summon'].invoke('square')
       Rake::Task['granblue:export:summon'].reenable
 
-      puts 'Exported 9 files'
+      # Run job tasks
+      Rake::Task['granblue:export:job'].invoke
+      Rake::Task['granblue:export:job'].reenable
+
+      puts 'Exported 10 files'
     end
   end
 end

--- a/lib/tasks/export_job.rake
+++ b/lib/tasks/export_job.rake
@@ -1,0 +1,33 @@
+namespace :granblue do
+  namespace :export do
+    def build_job_icon_url(id)
+      # Set up URL
+      base_url = 'https://prd-game-a-granbluefantasy.akamaized.net/assets_en/img/sp/ui/icon/job'
+      extension = '.png'
+
+      "#{base_url}/#{id}#{extension}"
+    end
+
+    desc 'Exports a list of weapon URLs for a given size'
+    task :job do |_t, _args|
+      # Include weapon model
+      Dir.glob("#{Rails.root}/app/models/job.rb").each { |file| require file }
+
+      # Set up filepath
+      dir = "#{Rails.root}/export/"
+      filename = "#{dir}/job-icon.txt"
+      FileUtils.mkdir(dir) unless Dir.exist?(dir)
+
+      # Write to file
+      File.open(filename, 'w') do |f|
+        Job.all.each do |w|
+          f.write("#{build_job_icon_url(w.granblue_id.to_s)} \n")
+        end
+      end
+
+      # CLI output
+      count = `wc -l #{filename}`.split.first.to_i
+      puts "Wrote #{count} job URLs for icon size"
+    end
+  end
+end


### PR DESCRIPTION
This is meant to support https://github.com/jedmund/hensei-web/pull/159.

All this PR does is add a field for `granblue_id` to the `jobs` table.

