### PR TITLE
Order search results by release or update date

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -72,7 +72,7 @@ module Api
                          Character.en_search(search_params[:query]).where(conditions)
                        end
                      else
-                       Character.where(conditions)
+                       Character.where(conditions).order(Arel.sql('greatest(release_date, flb_date, ulb_date) desc'))
                      end
 
         count = characters.length
@@ -110,7 +110,7 @@ module Api
                       Weapon.en_search(search_params[:query]).where(conditions)
                     end
                   else
-                    Weapon.where(conditions)
+                    Weapon.where(conditions).order(Arel.sql('greatest(release_date, flb_date, ulb_date) desc'))
                   end
 
         count = weapons.length
@@ -143,7 +143,7 @@ module Api
                       Summon.en_search(search_params[:query]).where(conditions)
                     end
                   else
-                    Summon.where(conditions)
+                    Summon.where(conditions).order(release_date: :desc).order(Arel.sql('greatest(release_date, flb_date, ulb_date, xlb_date) desc'))
                   end
 
         count = summons.length


### PR DESCRIPTION
The list of all items that shows up when you open the search modal will now list all items sorted latest first, whether the item is brand new or an item that recently got an uncap.

<img width="620" alt="CleanShot 2023-08-20 at 01 55 50@2x" src="https://github.com/jedmund/hensei-api/assets/383021/7afd16b9-8ef5-45d5-817b-6bbae8d891ae">
