### PR TITLE
Allow users to delete parties with remixes

### DIFF
--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -33,13 +33,9 @@ module Api
       end
 
       view :minimal do
-        fields :name, :element, :shortcode, :favorited, :extra,
-               :full_auto, :clear_time, :auto_guard, :auto_summon,
+        fields :name, :element, :shortcode, :favorited, :remix,
+               :extra, :full_auto, :clear_time, :auto_guard, :auto_summon,
                :created_at, :updated_at
-
-        field :remix do |p|
-          p.is_remix
-        end
 
         field :guidebooks do |p|
           {

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -69,7 +69,8 @@ module Api
         new_party.attributes = {
           user: current_user,
           name: remixed_name(@party.name),
-          source_party: @party
+          source_party: @party,
+          remix: true
         }
 
         new_party.local_id = party_params[:local_id] if !party_params.nil?

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -10,7 +10,8 @@ class Party < ApplicationRecord
   has_many :derivative_parties,
            class_name: 'Party',
            foreign_key: :source_party_id,
-           inverse_of: :source_party
+           inverse_of: :source_party,
+           dependent: :nullify
 
   belongs_to :user, optional: true
   belongs_to :raid, optional: true

--- a/db/data/20230702035600_populate_remix_flag_on_parties.rb
+++ b/db/data/20230702035600_populate_remix_flag_on_parties.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PopulateRemixFlagOnParties < ActiveRecord::Migration[7.0]
+  def up
+    Party.find_each do |party|
+      party.update(remix: party.source_party_id.present?)
+    end
+  end
+
+  def down
+    Party.find_each do |party|
+      party.update(remix: false)
+    end
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230619043726)
+DataMigrate::Data.define(version: 20230702035600)

--- a/db/migrate/20230702035508_add_remix_flag_to_parties.rb
+++ b/db/migrate/20230702035508_add_remix_flag_to_parties.rb
@@ -1,0 +1,5 @@
+class AddRemixFlagToParties < ActiveRecord::Migration[7.0]
+  def change
+    add_column :parties, :remix, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_073125) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_02_035508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -347,6 +347,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_073125) do
     t.uuid "guidebook1_id"
     t.uuid "guidebook2_id"
     t.boolean "auto_summon", default: false, null: false
+    t.boolean "remix", default: false, null: false
     t.index ["accessory_id"], name: "index_parties_on_accessory_id"
     t.index ["guidebook1_id"], name: "index_parties_on_guidebook1_id"
     t.index ["guidebook2_id"], name: "index_parties_on_guidebook2_id"


### PR DESCRIPTION
There was a bug that prevented users from deleting parties with remixes because the source party reference was not being nullified. This was fixed that with `dependent: :nullify`. 

On top of that, we also added a boolean key `remix` to the parties database to track if a party is a remix or not. This way, if a party is flagged as a remix but the source party is null, we know that the original party was deleted and can message this on the frontend.