### PR TITLE
Add granblue_id to WeaponKeys

### DIFF
--- a/app/blueprints/api/v1/weapon_key_blueprint.rb
+++ b/app/blueprints/api/v1/weapon_key_blueprint.rb
@@ -10,7 +10,7 @@ module Api
         }
       end
 
-      fields :slug, :series, :slot, :group, :order
+      fields :granblue_id, :slug, :series, :slot, :group, :order
     end
   end
 end

--- a/db/migrate/20230315095656_add_granblue_id_to_weapon_keys.rb
+++ b/db/migrate/20230315095656_add_granblue_id_to_weapon_keys.rb
@@ -1,0 +1,6 @@
+class AddGranblueIdToWeaponKeys < ActiveRecord::Migration[7.0]
+  def change
+    # This needs to be NOT NULL, but initially it will be nullable until we migrate data
+    add_column :weapon_keys, :granblue_id, :integer, unique: true, null: true
+  end
+end


### PR DESCRIPTION
This adds a `granblue_id` column to the `weapon_keys` table