### PR TITLE
Fix searching in Japanese

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -11,7 +11,7 @@ class Character < ApplicationRecord
                     }
                   }
 
-  pg_search_scope :jp_search,
+  pg_search_scope :ja_search,
                   against: :name_jp,
                   using: {
                     tsearch: {

--- a/app/models/guidebook.rb
+++ b/app/models/guidebook.rb
@@ -14,7 +14,7 @@ class Guidebook < ApplicationRecord
                     }
                   }
 
-  pg_search_scope :jp_search,
+  pg_search_scope :ja_search,
                   against: :name_jp,
                   using: {
                     tsearch: {

--- a/app/models/job_skill.rb
+++ b/app/models/job_skill.rb
@@ -16,7 +16,7 @@ class JobSkill < ApplicationRecord
                     }
                   }
 
-  pg_search_scope :jp_search,
+  pg_search_scope :ja_search,
                   against: :name_jp,
                   using: {
                     tsearch: {

--- a/app/models/summon.rb
+++ b/app/models/summon.rb
@@ -11,7 +11,7 @@ class Summon < ApplicationRecord
                     }
                   }
 
-  pg_search_scope :jp_search,
+  pg_search_scope :ja_search,
                   against: :name_jp,
                   using: {
                     tsearch: {

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -11,7 +11,7 @@ class Weapon < ApplicationRecord
                     }
                   }
 
-  pg_search_scope :jp_search,
+  pg_search_scope :ja_search,
                   against: :name_jp,
                   using: {
                     tsearch: {


### PR DESCRIPTION
This was broken because we were using the browser-provided locale as a prefix to our method, but that is 'ja' and our methods were prefixed with 'jp'.

This fixes https://github.com/jedmund/hensei-web/issues/271