### PR TITLE
Add endpoints for getting info about canonical items

### DIFF
--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class CharactersController < Api::V1::ApiController
+      before_action :set
+
+      def show
+        render json: CharacterBlueprint.render(@character)
+      end
+
+      private
+
+      def set
+        @character = Character.where(granblue_id: params[:id]).first
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/summons_controller.rb
+++ b/app/controllers/api/v1/summons_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SummonsController < Api::V1::ApiController
+      before_action :set
+
+      def show
+        render json: SummonBlueprint.render(@summon)
+      end
+
+      private
+
+      def set
+        @summon = Summon.where(granblue_id: params[:id]).first
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/weapons_controller.rb
+++ b/app/controllers/api/v1/weapons_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class WeaponsController < Api::V1::ApiController
+      before_action :set
+
+      def show
+        render json: WeaponBlueprint.render(@weapon)
+      end
+
+      private
+
+      def set
+        @weapon = Weapon.where(granblue_id: params[:id]).first
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
       resources :grid_weapons, only: %i[update destroy]
       resources :grid_characters, only: %i[update destroy]
       resources :grid_summons, only: %i[update destroy]
+      resources :weapons, only: :show
+      resources :characters, only: :show
+      resources :summons, only: :show
       resources :favorites, only: [:create]
 
       get 'version', to: 'api#version'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_31_084343) do
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "timescaledb"
 
   create_table "app_updates", primary_key: "updated_at", id: :datetime, force: :cascade do |t|
     t.string "update_type", null: false


### PR DESCRIPTION
This will be useful for all sorts of things, but immediately we needed it to show localized names of items on the Updates page