### PR TITLE
Add tables used for Siero's revival

### DIFF
--- a/app/blueprints/api/v1/guidebook_blueprint.rb
+++ b/app/blueprints/api/v1/guidebook_blueprint.rb
@@ -12,8 +12,8 @@ module Api
 
       field :description do |book|
         {
-          en: book.name_en,
-          ja: book.name_jp
+          en: book.description_en,
+          ja: book.description_jp
         }
       end
 

--- a/app/blueprints/api/v1/guidebook_blueprint.rb
+++ b/app/blueprints/api/v1/guidebook_blueprint.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class GuidebookBlueprint < ApiBlueprint
+      field :name do |book|
+        {
+          en: book.name_en,
+          ja: book.name_jp
+        }
+      end
+
+      field :description do |book|
+        {
+          en: book.name_en,
+          ja: book.name_jp
+        }
+      end
+
+      fields :granblue_id
+    end
+  end
+end

--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -40,6 +40,14 @@ module Api
           p.is_remix
         end
 
+        field :guidebooks do |p|
+          {
+            '0' => !p.guidebook0.nil? ? GuidebookBlueprint.render_as_hash(p.guidebook0) : nil,
+            '1' => !p.guidebook1.nil? ? GuidebookBlueprint.render_as_hash(p.guidebook1) : nil,
+            '2' => !p.guidebook2.nil? ? GuidebookBlueprint.render_as_hash(p.guidebook2) : nil
+          }
+        end
+
         association :raid,
                     blueprint: RaidBlueprint
 

--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -42,9 +42,9 @@ module Api
 
         field :guidebooks do |p|
           {
-            '0' => !p.guidebook0.nil? ? GuidebookBlueprint.render_as_hash(p.guidebook0) : nil,
             '1' => !p.guidebook1.nil? ? GuidebookBlueprint.render_as_hash(p.guidebook1) : nil,
-            '2' => !p.guidebook2.nil? ? GuidebookBlueprint.render_as_hash(p.guidebook2) : nil
+            '2' => !p.guidebook2.nil? ? GuidebookBlueprint.render_as_hash(p.guidebook2) : nil,
+            '3' => !p.guidebook3.nil? ? GuidebookBlueprint.render_as_hash(p.guidebook3) : nil
           }
         end
 

--- a/app/controllers/api/v1/guidebooks_controller.rb
+++ b/app/controllers/api/v1/guidebooks_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class GuidebooksController < Api::V1::ApiController
+      def all
+        render json: GuidebookBlueprint.render(Guidebook.all)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -241,6 +241,8 @@ module Api
       end
 
       def party_params
+        ap "Params are..."
+        ap params
         return unless params[:party].present?
 
         params.require(:party).permit(
@@ -263,7 +265,10 @@ module Api
           :clear_time,
           :button_count,
           :turn_count,
-          :chain_count
+          :chain_count,
+          :guidebook0_id,
+          :guidebook1_id,
+          :guidebook2_id
         )
       end
     end

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -8,6 +8,16 @@ module Api
       before_action :set, only: %w[update destroy]
       before_action :authorize, only: %w[update destroy]
 
+      MAX_CHARACTERS = 5
+      MAX_SUMMONS = 8
+      MAX_WEAPONS = 13
+
+      DEFAULT_MIN_CHARACTERS = 3
+      DEFAULT_MIN_SUMMONS = 2
+      DEFAULT_MIN_WEAPONS = 5
+
+      DEFAULT_MAX_CLEAR_TIME = 5400
+
       def create
         party = Party.new
         party.user = current_user if current_user
@@ -73,12 +83,15 @@ module Api
       end
 
       def index
-        conditions = build_conditions(request.params)
+        conditions = build_conditions
 
         @parties = Party.joins(:weapons)
                         .group('parties.id')
                         .having('count(distinct grid_weapons.weapon_id) > 2')
                         .where(conditions)
+                        .where(name_quality)
+                        .where(user_quality)
+                        .where(original)
                         .order(created_at: :desc)
                         .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
                         .each { |party| party.favorited = current_user ? party.is_favorited(current_user) : false }
@@ -99,11 +112,14 @@ module Api
       def favorites
         raise Api::V1::UnauthorizedError unless current_user
 
-        conditions = build_conditions(request.params)
+        conditions = build_conditions
         conditions[:favorites] = { user_id: current_user.id }
 
         @parties = Party.joins(:favorites)
                         .where(conditions)
+                        .where(name_quality)
+                        .where(user_quality)
+                        .where(original)
                         .order('favorites.created_at DESC')
                         .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
                         .each { |party| party.favorited = party.is_favorited(current_user) }
@@ -127,18 +143,70 @@ module Api
         render_unauthorized_response if @party.user != current_user || @party.edit_key != edit_key
       end
 
-      def build_conditions(params)
+      def build_conditions
+        params = request.params
+
         unless params['recency'].blank?
           start_time = (DateTime.current - params['recency'].to_i.seconds)
                          .to_datetime.beginning_of_day
         end
 
+        min_characters_count = params['characters_count'].blank? ? DEFAULT_MIN_CHARACTERS : params['characters_count'].to_i
+        min_summons_count = params['summons_count'].blank? ? DEFAULT_MIN_SUMMONS : params['summons_count'].to_i
+        min_weapons_count = params['weapons_count'].blank? ? DEFAULT_MIN_WEAPONS : params['weapons_count'].to_i
+        max_clear_time = params['max_clear_time'].blank? ? DEFAULT_MAX_CLEAR_TIME : params['max_clear_time'].to_i
+
         {}.tap do |hash|
-          hash[:element] = params['element'] unless params['element'].blank?
+          # Basic filters
+          hash[:element] = params['element'].to_i unless params['element'].blank?
           hash[:raid] = params['raid'] unless params['raid'].blank?
           hash[:created_at] = start_time..DateTime.current unless params['recency'].blank?
-          hash[:weapons_count] = 5..13
+
+          # Advanced filters: Team parameters
+          hash[:full_auto] = params['full_auto'].to_i unless params['full_auto'].blank? || params['full_auto'].to_i == -1
+          hash[:auto_guard] = params['auto_guard'].to_i unless params['auto_guard'].blank? || params['auto_guard'].to_i == -1
+          hash[:charge_attack] = params['charge_attack'].to_i unless params['charge_attack'].blank? || params['charge_attack'].to_i == -1
+
+          # Turn count of 0 will not be displayed, so disallow on the frontend or set default to 1
+          # How do we do the same for button count since that can reasonably be 1?
+          # hash[:turn_count] = params['turn_count'].to_i unless params['turn_count'].blank? || params['turn_count'].to_i <= 0
+          # hash[:button_count] = params['button_count'].to_i unless params['button_count'].blank?
+          # hash[:clear_time] = 0..max_clear_time
+
+          # Advanced filters: Object counts
+          hash[:characters_count] = min_characters_count..MAX_CHARACTERS
+          hash[:summons_count] = min_summons_count..MAX_SUMMONS
+          hash[:weapons_count] = min_weapons_count..MAX_WEAPONS
         end
+      end
+
+      def original
+        "source_party_id IS NULL" unless request.params['original'].blank? || request.params['original'] == "false"
+      end
+
+      def user_quality
+        "user_id IS NOT NULL" unless request.params[:user_quality].blank? || request.params[:user_quality] == "false"
+      end
+
+      def name_quality
+        low_quality = [
+          "Untitled",
+          "Remix of Untitled",
+          "Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Remix of Remix of Untitled",
+          "無題",
+          "無題のリミックス",
+          "無題のリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックスのリミックスのリミックス"
+        ]
+
+        joined_names = low_quality.map { |name| "'#{name}'" }.join(',')
+
+        "name NOT IN (#{joined_names})" unless request.params[:name_quality].blank? || request.params[:name_quality] == "false"
       end
 
       def remixed_name(name)

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -55,8 +55,8 @@ module Api
 
         # TODO: Validate accessory with job
 
-        return render json: PartyBlueprint.render(@party, view: :full, root: :party) if @party.save!
-
+        return render json: PartyBlueprint.render(@party, view: :full, root: :party) if @party.save
+        
         render_validation_error_response(@party)
       end
 
@@ -241,8 +241,6 @@ module Api
       end
 
       def party_params
-        ap "Params are..."
-        ap params
         return unless params[:party].present?
 
         params.require(:party).permit(
@@ -266,9 +264,9 @@ module Api
           :button_count,
           :turn_count,
           :chain_count,
-          :guidebook0_id,
           :guidebook1_id,
-          :guidebook2_id
+          :guidebook2_id,
+          :guidebook3_id
         )
       end
     end

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -196,6 +196,26 @@ module Api
                                               })
       end
 
+      def guidebooks
+        # Perform the query
+        books = if search_params[:query].present? && search_params[:query].length >= 2
+                  Guidebook.method("#{locale}_search").call(search_params[:query])
+                else
+                  Guidebook.all
+                end
+
+        count = books.length
+        paginated = books.paginate(page: search_params[:page], per_page: SEARCH_PER_PAGE)
+
+        render json: GuidebookBlueprint.render(paginated,
+                                               root: :results,
+                                               meta: {
+                                                 count: count,
+                                                 total_pages: total_pages(count),
+                                                 per_page: SEARCH_PER_PAGE
+                                               })
+      end
+
       private
 
       def total_pages(count)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -8,6 +8,16 @@ module Api
       before_action :set, except: %w[create check_email check_username]
       before_action :set_by_id, only: %w[info update]
 
+      MAX_CHARACTERS = 5
+      MAX_SUMMONS = 8
+      MAX_WEAPONS = 13
+
+      DEFAULT_MIN_CHARACTERS = 3
+      DEFAULT_MIN_SUMMONS = 2
+      DEFAULT_MIN_WEAPONS = 5
+
+      DEFAULT_MAX_CLEAR_TIME = 5400
+
       def create
         user = User.new(user_params)
 
@@ -44,11 +54,23 @@ module Api
           render_not_found_response('user')
         else
 
-          conditions = build_conditions(request.params)
+          conditions = build_conditions
           conditions[:user_id] = @user.id
+
+          @parties = Party
+                       .where(conditions)
+                       .where(name_quality)
+                       .where(user_quality)
+                       .where(original)
+                       .order(created_at: :desc)
+                       .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
+                       .each { |party| party.favorited = party.is_favorited(current_user) }
 
           parties = Party
                       .where(conditions)
+                      .where(name_quality)
+                      .where(user_quality)
+                      .where(original)
                       .order(created_at: :desc)
                       .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
                       .each do |party|
@@ -81,17 +103,70 @@ module Api
 
       private
 
-      def build_conditions(params)
+      def build_conditions
+        params = request.params
+
         unless params['recency'].blank?
           start_time = (DateTime.current - params['recency'].to_i.seconds)
                          .to_datetime.beginning_of_day
         end
 
+        min_characters_count = params['characters_count'].blank? ? DEFAULT_MIN_CHARACTERS : params['characters_count'].to_i
+        min_summons_count = params['summons_count'].blank? ? DEFAULT_MIN_SUMMONS : params['summons_count'].to_i
+        min_weapons_count = params['weapons_count'].blank? ? DEFAULT_MIN_WEAPONS : params['weapons_count'].to_i
+        max_clear_time = params['max_clear_time'].blank? ? DEFAULT_MAX_CLEAR_TIME : params['max_clear_time'].to_i
+
         {}.tap do |hash|
-          hash[:element] = params['element'] unless params['element'].blank?
+          # Basic filters
+          hash[:element] = params['element'].to_i unless params['element'].blank?
           hash[:raid] = params['raid'] unless params['raid'].blank?
           hash[:created_at] = start_time..DateTime.current unless params['recency'].blank?
+
+          # Advanced filters: Team parameters
+          hash[:full_auto] = params['full_auto'].to_i unless params['full_auto'].blank? || params['full_auto'].to_i == -1
+          hash[:auto_guard] = params['auto_guard'].to_i unless params['auto_guard'].blank? || params['auto_guard'].to_i == -1
+          hash[:charge_attack] = params['charge_attack'].to_i unless params['charge_attack'].blank? || params['charge_attack'].to_i == -1
+
+          # Turn count of 0 will not be displayed, so disallow on the frontend or set default to 1
+          # How do we do the same for button count since that can reasonably be 1?
+          # hash[:turn_count] = params['turn_count'].to_i unless params['turn_count'].blank? || params['turn_count'].to_i <= 0
+          # hash[:button_count] = params['button_count'].to_i unless params['button_count'].blank?
+          # hash[:clear_time] = 0..max_clear_time
+
+          # Advanced filters: Object counts
+          hash[:characters_count] = min_characters_count..MAX_CHARACTERS
+          hash[:summons_count] = min_summons_count..MAX_SUMMONS
+          hash[:weapons_count] = min_weapons_count..MAX_WEAPONS
         end
+      end
+
+      def original
+        "source_party_id IS NULL" unless params['original'].blank? || params['original'] == '0'
+      end
+
+      def user_quality
+        "user_id IS NOT NULL" unless params[:user_quality].nil? || params[:user_quality] == "0"
+      end
+
+      def name_quality
+        low_quality = [
+          "Untitled",
+          "Remix of Untitled",
+          "Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Remix of Untitled",
+          "Remix of Remix of Remix of Remix of Remix of Untitled",
+          "無題",
+          "無題のリミックス",
+          "無題のリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックスのリミックス",
+          "無題のリミックスのリミックスのリミックスのリミックスのリミックス"
+        ]
+
+        joined_names = low_quality.map { |name| "'#{name}'" }.join(',')
+
+        "name NOT IN (#{joined_names})" unless params[:name_quality].nil? || params[:name_quality] == "0"
       end
 
       # Specify whitelisted properties that can be modified.

--- a/app/models/guidebook.rb
+++ b/app/models/guidebook.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Guidebook < ApplicationRecord
+  alias eql? ==
+
+  include PgSearch::Model
+
+  pg_search_scope :en_search,
+                  against: :name_en,
+                  using: {
+                    tsearch: {
+                      prefix: true,
+                      dictionary: 'simple'
+                    }
+                  }
+
+  pg_search_scope :jp_search,
+                  against: :name_jp,
+                  using: {
+                    tsearch: {
+                      prefix: true,
+                      dictionary: 'simple'
+                    }
+                  }
+
+  def blueprint
+    GuidebookBlueprint
+  end
+
+  def display_resource(book)
+    book.name_en
+  end
+
+  def ==(other)
+    self.class == other.class && granblue_id === other.granblue_id
+  end
+end

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -66,6 +66,10 @@ class Party < ApplicationRecord
 
   ##### Amoeba configuration
   amoeba do
+    set weapons_count: 0
+    set characters_count: 0
+    set summons_count: 0
+
     nullify :description
     nullify :shortcode
 

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -41,11 +41,6 @@ class Party < ApplicationRecord
              class_name: 'JobSkill',
              optional: true
 
-  belongs_to :guidebook0,
-             foreign_key: 'guidebook0_id',
-             class_name: 'Guidebook',
-             optional: true
-
   belongs_to :guidebook1,
              foreign_key: 'guidebook1_id',
              class_name: 'Guidebook',
@@ -53,6 +48,11 @@ class Party < ApplicationRecord
 
   belongs_to :guidebook2,
              foreign_key: 'guidebook2_id',
+             class_name: 'Guidebook',
+             optional: true
+
+  belongs_to :guidebook3,
+             foreign_key: 'guidebook3_id',
              class_name: 'Guidebook',
              optional: true
 
@@ -95,6 +95,7 @@ class Party < ApplicationRecord
 
   ##### ActiveRecord Validations
   validate :skills_are_unique
+  validate :guidebooks_are_unique
 
   attr_accessor :favorited
 
@@ -144,5 +145,18 @@ class Party < ApplicationRecord
     end
 
     errors.add(:job_skills, 'must be unique')
+  end
+
+  def guidebooks_are_unique
+    guidebooks = [guidebook1, guidebook2, guidebook3].compact
+    return if guidebooks.uniq.length == guidebooks.length
+    
+    guidebooks.each_with_index do |book, index|
+      next if index.zero?
+
+      errors.add(:"guidebook#{index + 1}", 'must be unique') if guidebooks[0...index].include?(book)
+    end
+
+    errors.add(:guidebooks, 'must be unique')
   end
 end

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -41,6 +41,21 @@ class Party < ApplicationRecord
              class_name: 'JobSkill',
              optional: true
 
+  belongs_to :guidebook0,
+             foreign_key: 'guidebook0_id',
+             class_name: 'Guidebook',
+             optional: true
+
+  belongs_to :guidebook1,
+             foreign_key: 'guidebook1_id',
+             class_name: 'Guidebook',
+             optional: true
+
+  belongs_to :guidebook2,
+             foreign_key: 'guidebook2_id',
+             class_name: 'Guidebook',
+             optional: true
+
   has_many :characters,
            foreign_key: 'party_id',
            class_name: 'GridCharacter',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,12 +34,15 @@ Rails.application.routes.draw do
       post 'search/weapons', to: 'search#weapons'
       post 'search/summons', to: 'search#summons'
       post 'search/job_skills', to: 'search#job_skills'
+      post 'search/guidebooks', to: 'search#guidebooks'
 
       get 'jobs', to: 'jobs#all'
 
       get 'jobs/skills', to: 'job_skills#all'
       get 'jobs/:id/skills', to: 'job_skills#job'
       get 'jobs/:id/accessories', to: 'job_accessories#job'
+
+      get 'guidebooks', to: 'guidebooks#all'
 
       get 'raids', to: 'raids#all'
       get 'weapon_keys', to: 'weapon_keys#all'

--- a/db/migrate/20230321115930_add_default_to_counter_cache_on_parties.rb
+++ b/db/migrate/20230321115930_add_default_to_counter_cache_on_parties.rb
@@ -1,0 +1,7 @@
+class AddDefaultToCounterCacheOnParties < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :parties, :characters_count, 0
+    change_column_default :parties, :weapons_count, 0
+    change_column_default :parties, :summons_count, 0
+  end
+end

--- a/db/migrate/20230418052314_add_guidebooks.rb
+++ b/db/migrate/20230418052314_add_guidebooks.rb
@@ -1,0 +1,12 @@
+class AddGuidebooks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :guidebooks, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.string :granblue_id, null: false, unique: true
+      t.string :name_en, null: false, unique: true
+      t.string :name_jp, null: false, unique: true
+      t.string :description_en, null: false
+      t.string :description_jp, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230418052325_add_guidebooks_to_party.rb
+++ b/db/migrate/20230418052325_add_guidebooks_to_party.rb
@@ -1,0 +1,5 @@
+class AddGuidebooksToParty < ActiveRecord::Migration[7.0]
+  def change
+    add_column :parties, :guidebooks, :uuid, array: true, default: [], null: false
+  end
+end

--- a/db/migrate/20230418061932_update_guidebooks_structure.rb
+++ b/db/migrate/20230418061932_update_guidebooks_structure.rb
@@ -1,0 +1,6 @@
+class UpdateGuidebooksStructure < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :guidebooks, :updated_at
+    change_column_default :guidebooks, :created_at, -> { 'CURRENT_TIMESTAMP' }
+  end
+end

--- a/db/migrate/20230418071647_rename_guidebooks_to_guidebook_i_ds.rb
+++ b/db/migrate/20230418071647_rename_guidebooks_to_guidebook_i_ds.rb
@@ -1,0 +1,5 @@
+class RenameGuidebooksToGuidebookIDs < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :parties, :guidebooks, :guidebook_ids
+  end
+end

--- a/db/migrate/20230419033648_split_guidebooks_on_party.rb
+++ b/db/migrate/20230419033648_split_guidebooks_on_party.rb
@@ -1,0 +1,8 @@
+class SplitGuidebooksOnParty < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :parties, :guidebook_ids
+    add_reference :parties, :guidebook0, type: :uuid, foreign_key: { to_table: :guidebooks }
+    add_reference :parties, :guidebook1, type: :uuid, foreign_key: { to_table: :guidebooks }
+    add_reference :parties, :guidebook2, type: :uuid, foreign_key: { to_table: :guidebooks }
+  end
+end

--- a/db/migrate/20230419102354_rename_guidebook_columns.rb
+++ b/db/migrate/20230419102354_rename_guidebook_columns.rb
@@ -1,0 +1,5 @@
+class RenameGuidebookColumns < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :parties, :guidebook0_id, :guidebook3_id
+  end
+end

--- a/db/migrate/20230423070004_add_gacha_table.rb
+++ b/db/migrate/20230423070004_add_gacha_table.rb
@@ -1,0 +1,13 @@
+class AddGachaTable < ActiveRecord::Migration[7.0]
+  create_table :gacha, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+    t.references :drawable, polymorphic: true
+    t.boolean :premium
+    t.boolean :classic
+    t.boolean :flash
+    t.boolean :legend
+    t.boolean :valentines
+    t.boolean :summer
+    t.boolean :halloween
+    t.boolean :holiday
+  end
+end

--- a/db/migrate/20230423071446_add_recruits_to_weapon.rb
+++ b/db/migrate/20230423071446_add_recruits_to_weapon.rb
@@ -1,0 +1,5 @@
+class AddRecruitsToWeapon < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :weapons, :recruits, null: true, to_table: 'character_id', type: :uuid
+  end
+end

--- a/db/migrate/20230423125524_change_gacha_drawable_id_to_uuid.rb
+++ b/db/migrate/20230423125524_change_gacha_drawable_id_to_uuid.rb
@@ -1,0 +1,7 @@
+class ChangeGachaDrawableIdToUuid < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :gacha, :drawable_id, :bigint
+    remove_column :gacha, :drawable_type, :string
+    add_reference :gacha, :drawable, polymorphic: true, type: :uuid
+  end
+end

--- a/db/migrate/20230423132430_make_gacha_drawable_id_unique.rb
+++ b/db/migrate/20230423132430_make_gacha_drawable_id_unique.rb
@@ -1,0 +1,5 @@
+class MakeGachaDrawableIdUnique < ActiveRecord::Migration[7.0]
+  def change
+    add_index :gacha, :drawable_id, unique: true
+  end
+end

--- a/db/migrate/20230502012823_add_gacha_rateups_table.rb
+++ b/db/migrate/20230502012823_add_gacha_rateups_table.rb
@@ -1,0 +1,8 @@
+class AddGachaRateupsTable < ActiveRecord::Migration[7.0]
+  create_table :gacha_rateups, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+    t.references :gacha, type: :uuid
+    t.string :user_id
+    t.numeric :rate
+    t.datetime :created_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+  end
+end

--- a/db/migrate/20230503221903_add_sparks_table.rb
+++ b/db/migrate/20230503221903_add_sparks_table.rb
@@ -1,0 +1,11 @@
+class AddSparksTable < ActiveRecord::Migration[7.0]
+  create_table :sparks, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+    t.string :user_id, null: false
+    t.string :guild_ids, array: true, null: false
+    t.integer :crystals, default: 0
+    t.integer :tickets, default: 0
+    t.integer :ten_tickets, default: 0
+    t.references :target, polymorphic: true
+    t.datetime :updated_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+  end
+end

--- a/db/migrate/20230503224345_add_target_memo_to_sparks.rb
+++ b/db/migrate/20230503224345_add_target_memo_to_sparks.rb
@@ -1,0 +1,5 @@
+class AddTargetMemoToSparks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sparks, :target_memo, :string
+  end
+end

--- a/db/migrate/20230503224353_make_user_id_unique_in_sparks.rb
+++ b/db/migrate/20230503224353_make_user_id_unique_in_sparks.rb
@@ -1,0 +1,5 @@
+class MakeUserIdUniqueInSparks < ActiveRecord::Migration[7.0]
+  def change
+    add_index :sparks, :user_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_19_102354) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_03_224353) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -122,6 +122,29 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_19_102354) do
     t.datetime "updated_at", null: false
     t.index ["party_id"], name: "index_favorites_on_party_id"
     t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
+  create_table "gacha", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "premium"
+    t.boolean "classic"
+    t.boolean "flash"
+    t.boolean "legend"
+    t.boolean "valentines"
+    t.boolean "summer"
+    t.boolean "halloween"
+    t.boolean "holiday"
+    t.string "drawable_type"
+    t.uuid "drawable_id"
+    t.index ["drawable_id"], name: "index_gacha_on_drawable_id", unique: true
+    t.index ["drawable_type", "drawable_id"], name: "index_gacha_on_drawable"
+  end
+
+  create_table "gacha_rateups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "gacha_id"
+    t.string "user_id"
+    t.decimal "rate"
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.index ["gacha_id"], name: "index_gacha_rateups_on_gacha_id"
   end
 
   create_table "grid_characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -331,6 +354,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_19_102354) do
     t.string "slug"
   end
 
+  create_table "sparks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "user_id", null: false
+    t.string "guild_ids", null: false, array: true
+    t.integer "crystals", default: 0
+    t.integer "tickets", default: 0
+    t.integer "ten_tickets", default: 0
+    t.string "target_type"
+    t.bigint "target_id"
+    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.string "target_memo"
+    t.index ["target_type", "target_id"], name: "index_sparks_on_target"
+    t.index ["user_id"], name: "index_sparks_on_user_id", unique: true
+  end
+
   create_table "summons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name_en"
     t.string "name_jp"
@@ -413,7 +450,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_19_102354) do
     t.integer "awakening_types", default: [], array: true
     t.string "nicknames_en", default: [], null: false, array: true
     t.string "nicknames_jp", default: [], null: false, array: true
+    t.uuid "recruits_id"
     t.index ["name_en"], name: "index_weapons_on_name_en", opclass: :gin_trgm_ops, using: :gin
+    t.index ["recruits_id"], name: "index_weapons_on_recruits_id"
   end
 
   add_foreign_key "favorites", "parties"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_19_033648) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_19_102354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -306,13 +306,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_19_033648) do
     t.string "edit_key"
     t.uuid "local_id"
     t.integer "ultimate_mastery"
-    t.uuid "guidebook0_id"
+    t.uuid "guidebook3_id"
     t.uuid "guidebook1_id"
     t.uuid "guidebook2_id"
     t.index ["accessory_id"], name: "index_parties_on_accessory_id"
-    t.index ["guidebook0_id"], name: "index_parties_on_guidebook0_id"
     t.index ["guidebook1_id"], name: "index_parties_on_guidebook1_id"
     t.index ["guidebook2_id"], name: "index_parties_on_guidebook2_id"
+    t.index ["guidebook3_id"], name: "index_parties_on_guidebook3_id"
     t.index ["job_id"], name: "index_parties_on_job_id"
     t.index ["skill0_id"], name: "index_parties_on_skill0_id"
     t.index ["skill1_id"], name: "index_parties_on_skill1_id"
@@ -428,9 +428,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_19_033648) do
   add_foreign_key "jobs", "jobs", column: "base_job_id"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
-  add_foreign_key "parties", "guidebooks", column: "guidebook0_id"
   add_foreign_key "parties", "guidebooks", column: "guidebook1_id"
   add_foreign_key "parties", "guidebooks", column: "guidebook2_id"
+  add_foreign_key "parties", "guidebooks", column: "guidebook3_id"
   add_foreign_key "parties", "job_accessories", column: "accessory_id"
   add_foreign_key "parties", "job_skills", column: "skill0_id"
   add_foreign_key "parties", "job_skills", column: "skill1_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_18_061932) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_19_033648) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -306,8 +306,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_18_061932) do
     t.string "edit_key"
     t.uuid "local_id"
     t.integer "ultimate_mastery"
-    t.uuid "guidebooks", default: [], null: false, array: true
+    t.uuid "guidebook0_id"
+    t.uuid "guidebook1_id"
+    t.uuid "guidebook2_id"
     t.index ["accessory_id"], name: "index_parties_on_accessory_id"
+    t.index ["guidebook0_id"], name: "index_parties_on_guidebook0_id"
+    t.index ["guidebook1_id"], name: "index_parties_on_guidebook1_id"
+    t.index ["guidebook2_id"], name: "index_parties_on_guidebook2_id"
     t.index ["job_id"], name: "index_parties_on_job_id"
     t.index ["skill0_id"], name: "index_parties_on_skill0_id"
     t.index ["skill1_id"], name: "index_parties_on_skill1_id"
@@ -423,6 +428,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_18_061932) do
   add_foreign_key "jobs", "jobs", column: "base_job_id"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "parties", "guidebooks", column: "guidebook0_id"
+  add_foreign_key "parties", "guidebooks", column: "guidebook1_id"
+  add_foreign_key "parties", "guidebooks", column: "guidebook2_id"
   add_foreign_key "parties", "job_accessories", column: "accessory_id"
   add_foreign_key "parties", "job_skills", column: "skill0_id"
   add_foreign_key "parties", "job_skills", column: "skill1_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_21_115930) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_18_061932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -187,6 +187,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_21_115930) do
     t.index ["weapon_key3_id"], name: "index_grid_weapons_on_weapon_key3_id"
   end
 
+  create_table "guidebooks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "granblue_id", null: false
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.string "description_en", null: false
+    t.string "description_jp", null: false
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+  end
+
   create_table "job_accessories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "job_id"
     t.string "name_en", null: false
@@ -297,6 +306,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_21_115930) do
     t.string "edit_key"
     t.uuid "local_id"
     t.integer "ultimate_mastery"
+    t.uuid "guidebooks", default: [], null: false, array: true
     t.index ["accessory_id"], name: "index_parties_on_accessory_id"
     t.index ["job_id"], name: "index_parties_on_job_id"
     t.index ["skill0_id"], name: "index_parties_on_skill0_id"


### PR DESCRIPTION
I started working on Siero again during Guild Wars and decided that I only wanted to update one database for new unit releases.

This update adds migrations for 4 new tables:
- `guidebooks`: A table for storing basic guidebook information from Arcarum: Replicard Sandbox
- `gacha`: A mapping table between `weapons` and `summons` that stores appearance information for pullable items
- `gacha_rateups`: A table that stores a Discord user's rate-up information
- `sparks`: A table that stores a Discord user's sparks

We also added `recruits_id` to `weapons`, which is a reference to `characters` to keep track of what weapons recruit which characters.

Lastly, the business logic for Guidebooks is also included in this update, although the frontend still has a ways to go. We're mostly pushing this so that Siero can be deployed.

There is additional work that could be done around linking a user's granblue.team account with their Discord account, but that's for the future.