### PR TITLE
Clear counter cache on remix

### DIFF
--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -66,6 +66,10 @@ class Party < ApplicationRecord
 
   ##### Amoeba configuration
   amoeba do
+    set weapons_count: 0
+    set characters_count: 0
+    set summons_count: 0
+
     nullify :description
     nullify :shortcode
 


### PR DESCRIPTION
The counter-cache for weapons, summons, and characters on teams was not being reset when the team was remixed, leading to the numbers being doubled on each remix.

While funny, this is bad because it means that remixed teams forever fall outside of the acceptable # of weapons range to be displayed on the Teams page (>= 5 and <= 13) so who knows how many teams were just not visible.