### PR TITLE
Fix counter caches

### DIFF
--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -49,11 +49,6 @@ module Api
         association :user,
                     blueprint: UserBlueprint,
                     view: :minimal
-
-        # TODO: This should probably be paginated
-        association :remixes,
-                    blueprint: PartyBlueprint,
-                    view: :collection
       end
 
       view :jobs do
@@ -76,6 +71,15 @@ module Api
         association :accessory,
                     blueprint: JobAccessoryBlueprint
         fields :description, :charge_attack, :button_count, :turn_count, :chain_count
+
+        association :source_party,
+                    blueprint: PartyBlueprint,
+                    view: :minimal
+
+        # TODO: This should probably be paginated
+        association :remixes,
+                    blueprint: PartyBlueprint,
+                    view: :collection
       end
 
       view :collection do

--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -50,9 +50,10 @@ module Api
                     blueprint: UserBlueprint,
                     view: :minimal
 
+        # TODO: This should probably be paginated
         association :remixes,
                     blueprint: PartyBlueprint,
-                    view: :minimal
+                    view: :collection
       end
 
       view :jobs do

--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -36,6 +36,10 @@ module Api
         fields :name, :element, :shortcode, :favorited, :extra,
                :full_auto, :clear_time, :auto_guard, :created_at, :updated_at
 
+        field :remix do |p|
+          p.is_remix
+        end
+
         association :raid,
                     blueprint: RaidBlueprint
 
@@ -44,6 +48,10 @@ module Api
 
         association :user,
                     blueprint: UserBlueprint,
+                    view: :minimal
+
+        association :remixes,
+                    blueprint: PartyBlueprint,
                     view: :minimal
       end
 

--- a/app/models/grid_character.rb
+++ b/app/models/grid_character.rb
@@ -2,7 +2,7 @@
 
 class GridCharacter < ApplicationRecord
   belongs_to :party,
-             counter_cache: :weapons_count,
+             counter_cache: :characters_count,
              inverse_of: :characters
   validates_presence_of :party
 

--- a/app/models/grid_summon.rb
+++ b/app/models/grid_summon.rb
@@ -2,7 +2,7 @@
 
 class GridSummon < ApplicationRecord
   belongs_to :party,
-             counter_cache: :weapons_count,
+             counter_cache: :summons_count,
              inverse_of: :summons
   validates_presence_of :party
 

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -20,7 +20,7 @@ class Party < ApplicationRecord
              foreign_key: 'accessory_id',
              class_name: 'JobAccessory',
              optional: true
-  
+
   belongs_to :skill0,
              foreign_key: 'skill0_id',
              class_name: 'JobSkill',
@@ -80,6 +80,14 @@ class Party < ApplicationRecord
 
   def is_favorited(user)
     user.favorite_parties.include? self
+  end
+
+  def is_remix
+    self.source_party != nil
+  end
+
+  def remixes
+    Party.where(source_party_id: self.id)
   end
 
   def blueprint

--- a/db/migrate/20230128091710_add_character_and_summon_counts_to_party.rb
+++ b/db/migrate/20230128091710_add_character_and_summon_counts_to_party.rb
@@ -1,0 +1,6 @@
+class AddCharacterAndSummonCountsToParty < ActiveRecord::Migration[7.0]
+  def change
+    add_column :parties, :characters_count, :integer
+    add_column :parties, :summons_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_26_040207) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_28_091710) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -154,6 +154,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_26_040207) do
     t.integer "order"
     t.uuid "base_job_id"
     t.string "granblue_id"
+    t.boolean "accessory", default: false
+    t.integer "accessory_type", default: 0
     t.index ["base_job_id"], name: "index_jobs_on_base_job_id"
   end
 
@@ -221,6 +223,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_26_040207) do
     t.integer "turn_count"
     t.uuid "source_party_id"
     t.uuid "accessory_id"
+    t.integer "characters_count"
+    t.integer "summons_count"
     t.index ["accessory_id"], name: "index_parties_on_accessory_id"
     t.index ["job_id"], name: "index_parties_on_job_id"
     t.index ["skill0_id"], name: "index_parties_on_skill0_id"


### PR DESCRIPTION
The `weapons_count` cache was actually counting weapons, summons and characters. This is bad!

Now there are counter caches for each individual item type, which fixes the display of parties on the Teams page.