### PR TITLE
Implement all-entity search to support tagging objects

### DIFF
--- a/app/blueprints/api/v1/search_blueprint.rb
+++ b/app/blueprints/api/v1/search_blueprint.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SearchBlueprint < Blueprinter::Base
+      identifier :searchable_id
+      fields :searchable_type, :granblue_id, :name_en, :name_jp, :element
+    end
+  end
+end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -3,6 +3,16 @@
 class Character < ApplicationRecord
   include PgSearch::Model
 
+  multisearchable against: %i[name_en name_jp],
+                  additional_attributes: lambda { |character|
+                    {
+                      name_en: character.name_en,
+                      name_jp: character.name_jp,
+                      granblue_id: character.granblue_id,
+                      element: character.element
+                    }
+                  }
+
   pg_search_scope :en_search,
                   against: :name_en,
                   using: {

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,8 +1,20 @@
 # frozen_string_literal: true
 
 class Job < ApplicationRecord
+  include PgSearch::Model
+
   belongs_to :party
   has_many :skills, class_name: 'JobSkill'
+
+  multisearchable against: %i[name_en name_jp],
+                  additional_attributes: lambda { |job|
+                    {
+                      name_en: job.name_en,
+                      name_jp: job.name_jp,
+                      granblue_id: job.granblue_id,
+                      element: 0
+                    }
+                  }
 
   belongs_to :base_job,
              foreign_key: 'base_job_id',

--- a/app/models/summon.rb
+++ b/app/models/summon.rb
@@ -3,6 +3,16 @@
 class Summon < ApplicationRecord
   include PgSearch::Model
 
+  multisearchable against: %i[name_en name_jp],
+                  additional_attributes: lambda { |summon|
+                    {
+                      name_en: summon.name_en,
+                      name_jp: summon.name_jp,
+                      granblue_id: summon.granblue_id,
+                      element: summon.element
+                    }
+                  }
+
   pg_search_scope :en_search,
                   against: :name_en,
                   using: {

--- a/app/models/weapon.rb
+++ b/app/models/weapon.rb
@@ -3,6 +3,16 @@
 class Weapon < ApplicationRecord
   include PgSearch::Model
 
+  multisearchable against: %i[name_en name_jp],
+                  additional_attributes: lambda { |weapon|
+                    {
+                      name_en: weapon.name_en,
+                      name_jp: weapon.name_jp,
+                      granblue_id: weapon.granblue_id,
+                      element: weapon.element
+                    }
+                  }
+
   pg_search_scope :en_search,
                   against: :name_en,
                   using: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
       post 'check/email', to: 'users#check_email'
       post 'check/username', to: 'users#check_username'
 
+      post 'search', to: 'search#all'
       post 'search/characters', to: 'search#characters'
       post 'search/weapons', to: 'search#weapons'
       post 'search/summons', to: 'search#summons'

--- a/db/migrate/20230705065015_create_pg_search_documents.rb
+++ b/db/migrate/20230705065015_create_pg_search_documents.rb
@@ -1,0 +1,21 @@
+class CreatePgSearchDocuments < ActiveRecord::Migration[7.0]
+  def up
+    say_with_time('Creating table for pg_search multisearch') do
+      create_table :pg_search_documents do |t|
+        t.text :content
+        t.string :granblue_id
+        t.string :name_en
+        t.string :name_jp
+        t.integer :element
+        t.belongs_to :searchable, type: :uuid, polymorphic: true, index: true
+        t.timestamps null: false
+      end
+    end
+  end
+
+  def down
+    say_with_time('Dropping table for pg_search multisearch') do
+      drop_table :pg_search_documents
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_02_035508) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_05_065015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -359,6 +359,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_02_035508) do
     t.index ["skill3_id"], name: "index_parties_on_skill3_id"
     t.index ["source_party_id"], name: "index_parties_on_source_party_id"
     t.index ["user_id"], name: "index_parties_on_user_id"
+  end
+
+  create_table "pg_search_documents", force: :cascade do |t|
+    t.text "content"
+    t.string "granblue_id"
+    t.string "name_en"
+    t.string "name_jp"
+    t.integer "element"
+    t.string "searchable_type"
+    t.uuid "searchable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable"
   end
 
   create_table "raid_groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
This adds a new route for `SearchController` that lets a user search across characters, summons, weapons and jobs for entities via a tagging interface. We do this using pg_search's multisearch function.