### PR TITLE
Implements advanced filters (#90)

### DIFF
--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -8,6 +8,16 @@ module Api
       before_action :set, only: %w[update destroy]
       before_action :authorize, only: %w[update destroy]
 
+      MAX_CHARACTERS = 5
+      MAX_SUMMONS = 8
+      MAX_WEAPONS = 13
+
+      DEFAULT_MIN_CHARACTERS = 3
+      DEFAULT_MIN_SUMMONS = 2
+      DEFAULT_MIN_WEAPONS = 5
+
+      DEFAULT_MAX_CLEAR_TIME = 5400
+
       def create
         party = Party.new
         party.user = current_user if current_user
@@ -73,12 +83,15 @@ module Api
       end
 
       def index
-        conditions = build_conditions(request.params)
+        conditions = build_conditions
 
         @parties = Party.joins(:weapons)
                         .group('parties.id')
                         .having('count(distinct grid_weapons.weapon_id) > 2')
                         .where(conditions)
+                        .where(name_quality)
+                        .where(user_quality)
+                        .where(original)
                         .order(created_at: :desc)
                         .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
                         .each { |party| party.favorited = current_user ? party.is_favorited(current_user) : false }
@@ -99,11 +112,14 @@ module Api
       def favorites
         raise Api::V1::UnauthorizedError unless current_user
 
-        conditions = build_conditions(request.params)
+        conditions = build_conditions
         conditions[:favorites] = { user_id: current_user.id }
 
         @parties = Party.joins(:favorites)
                         .where(conditions)
+                        .where(name_quality)
+                        .where(user_quality)
+                        .where(original)
                         .order('favorites.created_at DESC')
                         .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
                         .each { |party| party.favorited = party.is_favorited(current_user) }
@@ -127,18 +143,70 @@ module Api
         render_unauthorized_response if @party.user != current_user || @party.edit_key != edit_key
       end
 
-      def build_conditions(params)
+      def build_conditions
+        params = request.params
+
         unless params['recency'].blank?
           start_time = (DateTime.current - params['recency'].to_i.seconds)
                          .to_datetime.beginning_of_day
         end
 
+        min_characters_count = params['characters_count'].blank? ? DEFAULT_MIN_CHARACTERS : params['characters_count'].to_i
+        min_summons_count = params['summons_count'].blank? ? DEFAULT_MIN_SUMMONS : params['summons_count'].to_i
+        min_weapons_count = params['weapons_count'].blank? ? DEFAULT_MIN_WEAPONS : params['weapons_count'].to_i
+        max_clear_time = params['max_clear_time'].blank? ? DEFAULT_MAX_CLEAR_TIME : params['max_clear_time'].to_i
+
         {}.tap do |hash|
-          hash[:element] = params['element'] unless params['element'].blank?
+          # Basic filters
+          hash[:element] = params['element'].to_i unless params['element'].blank?
           hash[:raid] = params['raid'] unless params['raid'].blank?
           hash[:created_at] = start_time..DateTime.current unless params['recency'].blank?
-          hash[:weapons_count] = 5..13
+
+          # Advanced filters: Team parameters
+          hash[:full_auto] = params['full_auto'].to_i unless params['full_auto'].blank? || params['full_auto'].to_i == -1
+          hash[:auto_guard] = params['auto_guard'].to_i unless params['auto_guard'].blank? || params['auto_guard'].to_i == -1
+          hash[:charge_attack] = params['charge_attack'].to_i unless params['charge_attack'].blank? || params['charge_attack'].to_i == -1
+
+          # Turn count of 0 will not be displayed, so disallow on the frontend or set default to 1
+          # How do we do the same for button count since that can reasonably be 1?
+          # hash[:turn_count] = params['turn_count'].to_i unless params['turn_count'].blank? || params['turn_count'].to_i <= 0
+          # hash[:button_count] = params['button_count'].to_i unless params['button_count'].blank?
+          # hash[:clear_time] = 0..max_clear_time
+
+          # Advanced filters: Object counts
+          hash[:characters_count] = min_characters_count..MAX_CHARACTERS
+          hash[:summons_count] = min_summons_count..MAX_SUMMONS
+          hash[:weapons_count] = min_weapons_count..MAX_WEAPONS
         end
+      end
+
+      def original
+        "source_party_id IS NULL" unless request.params['original'].blank? || request.params['original'] == "false"
+      end
+
+      def user_quality
+        "user_id IS NOT NULL" unless request.params[:user_quality].blank? || request.params[:user_quality] == "false"
+      end
+
+      def name_quality
+        low_quality = [
+          "Untitled",
+          "Remix of Untitled",
+          "Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Remix of Remix of Untitled",
+          "無題",
+          "無題のリミックス",
+          "無題のリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックスのリミックスのリミックス"
+        ]
+
+        joined_names = low_quality.map { |name| "'#{name}'" }.join(',')
+
+        "name NOT IN (#{joined_names})" unless request.params[:name_quality].blank? || request.params[:name_quality] == "false"
       end
 
       def remixed_name(name)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -8,6 +8,16 @@ module Api
       before_action :set, except: %w[create check_email check_username]
       before_action :set_by_id, only: %w[info update]
 
+      MAX_CHARACTERS = 5
+      MAX_SUMMONS = 8
+      MAX_WEAPONS = 13
+
+      DEFAULT_MIN_CHARACTERS = 3
+      DEFAULT_MIN_SUMMONS = 2
+      DEFAULT_MIN_WEAPONS = 5
+
+      DEFAULT_MAX_CLEAR_TIME = 5400
+
       def create
         user = User.new(user_params)
 
@@ -44,11 +54,23 @@ module Api
           render_not_found_response('user')
         else
 
-          conditions = build_conditions(request.params)
+          conditions = build_conditions
           conditions[:user_id] = @user.id
+
+          @parties = Party
+                       .where(conditions)
+                       .where(name_quality)
+                       .where(user_quality)
+                       .where(original)
+                       .order(created_at: :desc)
+                       .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
+                       .each { |party| party.favorited = party.is_favorited(current_user) }
 
           parties = Party
                       .where(conditions)
+                      .where(name_quality)
+                      .where(user_quality)
+                      .where(original)
                       .order(created_at: :desc)
                       .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
                       .each do |party|
@@ -81,17 +103,70 @@ module Api
 
       private
 
-      def build_conditions(params)
+      def build_conditions
+        params = request.params
+
         unless params['recency'].blank?
           start_time = (DateTime.current - params['recency'].to_i.seconds)
                          .to_datetime.beginning_of_day
         end
 
+        min_characters_count = params['characters_count'].blank? ? DEFAULT_MIN_CHARACTERS : params['characters_count'].to_i
+        min_summons_count = params['summons_count'].blank? ? DEFAULT_MIN_SUMMONS : params['summons_count'].to_i
+        min_weapons_count = params['weapons_count'].blank? ? DEFAULT_MIN_WEAPONS : params['weapons_count'].to_i
+        max_clear_time = params['max_clear_time'].blank? ? DEFAULT_MAX_CLEAR_TIME : params['max_clear_time'].to_i
+
         {}.tap do |hash|
-          hash[:element] = params['element'] unless params['element'].blank?
+          # Basic filters
+          hash[:element] = params['element'].to_i unless params['element'].blank?
           hash[:raid] = params['raid'] unless params['raid'].blank?
           hash[:created_at] = start_time..DateTime.current unless params['recency'].blank?
+
+          # Advanced filters: Team parameters
+          hash[:full_auto] = params['full_auto'].to_i unless params['full_auto'].blank? || params['full_auto'].to_i == -1
+          hash[:auto_guard] = params['auto_guard'].to_i unless params['auto_guard'].blank? || params['auto_guard'].to_i == -1
+          hash[:charge_attack] = params['charge_attack'].to_i unless params['charge_attack'].blank? || params['charge_attack'].to_i == -1
+
+          # Turn count of 0 will not be displayed, so disallow on the frontend or set default to 1
+          # How do we do the same for button count since that can reasonably be 1?
+          # hash[:turn_count] = params['turn_count'].to_i unless params['turn_count'].blank? || params['turn_count'].to_i <= 0
+          # hash[:button_count] = params['button_count'].to_i unless params['button_count'].blank?
+          # hash[:clear_time] = 0..max_clear_time
+
+          # Advanced filters: Object counts
+          hash[:characters_count] = min_characters_count..MAX_CHARACTERS
+          hash[:summons_count] = min_summons_count..MAX_SUMMONS
+          hash[:weapons_count] = min_weapons_count..MAX_WEAPONS
         end
+      end
+
+      def original
+        "source_party_id IS NULL" unless params['original'].blank? || params['original'] == '0'
+      end
+
+      def user_quality
+        "user_id IS NOT NULL" unless params[:user_quality].nil? || params[:user_quality] == "0"
+      end
+
+      def name_quality
+        low_quality = [
+          "Untitled",
+          "Remix of Untitled",
+          "Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Remix of Remix of Untitled",
+          "無題",
+          "無題のリミックス",
+          "無題のリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックスのリミックスのリミックス"
+        ]
+
+        joined_names = low_quality.map { |name| "'#{name}'" }.join(',')
+
+        "name NOT IN (#{joined_names})" unless params[:name_quality].nil? || params[:name_quality] == "0"
       end
 
       # Specify whitelisted properties that can be modified.

--- a/db/migrate/20230321115930_add_default_to_counter_cache_on_parties.rb
+++ b/db/migrate/20230321115930_add_default_to_counter_cache_on_parties.rb
@@ -1,0 +1,7 @@
+class AddDefaultToCounterCacheOnParties < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :parties, :characters_count, 0
+    change_column_default :parties, :weapons_count, 0
+    change_column_default :parties, :summons_count, 0
+  end
+end


### PR DESCRIPTION
* Add advanced filters

Adds new filters to search:

* Full auto
* Charge attack
* Auto guard
* Number of weapons (user-selectable now)
* Number of summons
* Number of characters
* Maximum number of turns
* Maximum number of buttons
* Maximum clear time
* User quality (No anonymous users)
* Name quality (No untitled teams)
* Remixes (Only show original teams)

* Update advanced filter params

* Add default to party counter cache