### PR TITLE
Allow editing of unauth teams

### DIFF
--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -68,9 +68,10 @@ module Api
         include_view :characters
         include_view :job_skills
 
+        fields :local_id, :description, :charge_attack, :button_count, :turn_count, :chain_count
+
         association :accessory,
                     blueprint: JobAccessoryBlueprint
-        fields :description, :charge_attack, :button_count, :turn_count, :chain_count
 
         association :source_party,
                     blueprint: PartyBlueprint,
@@ -90,7 +91,7 @@ module Api
         include_view :full
         fields :edit_key
       end
-      
+
       view :destroyed do
         fields :name, :description, :created_at, :updated_at
       end

--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -86,6 +86,11 @@ module Api
         include_view :preview
       end
 
+      view :created do
+        include_view :full
+        fields :edit_key
+      end
+      
       view :destroyed do
         fields :name, :description, :created_at, :updated_at
       end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -50,6 +50,12 @@ module Api
         @current_user
       end
 
+      def edit_key
+        @edit_key ||= request.headers['X-Edit-Key'] if request.headers['X-Edit-Key']
+        
+        @edit_key
+      end
+
       # Set the response content-type
       def content_type(content_type)
         response.headers['Content-Type'] = content_type

--- a/app/controllers/api/v1/grid_characters_controller.rb
+++ b/app/controllers/api/v1/grid_characters_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       before_action :find_party, only: :create
       before_action :set, only: %i[update destroy]
-      before_action :check_authorization, only: %i[update destroy]
+      before_action :authorize, only: %i[create update destroy]
       before_action :find_incoming_character, only: :create
       before_action :find_current_characters, only: :create
 
@@ -135,8 +135,12 @@ module Api
         render_unauthorized_response if current_user && (party.user != current_user)
       end
 
-      def check_authorization
-        render_unauthorized_response if @character.party.user != current_user
+      def authorize
+        # Create
+        unauthorized_create = @party && (@party.user != current_user || @party.edit_key != edit_key)
+        unauthorized_update = @character && @character.party && (@character.party.user != current_user || @character.party.edit_key != edit_key)
+
+        render_unauthorized_response if unauthorized_create || unauthorized_update
       end
 
       # Specify whitelisted properties that can be modified.

--- a/app/controllers/api/v1/grid_summons_controller.rb
+++ b/app/controllers/api/v1/grid_summons_controller.rb
@@ -3,12 +3,12 @@
 module Api
   module V1
     class GridSummonsController < Api::V1::ApiController
-      before_action :set, only: %w[update destroy]
-
       attr_reader :party, :incoming_summon
-
+      
+      before_action :set, only: %w[update destroy]
       before_action :find_party, only: :create
       before_action :find_incoming_summon, only: :create
+      before_action :authorize, only: %i[create update destroy]
 
       def create
         # Create the GridSummon with the desired parameters
@@ -92,6 +92,14 @@ module Api
         GridSummonBlueprint.render(grid_summon, view: :nested,
                                    root: :grid_summon,
                                    meta: { replaced: conflict_position })
+      end
+
+      def authorize
+        # Create
+        unauthorized_create = @party && (@party.user != current_user || @party.edit_key != edit_key)
+        unauthorized_update = @summon && @summon.party && (@summon.party.user != current_user || @summon.party.edit_key != edit_key)
+
+        render_unauthorized_response if unauthorized_create || unauthorized_update
       end
 
       def set

--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class JobsController < Api::V1::ApiController
       before_action :set, only: %w[update_job update_job_skills]
+      before_action :authorize, only: %w[update_job update_job_skills]
 
       def all
         render json: JobBlueprint.render(Job.all)
@@ -163,6 +164,10 @@ module Api
         else
           false
         end
+      end
+
+      def authorize
+        render_unauthorized_response if @party.user != current_user || @party.edit_key != edit_key
       end
 
       def set

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -26,7 +26,7 @@ module Api
         # end
 
         if party.save!
-          return render json: PartyBlueprint.render(party, view: :full, root: :party),
+          return render json: PartyBlueprint.render(party, view: :created, root: :party),
                         status: :created
         end
 

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -173,6 +173,7 @@ module Api
 
         params.require(:party).permit(
           :user_id,
+          :local_id,
           :extra,
           :name,
           :description,

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -62,6 +62,7 @@ class Party < ApplicationRecord
   has_many :favorites
 
   before_create :set_shortcode
+  before_save :set_edit_key
 
   ##### Amoeba configuration
   amoeba do
@@ -98,6 +99,12 @@ class Party < ApplicationRecord
 
   def set_shortcode
     self.shortcode = random_string
+  end
+
+  def set_edit_key
+    if !self.user
+      self.edit_key = Digest::SHA1.hexdigest([Time.now, rand].join)
+    end
   end
 
   def random_string

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -62,7 +62,7 @@ class Party < ApplicationRecord
   has_many :favorites
 
   before_create :set_shortcode
-  before_save :set_edit_key
+  before_create :set_edit_key
 
   ##### Amoeba configuration
   amoeba do

--- a/db/migrate/20230131082521_add_edit_key_to_parties.rb
+++ b/db/migrate/20230131082521_add_edit_key_to_parties.rb
@@ -1,0 +1,5 @@
+class AddEditKeyToParties < ActiveRecord::Migration[7.0]
+  def change
+    add_column :parties, :edit_key, :string, unique: true, null: true
+  end
+end

--- a/db/migrate/20230131084343_add_local_id_to_parties.rb
+++ b/db/migrate/20230131084343_add_local_id_to_parties.rb
@@ -1,0 +1,5 @@
+class AddLocalIdToParties < ActiveRecord::Migration[7.0]
+  def change
+    add_column :parties, :local_id, :uuid, null: true, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_31_082521) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_31_084343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -226,6 +226,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_31_082521) do
     t.integer "characters_count"
     t.integer "summons_count"
     t.string "edit_key"
+    t.uuid "local_id"
     t.index ["accessory_id"], name: "index_parties_on_accessory_id"
     t.index ["job_id"], name: "index_parties_on_job_id"
     t.index ["skill0_id"], name: "index_parties_on_skill0_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_30_114432) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_31_082521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
-  enable_extension "timescaledb"
 
   create_table "app_updates", primary_key: "updated_at", id: :datetime, force: :cascade do |t|
     t.string "update_type", null: false
@@ -226,6 +225,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_30_114432) do
     t.uuid "accessory_id"
     t.integer "characters_count"
     t.integer "summons_count"
+    t.string "edit_key"
     t.index ["accessory_id"], name: "index_parties_on_accessory_id"
     t.index ["job_id"], name: "index_parties_on_job_id"
     t.index ["skill0_id"], name: "index_parties_on_skill0_id"


### PR DESCRIPTION
This PR revamps how we handle unauth teams and is part bug fix and part new feature. This is the backend support for https://github.com/jedmund/hensei-web/pull/212

### New strategy
1. The client creates a UUID if there is no `user` object stored in cookies when visiting `/new`. This should only happen once (unless the cookie expires or is cleared)
2. The UUID is sent to the server as the `local_id` with the party payload as it is being created. On create, the party creates itself an `edit_key`—essentially a party-specific access token—if it does not have a `User` association. It is stored alongside the party and only sent back **once** (with the party's `201` response) and the client is responsible for storing it.
3. The client stores the edit key in the browser's local storage alongside the party ID as its key.
4. When requesting party data, the client checks the `user_id` in its cookies with the `local_id` in the party payload. However, the `edit_key` must be sent with any PUT or DELETE requests as `X-Edit-Key` in order to validate that the user can truly edit that party. It is retrieved from local storage with the party's ID.