### PR TITLE
Adds support for managing app updates

### DIFF
--- a/app/blueprints/api/v1/job_accessory_blueprint.rb
+++ b/app/blueprints/api/v1/job_accessory_blueprint.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class JobAccessoryBlueprint < ApiBlueprint
+      field :name do |skill|
+        {
+          en: skill.name_en,
+          ja: skill.name_jp
+        }
+      end
+
+      association :job,
+                  name: :job,
+                  blueprint: JobBlueprint
+
+      fields :granblue_id, :rarity, :release_date
+    end
+  end
+end

--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -64,6 +64,8 @@ module Api
         include_view :characters
         include_view :job_skills
 
+        association :accessory,
+                    blueprint: JobAccessoryBlueprint
         fields :description, :charge_attack, :button_count, :turn_count, :chain_count
       end
 

--- a/app/blueprints/api/v1/update_blueprint.rb
+++ b/app/blueprints/api/v1/update_blueprint.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class UpdateBlueprint < Blueprinter::Base
+      fields :update_type, :updated_at
+    end
+  end
+end

--- a/app/blueprints/api/v1/update_blueprint.rb
+++ b/app/blueprints/api/v1/update_blueprint.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class UpdateBlueprint < Blueprinter::Base
-      fields :update_type, :updated_at
+      fields :version, :update_type, :updated_at
     end
   end
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -36,6 +36,11 @@ module Api
       respond_to :json
 
       ##### Methods
+      # Returns the latest update
+      def latest
+        render json: UpdateBlueprint.render_as_json(AppUpdate.last)
+      end
+
       # Assign the current user if the Doorkeeper token isn't nil, then
       # update the current user's last seen datetime and last IP address
       # before returning
@@ -85,9 +90,9 @@ module Api
 
       def render_not_found_response(object)
         render json: ErrorBlueprint.render(nil, error: {
-                                             message: "#{object.capitalize} could not be found",
-                                             code: 'not_found'
-                                           }), status: :not_found
+          message: "#{object.capitalize} could not be found",
+          code: 'not_found'
+        }), status: :not_found
       end
 
       def render_unauthorized_response

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -37,7 +37,7 @@ module Api
 
       ##### Methods
       # Returns the latest update
-      def latest
+      def version
         render json: UpdateBlueprint.render_as_json(AppUpdate.last)
       end
 

--- a/app/controllers/api/v1/job_accessories_controller.rb
+++ b/app/controllers/api/v1/job_accessories_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class JobAccessoriesController < Api::V1::ApiController
+      def job
+        accessories = JobAccessory.where('job_id = ?', params[:id])
+        render json: JobAccessoryBlueprint.render(accessories)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -44,6 +44,8 @@ module Api
 
         @party.attributes = party_params.except(:skill1_id, :skill2_id, :skill3_id)
 
+        # TODO: Validate accessory with job
+
         return render json: PartyBlueprint.render(@party, view: :full, root: :party) if @party.save!
 
         render_validation_error_response(@party)
@@ -64,7 +66,7 @@ module Api
 
         if new_party.save
           render json: PartyBlueprint.render(new_party, view: :full, root: :party,
-                                                        meta: { remix: true })
+                                             meta: { remix: true })
         else
           render_validation_error_response(new_party)
         end
@@ -124,7 +126,7 @@ module Api
       def build_conditions(params)
         unless params['recency'].blank?
           start_time = (DateTime.current - params['recency'].to_i.seconds)
-                       .to_datetime.beginning_of_day
+                         .to_datetime.beginning_of_day
         end
 
         {}.tap do |hash|
@@ -176,6 +178,7 @@ module Api
           :description,
           :raid_id,
           :job_id,
+          :accessory_id,
           :skill0_id,
           :skill1_id,
           :skill2_id,

--- a/app/models/app_update.rb
+++ b/app/models/app_update.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AppUpdate < ApplicationRecord
+
+end

--- a/app/models/job_accessory.rb
+++ b/app/models/job_accessory.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class JobAccessory < ApplicationRecord
+  include PgSearch::Model
+
+  belongs_to :job
+
+  pg_search_scope :en_search,
+                  against: :name_en,
+                  using: {
+                    tsearch: {
+                      prefix: true,
+                      dictionary: 'simple'
+                    }
+                  }
+
+  pg_search_scope :jp_search,
+                  against: :name_jp,
+                  using: {
+                    tsearch: {
+                      prefix: true,
+                      dictionary: 'simple'
+                    }
+                  }
+
+  def blueprint
+    JobAccessoryBlueprint
+  end
+
+  def display_resource(skill)
+    skill.name_en
+  end
+
+  def ==(other)
+    self.class == other.class && id == other.id
+  end
+end

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -16,6 +16,11 @@ class Party < ApplicationRecord
   belongs_to :raid, optional: true
   belongs_to :job, optional: true
 
+  belongs_to :accessory,
+             foreign_key: 'accessory_id',
+             class_name: 'JobAccessory',
+             optional: true
+  
   belongs_to :skill0,
              foreign_key: 'skill0_id',
              class_name: 'JobSkill',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
       resources :grid_summons, only: %i[update destroy]
       resources :favorites, only: [:create]
 
+      get 'latest', to: 'api#latest'
+
       get 'users/info/:id', to: 'users#info'
 
       get 'parties/favorites', to: 'parties#favorites'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
 
       get 'jobs/skills', to: 'job_skills#all'
       get 'jobs/:id/skills', to: 'job_skills#job'
+      get 'jobs/:id/accessories', to: 'job_accessories#job'
 
       get 'raids', to: 'raids#all'
       get 'weapon_keys', to: 'weapon_keys#all'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
       resources :grid_summons, only: %i[update destroy]
       resources :favorites, only: [:create]
 
-      get 'latest', to: 'api#latest'
+      get 'version', to: 'api#version'
 
       get 'users/info/:id', to: 'users#info'
 

--- a/db/migrate/20230124000252_create_job_accessories.rb
+++ b/db/migrate/20230124000252_create_job_accessories.rb
@@ -1,0 +1,14 @@
+class CreateJobAccessories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :job_accessories, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.references :job, type: :uuid
+
+      t.string :name_en, null: false, unique: true
+      t.string :name_jp, null: false, unique: true
+      t.string :granblue_id, null: false, unique: true
+
+      t.integer :rarity
+      t.date :release_date
+    end
+  end
+end

--- a/db/migrate/20230124013326_add_accessory_type_to_job_accessories.rb
+++ b/db/migrate/20230124013326_add_accessory_type_to_job_accessories.rb
@@ -1,0 +1,5 @@
+class AddAccessoryTypeToJobAccessories < ActiveRecord::Migration[7.0]
+  def change
+    add_column :job_accessories, :accessory_type, :integer
+  end
+end

--- a/db/migrate/20230124100823_add_accessory_id_to_party.rb
+++ b/db/migrate/20230124100823_add_accessory_id_to_party.rb
@@ -1,0 +1,7 @@
+class AddAccessoryIdToParty < ActiveRecord::Migration[7.0]
+  def change
+    change_table(:parties) do |t|
+      t.references :accessory, type: :uuid, foreign_key: { to_table: 'job_accessories' }
+    end
+  end
+end

--- a/db/migrate/20230126030358_add_updates_table.rb
+++ b/db/migrate/20230126030358_add_updates_table.rb
@@ -2,7 +2,7 @@ class AddUpdatesTable < ActiveRecord::Migration[7.0]
   def change
     create_table :app_updates, id: false do |t|
       t.string :update_type, null: false
-      t.datetime :updated_at, null: false, unique: true
+      t.datetime :updated_at, null: false, unique: true, primary_key: true
     end
   end
 end

--- a/db/migrate/20230126030358_add_updates_table.rb
+++ b/db/migrate/20230126030358_add_updates_table.rb
@@ -1,0 +1,8 @@
+class AddUpdatesTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :app_updates, id: false do |t|
+      t.string :update_type, null: false
+      t.datetime :updated_at, null: false, unique: true
+    end
+  end
+end

--- a/db/migrate/20230126040207_add_version_to_app_updates.rb
+++ b/db/migrate/20230126040207_add_version_to_app_updates.rb
@@ -1,0 +1,5 @@
+class AddVersionToAppUpdates < ActiveRecord::Migration[7.0]
+  def change
+    add_column :app_updates, :version, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_24_013326) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_24_100823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -215,6 +215,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_013326) do
     t.integer "chain_count"
     t.integer "turn_count"
     t.uuid "source_party_id"
+    t.uuid "accessory_id"
+    t.index ["accessory_id"], name: "index_parties_on_accessory_id"
     t.index ["job_id"], name: "index_parties_on_job_id"
     t.index ["skill0_id"], name: "index_parties_on_skill0_id"
     t.index ["skill1_id"], name: "index_parties_on_skill1_id"
@@ -324,6 +326,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_013326) do
   add_foreign_key "jobs", "jobs", column: "base_job_id"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "parties", "job_accessories", column: "accessory_id"
   add_foreign_key "parties", "job_skills", column: "skill0_id"
   add_foreign_key "parties", "job_skills", column: "skill1_id"
   add_foreign_key "parties", "job_skills", column: "skill2_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_26_030358) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_040207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_26_030358) do
 
   create_table "app_updates", primary_key: "updated_at", id: :datetime, force: :cascade do |t|
     t.string "update_type", null: false
+    t.string "version"
   end
 
   create_table "characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,9 +17,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_26_030358) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "app_updates", id: false, force: :cascade do |t|
+  create_table "app_updates", primary_key: "updated_at", id: :datetime, force: :cascade do |t|
     t.string "update_type", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_24_100823) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_030358) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "app_updates", id: false, force: :cascade do |t|
+    t.string "update_type", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name_en"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_23_055508) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_24_000252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
-  enable_extension "timescaledb"
 
   create_table "characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name_en"
@@ -113,6 +112,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_055508) do
     t.index ["weapon_key1_id"], name: "index_grid_weapons_on_weapon_key1_id"
     t.index ["weapon_key2_id"], name: "index_grid_weapons_on_weapon_key2_id"
     t.index ["weapon_key3_id"], name: "index_grid_weapons_on_weapon_key3_id"
+  end
+
+  create_table "job_accessories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "job_id"
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.string "granblue_id", null: false
+    t.integer "rarity"
+    t.date "release_date"
+    t.index ["job_id"], name: "index_job_accessories_on_job_id"
   end
 
   create_table "job_skills", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_24_000252) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_24_013326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -121,6 +121,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_000252) do
     t.string "granblue_id", null: false
     t.integer "rarity"
     t.date "release_date"
+    t.integer "accessory_type"
     t.index ["job_id"], name: "index_job_accessories_on_job_id"
   end
 

--- a/lib/tasks/export_accessories.rake
+++ b/lib/tasks/export_accessories.rake
@@ -1,0 +1,50 @@
+namespace :granblue do
+  namespace :export do
+    def build_shield_url(id, size)
+      # Set up URL
+      base_url = 'https://prd-game-a-granbluefantasy.akamaized.net/assets_en/img/sp/assets/shield'
+      extension = '.jpg'
+
+      directory = 'm' if size.to_s == 'grid'
+      directory = 's' if size.to_s == 'square'
+
+      "#{base_url}/#{directory}/#{id}#{extension}"
+    end
+
+    def build_manabelly_url(id, size)
+      # Set up URL
+      base_url = 'https://prd-game-a-granbluefantasy.akamaized.net/assets_en/img/sp/assets/manabelly'
+      extension = '.png'
+
+      "#{base_url}/#{id}#{extension}"
+    end
+
+    desc 'Exports a list of accessories for a given size'
+    task :accessory, [:size] => :environment do |_t, args|
+      # Set up options
+      size = args[:size]
+
+      Dir.glob("#{Rails.root}/app/models/job_accessory.rb").each { |file| require file }
+
+      # Set up filepath
+      dir = "#{Rails.root}/export/"
+      filename = "#{dir}/accessory-#{size}.txt"
+      FileUtils.mkdir(dir) unless Dir.exist?(dir)
+
+      # Write to file
+      File.open(filename, 'w') do |f|
+        JobAccessory.all.each do |w|
+          if w.accessory_type === 1
+            f.write("#{build_shield_url(w.granblue_id.to_s, size)} \n")
+          elsif w.accessory_type === 2
+            f.write("#{build_manabelly_url(w.granblue_id.to_s, size)} \n")
+          end
+        end
+      end
+
+      # CLI output
+      count = `wc -l #{filename}`.split.first.to_i
+      puts "Wrote #{count} job accessory URLs for \"#{size}\" size"
+    end
+  end
+end

--- a/lib/tasks/export_accessories.rake
+++ b/lib/tasks/export_accessories.rake
@@ -1,22 +1,14 @@
 namespace :granblue do
   namespace :export do
-    def build_shield_url(id, size)
+    def build_url(id, type, size)
       # Set up URL
-      base_url = 'https://prd-game-a-granbluefantasy.akamaized.net/assets_en/img/sp/assets/shield'
+      base_url = 'https://prd-game-a-granbluefantasy.akamaized.net/assets_en/img/sp/assets'
       extension = '.jpg'
 
       directory = 'm' if size.to_s == 'grid'
       directory = 's' if size.to_s == 'square'
 
-      "#{base_url}/#{directory}/#{id}#{extension}"
-    end
-
-    def build_manabelly_url(id, size)
-      # Set up URL
-      base_url = 'https://prd-game-a-granbluefantasy.akamaized.net/assets_en/img/sp/assets/manabelly'
-      extension = '.png'
-
-      "#{base_url}/#{id}#{extension}"
+      "#{base_url}/#{type}/#{directory}/#{id}#{extension}"
     end
 
     desc 'Exports a list of accessories for a given size'
@@ -35,9 +27,9 @@ namespace :granblue do
       File.open(filename, 'w') do |f|
         JobAccessory.all.each do |w|
           if w.accessory_type === 1
-            f.write("#{build_shield_url(w.granblue_id.to_s, size)} \n")
+            f.write("#{build_url(w.granblue_id.to_s, "shield", size)} \n")
           elsif w.accessory_type === 2
-            f.write("#{build_manabelly_url(w.granblue_id.to_s, size)} \n")
+            f.write("#{build_url(w.granblue_id.to_s, "familiar", size)} \n")
           end
         end
       end

--- a/lib/tasks/export_all.rake
+++ b/lib/tasks/export_all.rake
@@ -36,7 +36,14 @@ namespace :granblue do
       Rake::Task['granblue:export:job'].invoke
       Rake::Task['granblue:export:job'].reenable
 
-      puts 'Exported 10 files'
+      # Run job accessory tasks
+      Rake::Task['granblue:export:accessory'].invoke('grid')
+      Rake::Task['granblue:export:accessory'].reenable
+
+      Rake::Task['granblue:export:accessory'].invoke('square')
+      Rake::Task['granblue:export:accessory'].reenable
+
+      puts 'Exported 12 files'
     end
   end
 end


### PR DESCRIPTION
This is a purely backend system to support update toasts on the frontend.

A new table `app_updates` was created that contains a version string, timestamp and update type. This can be fetched at `/version` to tell the frontend when something has changed.