### PR TITLE
Implement roles and visibility

### DIFF
--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -35,7 +35,7 @@ module Api
       view :minimal do
         fields :name, :element, :shortcode, :favorited, :remix,
                :extra, :full_auto, :clear_time, :auto_guard, :auto_summon,
-               :created_at, :updated_at
+               :visibility, :created_at, :updated_at
 
         field :guidebooks do |p|
           {

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -50,9 +50,17 @@ module Api
         @current_user
       end
 
+      def admin_mode
+        if current_user && current_user.admin? && request.headers['X-Admin-Mode']
+          @admin_mode ||= request.headers['X-Admin-Mode'] == 'true'
+        end
+
+        @admin_mode
+      end
+
       def edit_key
         @edit_key ||= request.headers['X-Edit-Key'] if request.headers['X-Edit-Key']
-        
+
         @edit_key
       end
 
@@ -96,9 +104,9 @@ module Api
 
       def render_not_found_response(object)
         render json: ErrorBlueprint.render(nil, error: {
-          message: "#{object.capitalize} could not be found",
-          code: 'not_found'
-        }), status: :not_found
+                                             message: "#{object.capitalize} could not be found",
+                                             code: 'not_found'
+                                           }), status: :not_found
       end
 
       def render_unauthorized_response

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -33,7 +33,7 @@ module Api
 
       def show
         # If a party is private, check that the user is the owner or an admin
-        return render_unauthorized_response if !current_user || (@party.private && not_owner && !admin_mode)
+        return render_unauthorized_response if !current_user || (@party.private? && not_owner && !admin_mode)
 
         return render json: PartyBlueprint.render(@party, view: :full, root: :party) if @party
 

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -33,7 +33,9 @@ module Api
 
       def show
         # If a party is private, check that the user is the owner or an admin
-        return render_unauthorized_response if !current_user || (@party.private? && not_owner && !admin_mode)
+        if (@party.private? && !current_user) || (@party.private? && not_owner && !admin_mode)
+          return render_unauthorized_response
+        end
 
         return render json: PartyBlueprint.render(@party, view: :full, root: :party) if @party
 
@@ -107,7 +109,7 @@ module Api
       private
 
       def authorize
-        render_unauthorized_response if not_owner || @party.edit_key != edit_key || !admin_mode
+        render_unauthorized_response if (not_owner && !admin_mode) || (@party.edit_key != edit_key && !admin_mode)
       end
 
       def not_owner

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -32,9 +32,8 @@ module Api
       end
 
       def show
-        # If a party is private, check that the user is the owner
-        not_owner = current_user && @party.private? && @party.user != current_user
-        return render_unauthorized_response if !current_user || (not_owner && !admin_mode)
+        # If a party is private, check that the user is the owner or an admin
+        return render_unauthorized_response if !current_user || (@party.private && not_owner && !admin_mode)
 
         return render json: PartyBlueprint.render(@party, view: :full, root: :party) if @party
 
@@ -108,7 +107,11 @@ module Api
       private
 
       def authorize
-        render_unauthorized_response if @party.user != current_user || @party.edit_key != edit_key
+        render_unauthorized_response if not_owner || @party.edit_key != edit_key || !admin_mode
+      end
+
+      def not_owner
+        current_user && @party.user != current_user
       end
 
       def build_filters

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -256,7 +256,7 @@ module Api
         if favorites
           'visibility < 3'
         else
-          'visibility == 1'
+          'visibility = 1'
         end
       end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -63,6 +63,7 @@ module Api
                     .where(name_quality)
                     .where(user_quality)
                     .where(original)
+                    .where(privacy)
                     .order(created_at: :desc)
                     .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
                     .each do |party|
@@ -117,15 +118,15 @@ module Api
           # Advanced filters: Team parameters
           unless params['full_auto'].blank? || params['full_auto'].to_i == -1
             hash[:full_auto] =
-params['full_auto'].to_i
+              params['full_auto'].to_i
           end
           unless params['auto_guard'].blank? || params['auto_guard'].to_i == -1
             hash[:auto_guard] =
-params['auto_guard'].to_i
+              params['auto_guard'].to_i
           end
           unless params['charge_attack'].blank? || params['charge_attack'].to_i == -1
             hash[:charge_attack] =
-params['charge_attack'].to_i
+              params['charge_attack'].to_i
           end
 
           # Turn count of 0 will not be displayed, so disallow on the frontend or set default to 1
@@ -174,6 +175,12 @@ params['charge_attack'].to_i
         return if params.key?('name_quality') || params[:name_quality].nil? || params[:name_quality] == '0'
 
         "name NOT IN (#{joined_names})"
+      end
+
+      def privacy
+        return if admin_mode
+
+        'visibility = 1' if current_user != @user
       end
 
       # Specify whitelisted properties that can be modified.

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -41,6 +41,8 @@ module Api
         render_validation_error_response(@user)
       end
 
+      # TODO: Allow admins to update other users
+
       def update
         render json: UserBlueprint.render(@user, view: :minimal) if @user.update(user_params)
       end
@@ -57,13 +59,13 @@ module Api
           conditions[:user_id] = @user.id
 
           parties = Party
-                      .where(conditions)
-                      .where(name_quality)
-                      .where(user_quality)
-                      .where(original)
-                      .order(created_at: :desc)
-                      .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
-                      .each do |party|
+                    .where(conditions)
+                    .where(name_quality)
+                    .where(user_quality)
+                    .where(original)
+                    .order(created_at: :desc)
+                    .paginate(page: request.params[:page], per_page: COLLECTION_PER_PAGE)
+                    .each do |party|
             party.favorited = current_user ? party.is_favorited(current_user) : false
           end
 
@@ -98,7 +100,7 @@ module Api
 
         unless params['recency'].blank?
           start_time = (DateTime.current - params['recency'].to_i.seconds)
-                         .to_datetime.beginning_of_day
+                       .to_datetime.beginning_of_day
         end
 
         min_characters_count = params['characters_count'].blank? ? DEFAULT_MIN_CHARACTERS : params['characters_count'].to_i
@@ -113,9 +115,18 @@ module Api
           hash[:created_at] = start_time..DateTime.current unless params['recency'].blank?
 
           # Advanced filters: Team parameters
-          hash[:full_auto] = params['full_auto'].to_i unless params['full_auto'].blank? || params['full_auto'].to_i == -1
-          hash[:auto_guard] = params['auto_guard'].to_i unless params['auto_guard'].blank? || params['auto_guard'].to_i == -1
-          hash[:charge_attack] = params['charge_attack'].to_i unless params['charge_attack'].blank? || params['charge_attack'].to_i == -1
+          unless params['full_auto'].blank? || params['full_auto'].to_i == -1
+            hash[:full_auto] =
+params['full_auto'].to_i
+          end
+          unless params['auto_guard'].blank? || params['auto_guard'].to_i == -1
+            hash[:auto_guard] =
+params['auto_guard'].to_i
+          end
+          unless params['charge_attack'].blank? || params['charge_attack'].to_i == -1
+            hash[:charge_attack] =
+params['charge_attack'].to_i
+          end
 
           # Turn count of 0 will not be displayed, so disallow on the frontend or set default to 1
           # How do we do the same for button count since that can reasonably be 1?
@@ -131,38 +142,38 @@ module Api
       end
 
       def original
-        unless params.key?('original') || params['original'].blank? || params['original'] == '0'
-          "source_party_id IS NULL"
-        end
+        return if params.key?('original') || params['original'].blank? || params['original'] == '0'
+
+        'source_party_id IS NULL'
       end
 
       def user_quality
-        unless params.key?('user_quality') || params[:user_quality].nil? || params[:user_quality] == "0"
-          "user_id IS NOT NULL"
-        end
+        return if params.key?('user_quality') || params[:user_quality].nil? || params[:user_quality] == '0'
+
+        'user_id IS NOT NULL'
       end
 
       def name_quality
         low_quality = [
-          "Untitled",
-          "Remix of Untitled",
-          "Remix of Remix of Untitled",
-          "Remix of Remix of Remix of Untitled",
-          "Remix of Remix of Remix of Remix of Untitled",
-          "Remix of Remix of Remix of Remix of Remix of Untitled",
-          "無題",
-          "無題のリミックス",
-          "無題のリミックスのリミックス",
-          "無題のリミックスのリミックスのリミックス",
-          "無題のリミックスのリミックスのリミックスのリミックス",
-          "無題のリミックスのリミックスのリミックスのリミックスのリミックス"
+          'Untitled',
+          'Remix of Untitled',
+          'Remix of Remix of Untitled',
+          'Remix of Remix of Remix of Untitled',
+          'Remix of Remix of Remix of Remix of Untitled',
+          'Remix of Remix of Remix of Remix of Remix of Untitled',
+          '無題',
+          '無題のリミックス',
+          '無題のリミックスのリミックス',
+          '無題のリミックスのリミックスのリミックス',
+          '無題のリミックスのリミックスのリミックスのリミックス',
+          '無題のリミックスのリミックスのリミックスのリミックスのリミックス'
         ]
 
         joined_names = low_quality.map { |name| "'#{name}'" }.join(',')
 
-        unless params.key?('name_quality') || params[:name_quality].nil? || params[:name_quality] == "0"
-          "name NOT IN (#{joined_names})"
-        end
+        return if params.key?('name_quality') || params[:name_quality].nil? || params[:name_quality] == '0'
+
+        "name NOT IN (#{joined_names})"
       end
 
       # Specify whitelisted properties that can be modified.

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -105,15 +105,27 @@ class Party < ApplicationRecord
   end
 
   def is_remix
-    self.source_party != nil
+    !source_party.nil?
   end
 
   def remixes
-    Party.where(source_party_id: self.id)
+    Party.where(source_party_id: id)
   end
 
   def blueprint
     PartyBlueprint
+  end
+
+  def public?
+    visibility == 1
+  end
+
+  def unlisted?
+    visibility == 2
+  end
+
+  def private?
+    visibility == 3
   end
 
   private
@@ -123,9 +135,9 @@ class Party < ApplicationRecord
   end
 
   def set_edit_key
-    if !self.user
-      self.edit_key = Digest::SHA1.hexdigest([Time.now, rand].join)
-    end
+    return if user
+
+    self.edit_key = Digest::SHA1.hexdigest([Time.now, rand].join)
   end
 
   def random_string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,10 @@ class User < ApplicationRecord
     favorites.map(&:party)
   end
 
+  def admin?
+    role == 9
+  end
+
   def blueprint
     UserBlueprint
   end

--- a/db/migrate/20230824222028_add_role_to_users.rb
+++ b/db/migrate/20230824222028_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :integer, default: 1, null: false
+  end
+end

--- a/db/migrate/20230824222107_add_visibility_to_parties.rb
+++ b/db/migrate/20230824222107_add_visibility_to_parties.rb
@@ -1,0 +1,5 @@
+class AddVisibilityToParties < ActiveRecord::Migration[7.0]
+  def change
+    add_column :parties, :visibility, :integer, default: 1, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,548 +10,550 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_820_113_900) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_24_222107) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'btree_gin'
-  enable_extension 'pg_trgm'
-  enable_extension 'pgcrypto'
-  enable_extension 'plpgsql'
+  enable_extension "btree_gin"
+  enable_extension "pg_trgm"
+  enable_extension "pgcrypto"
+  enable_extension "plpgsql"
 
-  create_table 'app_updates', primary_key: 'updated_at', id: :datetime, force: :cascade do |t|
-    t.string 'update_type', null: false
-    t.string 'version'
+  create_table "app_updates", primary_key: "updated_at", id: :datetime, force: :cascade do |t|
+    t.string "update_type", null: false
+    t.string "version"
   end
 
-  create_table 'awakenings', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'name_en', null: false
-    t.string 'name_jp', null: false
-    t.string 'slug', null: false
-    t.string 'object_type', null: false
-    t.integer 'order', default: 0, null: false
+  create_table "awakenings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.string "slug", null: false
+    t.string "object_type", null: false
+    t.integer "order", default: 0, null: false
   end
 
-  create_table 'character_charge_attacks', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'character_id'
-    t.string 'name_en', null: false
-    t.string 'name_jp', null: false
-    t.string 'description_en', null: false
-    t.string 'description_jp', null: false
-    t.integer 'order', null: false
-    t.string 'form'
-    t.uuid 'effects', array: true
-    t.index ['character_id'], name: 'index_character_charge_attacks_on_character_id'
+  create_table "character_charge_attacks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "character_id"
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.string "description_en", null: false
+    t.string "description_jp", null: false
+    t.integer "order", null: false
+    t.string "form"
+    t.uuid "effects", array: true
+    t.index ["character_id"], name: "index_character_charge_attacks_on_character_id"
   end
 
-  create_table 'character_skills', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'character_id'
-    t.string 'name_en', null: false
-    t.string 'name_jp', null: false
-    t.string 'description_en', null: false
-    t.string 'description_jp', null: false
-    t.integer 'type', null: false
-    t.integer 'position', null: false
-    t.string 'form'
-    t.integer 'cooldown', default: 0, null: false
-    t.integer 'lockout', default: 0, null: false
-    t.integer 'duration', array: true
-    t.boolean 'recast', default: false, null: false
-    t.integer 'obtained_at', default: 1, null: false
-    t.uuid 'effects', array: true
-    t.index ['character_id'], name: 'index_character_skills_on_character_id'
+  create_table "character_skills", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "character_id"
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.string "description_en", null: false
+    t.string "description_jp", null: false
+    t.integer "type", null: false
+    t.integer "position", null: false
+    t.string "form"
+    t.integer "cooldown", default: 0, null: false
+    t.integer "lockout", default: 0, null: false
+    t.integer "duration", array: true
+    t.boolean "recast", default: false, null: false
+    t.integer "obtained_at", default: 1, null: false
+    t.uuid "effects", array: true
+    t.index ["character_id"], name: "index_character_skills_on_character_id"
   end
 
-  create_table 'character_support_skills', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'character_id'
-    t.string 'name_en', null: false
-    t.string 'name_jp', null: false
-    t.string 'description_en', null: false
-    t.string 'description_jp', null: false
-    t.integer 'position', null: false
-    t.integer 'obtained_at'
-    t.boolean 'emp', default: false, null: false
-    t.boolean 'transcendence', default: false, null: false
-    t.uuid 'effects', array: true
-    t.index ['character_id'], name: 'index_character_support_skills_on_character_id'
+  create_table "character_support_skills", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "character_id"
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.string "description_en", null: false
+    t.string "description_jp", null: false
+    t.integer "position", null: false
+    t.integer "obtained_at"
+    t.boolean "emp", default: false, null: false
+    t.boolean "transcendence", default: false, null: false
+    t.uuid "effects", array: true
+    t.index ["character_id"], name: "index_character_support_skills_on_character_id"
   end
 
-  create_table 'characters', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'name_en'
-    t.string 'name_jp'
-    t.string 'granblue_id'
-    t.integer 'rarity'
-    t.integer 'element'
-    t.integer 'proficiency1'
-    t.integer 'proficiency2'
-    t.integer 'gender'
-    t.integer 'race1'
-    t.integer 'race2'
-    t.boolean 'flb', default: false, null: false
-    t.integer 'min_hp'
-    t.integer 'max_hp'
-    t.integer 'max_hp_flb'
-    t.integer 'min_atk'
-    t.integer 'max_atk'
-    t.integer 'max_atk_flb'
-    t.integer 'base_da'
-    t.integer 'base_ta'
-    t.float 'ougi_ratio'
-    t.float 'ougi_ratio_flb'
-    t.boolean 'special', default: false, null: false
-    t.boolean 'ulb', default: false, null: false
-    t.integer 'max_hp_ulb'
-    t.integer 'max_atk_ulb'
-    t.integer 'character_id', default: [], null: false, array: true
-    t.string 'nicknames_en', default: [], null: false, array: true
-    t.string 'nicknames_jp', default: [], null: false, array: true
-    t.string 'wiki_en', default: '', null: false
-    t.date 'release_date'
-    t.date 'flb_date'
-    t.date 'ulb_date'
-    t.string 'wiki_ja', default: '', null: false
-    t.string 'gamewith', default: '', null: false
-    t.string 'kamigame', default: '', null: false
-    t.index ['name_en'], name: 'index_characters_on_name_en', opclass: :gin_trgm_ops, using: :gin
+  create_table "characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_jp"
+    t.string "granblue_id"
+    t.integer "rarity"
+    t.integer "element"
+    t.integer "proficiency1"
+    t.integer "proficiency2"
+    t.integer "gender"
+    t.integer "race1"
+    t.integer "race2"
+    t.boolean "flb", default: false, null: false
+    t.integer "min_hp"
+    t.integer "max_hp"
+    t.integer "max_hp_flb"
+    t.integer "min_atk"
+    t.integer "max_atk"
+    t.integer "max_atk_flb"
+    t.integer "base_da"
+    t.integer "base_ta"
+    t.float "ougi_ratio"
+    t.float "ougi_ratio_flb"
+    t.boolean "special", default: false, null: false
+    t.boolean "ulb", default: false, null: false
+    t.integer "max_hp_ulb"
+    t.integer "max_atk_ulb"
+    t.integer "character_id", default: [], null: false, array: true
+    t.string "nicknames_en", default: [], null: false, array: true
+    t.string "nicknames_jp", default: [], null: false, array: true
+    t.string "wiki_en", default: "", null: false
+    t.date "release_date"
+    t.date "flb_date"
+    t.date "ulb_date"
+    t.string "wiki_ja", default: "", null: false
+    t.string "gamewith", default: "", null: false
+    t.string "kamigame", default: "", null: false
+    t.index ["name_en"], name: "index_characters_on_name_en", opclass: :gin_trgm_ops, using: :gin
   end
 
-  create_table 'data_migrations', primary_key: 'version', id: :string, force: :cascade do |t|
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
-  create_table 'effects', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'name_en', null: false
-    t.string 'name_jp', null: false
-    t.string 'description_en', null: false
-    t.string 'description_jp', null: false
-    t.integer 'accuracy_value'
-    t.string 'accuracy_suffix'
-    t.string 'accuracy_comparator'
-    t.jsonb 'strength', array: true
-    t.integer 'healing_cap'
-    t.boolean 'duration_indefinite', default: false, null: false
-    t.integer 'duration_value'
-    t.string 'duration_unit'
-    t.string 'notes_en'
-    t.string 'notes_jp'
+  create_table "effects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.string "description_en", null: false
+    t.string "description_jp", null: false
+    t.integer "accuracy_value"
+    t.string "accuracy_suffix"
+    t.string "accuracy_comparator"
+    t.jsonb "strength", array: true
+    t.integer "healing_cap"
+    t.boolean "duration_indefinite", default: false, null: false
+    t.integer "duration_value"
+    t.string "duration_unit"
+    t.string "notes_en"
+    t.string "notes_jp"
   end
 
-  create_table 'favorites', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'user_id'
-    t.uuid 'party_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['party_id'], name: 'index_favorites_on_party_id'
-    t.index ['user_id'], name: 'index_favorites_on_user_id'
+  create_table "favorites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id"
+    t.uuid "party_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["party_id"], name: "index_favorites_on_party_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
-  create_table 'gacha', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.boolean 'premium'
-    t.boolean 'classic'
-    t.boolean 'flash'
-    t.boolean 'legend'
-    t.boolean 'valentines'
-    t.boolean 'summer'
-    t.boolean 'halloween'
-    t.boolean 'holiday'
-    t.string 'drawable_type'
-    t.uuid 'drawable_id'
-    t.index ['drawable_id'], name: 'index_gacha_on_drawable_id', unique: true
-    t.index %w[drawable_type drawable_id], name: 'index_gacha_on_drawable'
+  create_table "gacha", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "premium"
+    t.boolean "classic"
+    t.boolean "flash"
+    t.boolean "legend"
+    t.boolean "valentines"
+    t.boolean "summer"
+    t.boolean "halloween"
+    t.boolean "holiday"
+    t.string "drawable_type"
+    t.uuid "drawable_id"
+    t.index ["drawable_id"], name: "index_gacha_on_drawable_id", unique: true
+    t.index ["drawable_type", "drawable_id"], name: "index_gacha_on_drawable"
   end
 
-  create_table 'gacha_rateups', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'gacha_id'
-    t.string 'user_id'
-    t.decimal 'rate'
-    t.datetime 'created_at', default: -> { 'CURRENT_TIMESTAMP' }, null: false
-    t.index ['gacha_id'], name: 'index_gacha_rateups_on_gacha_id'
+  create_table "gacha_rateups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "gacha_id"
+    t.string "user_id"
+    t.decimal "rate"
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.index ["gacha_id"], name: "index_gacha_rateups_on_gacha_id"
   end
 
-  create_table 'grid_characters', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'party_id'
-    t.uuid 'character_id'
-    t.integer 'uncap_level'
-    t.integer 'position'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.boolean 'perpetuity', default: false, null: false
-    t.integer 'transcendence_step', default: 0, null: false
-    t.jsonb 'ring1', default: { 'modifier' => nil, 'strength' => nil }, null: false
-    t.jsonb 'ring2', default: { 'modifier' => nil, 'strength' => nil }, null: false
-    t.jsonb 'ring3', default: { 'modifier' => nil, 'strength' => nil }, null: false
-    t.jsonb 'ring4', default: { 'modifier' => nil, 'strength' => nil }, null: false
-    t.jsonb 'earring', default: { 'modifier' => nil, 'strength' => nil }, null: false
-    t.boolean 'skill0_enabled', default: true, null: false
-    t.boolean 'skill1_enabled', default: true, null: false
-    t.boolean 'skill2_enabled', default: true, null: false
-    t.boolean 'skill3_enabled', default: true, null: false
-    t.uuid 'awakening_id'
-    t.integer 'awakening_level', default: 1
-    t.index ['awakening_id'], name: 'index_grid_characters_on_awakening_id'
-    t.index ['character_id'], name: 'index_grid_characters_on_character_id'
-    t.index ['party_id'], name: 'index_grid_characters_on_party_id'
+  create_table "grid_characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "party_id"
+    t.uuid "character_id"
+    t.integer "uncap_level"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "perpetuity", default: false, null: false
+    t.integer "transcendence_step", default: 0, null: false
+    t.jsonb "ring1", default: {"modifier"=>nil, "strength"=>nil}, null: false
+    t.jsonb "ring2", default: {"modifier"=>nil, "strength"=>nil}, null: false
+    t.jsonb "ring3", default: {"modifier"=>nil, "strength"=>nil}, null: false
+    t.jsonb "ring4", default: {"modifier"=>nil, "strength"=>nil}, null: false
+    t.jsonb "earring", default: {"modifier"=>nil, "strength"=>nil}, null: false
+    t.boolean "skill0_enabled", default: true, null: false
+    t.boolean "skill1_enabled", default: true, null: false
+    t.boolean "skill2_enabled", default: true, null: false
+    t.boolean "skill3_enabled", default: true, null: false
+    t.uuid "awakening_id"
+    t.integer "awakening_level", default: 1
+    t.index ["awakening_id"], name: "index_grid_characters_on_awakening_id"
+    t.index ["character_id"], name: "index_grid_characters_on_character_id"
+    t.index ["party_id"], name: "index_grid_characters_on_party_id"
   end
 
-  create_table 'grid_summons', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'party_id'
-    t.uuid 'summon_id'
-    t.integer 'uncap_level'
-    t.boolean 'main'
-    t.boolean 'friend'
-    t.integer 'position'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'transcendence_step', default: 0, null: false
-    t.boolean 'quick_summon', default: false, null: false
-    t.index ['party_id'], name: 'index_grid_summons_on_party_id'
-    t.index ['summon_id'], name: 'index_grid_summons_on_summon_id'
+  create_table "grid_summons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "party_id"
+    t.uuid "summon_id"
+    t.integer "uncap_level"
+    t.boolean "main"
+    t.boolean "friend"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "transcendence_step", default: 0, null: false
+    t.boolean "quick_summon", default: false, null: false
+    t.index ["party_id"], name: "index_grid_summons_on_party_id"
+    t.index ["summon_id"], name: "index_grid_summons_on_summon_id"
   end
 
-  create_table 'grid_weapons', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'party_id'
-    t.uuid 'weapon_id'
-    t.uuid 'weapon_key1_id'
-    t.uuid 'weapon_key2_id'
-    t.integer 'uncap_level'
-    t.boolean 'mainhand'
-    t.integer 'position'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.uuid 'weapon_key3_id'
-    t.integer 'ax_modifier1'
-    t.float 'ax_strength1'
-    t.integer 'ax_modifier2'
-    t.float 'ax_strength2'
-    t.integer 'element'
-    t.integer 'awakening_level', default: 1, null: false
-    t.uuid 'awakening_id'
-    t.index ['awakening_id'], name: 'index_grid_weapons_on_awakening_id'
-    t.index ['party_id'], name: 'index_grid_weapons_on_party_id'
-    t.index ['weapon_id'], name: 'index_grid_weapons_on_weapon_id'
-    t.index ['weapon_key1_id'], name: 'index_grid_weapons_on_weapon_key1_id'
-    t.index ['weapon_key2_id'], name: 'index_grid_weapons_on_weapon_key2_id'
-    t.index ['weapon_key3_id'], name: 'index_grid_weapons_on_weapon_key3_id'
+  create_table "grid_weapons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "party_id"
+    t.uuid "weapon_id"
+    t.uuid "weapon_key1_id"
+    t.uuid "weapon_key2_id"
+    t.integer "uncap_level"
+    t.boolean "mainhand"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "weapon_key3_id"
+    t.integer "ax_modifier1"
+    t.float "ax_strength1"
+    t.integer "ax_modifier2"
+    t.float "ax_strength2"
+    t.integer "element"
+    t.integer "awakening_level", default: 1, null: false
+    t.uuid "awakening_id"
+    t.index ["awakening_id"], name: "index_grid_weapons_on_awakening_id"
+    t.index ["party_id"], name: "index_grid_weapons_on_party_id"
+    t.index ["weapon_id"], name: "index_grid_weapons_on_weapon_id"
+    t.index ["weapon_key1_id"], name: "index_grid_weapons_on_weapon_key1_id"
+    t.index ["weapon_key2_id"], name: "index_grid_weapons_on_weapon_key2_id"
+    t.index ["weapon_key3_id"], name: "index_grid_weapons_on_weapon_key3_id"
   end
 
-  create_table 'guidebooks', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'granblue_id', null: false
-    t.string 'name_en', null: false
-    t.string 'name_jp', null: false
-    t.string 'description_en', null: false
-    t.string 'description_jp', null: false
-    t.datetime 'created_at', default: -> { 'CURRENT_TIMESTAMP' }, null: false
+  create_table "guidebooks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "granblue_id", null: false
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.string "description_en", null: false
+    t.string "description_jp", null: false
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
   end
 
-  create_table 'job_accessories', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'job_id'
-    t.string 'name_en', null: false
-    t.string 'name_jp', null: false
-    t.string 'granblue_id', null: false
-    t.integer 'rarity'
-    t.date 'release_date'
-    t.integer 'accessory_type'
-    t.index ['job_id'], name: 'index_job_accessories_on_job_id'
+  create_table "job_accessories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "job_id"
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.string "granblue_id", null: false
+    t.integer "rarity"
+    t.date "release_date"
+    t.integer "accessory_type"
+    t.index ["job_id"], name: "index_job_accessories_on_job_id"
   end
 
-  create_table 'job_skills', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'job_id'
-    t.string 'name_en', null: false
-    t.string 'name_jp', null: false
-    t.string 'slug', null: false
-    t.integer 'color', null: false
-    t.boolean 'main', default: false
-    t.boolean 'sub', default: false
-    t.boolean 'emp', default: false
-    t.integer 'order'
-    t.boolean 'base', default: false
-    t.index ['job_id'], name: 'index_job_skills_on_job_id'
+  create_table "job_skills", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "job_id"
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.string "slug", null: false
+    t.integer "color", null: false
+    t.boolean "main", default: false
+    t.boolean "sub", default: false
+    t.boolean "emp", default: false
+    t.integer "order"
+    t.boolean "base", default: false
+    t.index ["job_id"], name: "index_job_skills_on_job_id"
   end
 
-  create_table 'jobs', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'name_en'
-    t.string 'name_jp'
-    t.integer 'proficiency1'
-    t.integer 'proficiency2'
-    t.string 'row'
-    t.boolean 'master_level', default: false, null: false
-    t.integer 'order'
-    t.uuid 'base_job_id'
-    t.string 'granblue_id'
-    t.boolean 'accessory', default: false
-    t.integer 'accessory_type', default: 0
-    t.boolean 'ultimate_mastery', default: false, null: false
-    t.index ['base_job_id'], name: 'index_jobs_on_base_job_id'
+  create_table "jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_jp"
+    t.integer "proficiency1"
+    t.integer "proficiency2"
+    t.string "row"
+    t.boolean "master_level", default: false, null: false
+    t.integer "order"
+    t.uuid "base_job_id"
+    t.string "granblue_id"
+    t.boolean "accessory", default: false
+    t.integer "accessory_type", default: 0
+    t.boolean "ultimate_mastery", default: false, null: false
+    t.index ["base_job_id"], name: "index_jobs_on_base_job_id"
   end
 
-  create_table 'oauth_access_grants', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'resource_owner_id', null: false
-    t.uuid 'application_id', null: false
-    t.string 'token', null: false
-    t.integer 'expires_in', null: false
-    t.text 'redirect_uri', null: false
-    t.datetime 'created_at', precision: nil, null: false
-    t.datetime 'revoked_at', precision: nil
-    t.string 'scopes'
-    t.index ['token'], name: 'index_oauth_access_grants_on_token', unique: true
+  create_table "oauth_access_grants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "resource_owner_id", null: false
+    t.uuid "application_id", null: false
+    t.string "token", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "revoked_at", precision: nil
+    t.string "scopes"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
-  create_table 'oauth_access_tokens', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'resource_owner_id'
-    t.uuid 'application_id'
-    t.string 'token', null: false
-    t.string 'refresh_token'
-    t.integer 'expires_in'
-    t.datetime 'revoked_at', precision: nil
-    t.datetime 'created_at', precision: nil, null: false
-    t.string 'scopes'
-    t.string 'previous_refresh_token', default: ''
-    t.index ['refresh_token'], name: 'index_oauth_access_tokens_on_refresh_token', unique: true
-    t.index ['resource_owner_id'], name: 'index_oauth_access_tokens_on_resource_owner_id'
-    t.index ['token'], name: 'index_oauth_access_tokens_on_token', unique: true
+  create_table "oauth_access_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "resource_owner_id"
+    t.uuid "application_id"
+    t.string "token", null: false
+    t.string "refresh_token"
+    t.integer "expires_in"
+    t.datetime "revoked_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.string "scopes"
+    t.string "previous_refresh_token", default: ""
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
-  create_table 'oauth_applications', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'uid', null: false
-    t.string 'secret', null: false
-    t.text 'redirect_uri', null: false
-    t.string 'scopes', default: '', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['uid'], name: 'index_oauth_applications_on_uid', unique: true
+  create_table "oauth_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "uid", null: false
+    t.string "secret", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table 'parties', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'user_id'
-    t.string 'shortcode'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.boolean 'extra', default: false, null: false
-    t.string 'name'
-    t.text 'description'
-    t.uuid 'raid_id'
-    t.integer 'element'
-    t.integer 'weapons_count', default: 0
-    t.uuid 'job_id'
-    t.integer 'master_level'
-    t.uuid 'skill1_id'
-    t.uuid 'skill2_id'
-    t.uuid 'skill3_id'
-    t.uuid 'skill0_id'
-    t.boolean 'full_auto', default: false, null: false
-    t.boolean 'auto_guard', default: false, null: false
-    t.boolean 'charge_attack', default: true, null: false
-    t.integer 'clear_time', default: 0, null: false
-    t.integer 'button_count'
-    t.integer 'chain_count'
-    t.integer 'turn_count'
-    t.uuid 'source_party_id'
-    t.uuid 'accessory_id'
-    t.integer 'characters_count', default: 0
-    t.integer 'summons_count', default: 0
-    t.string 'edit_key'
-    t.uuid 'local_id'
-    t.integer 'ultimate_mastery'
-    t.uuid 'guidebook3_id'
-    t.uuid 'guidebook1_id'
-    t.uuid 'guidebook2_id'
-    t.boolean 'auto_summon', default: false, null: false
-    t.boolean 'remix', default: false, null: false
-    t.index ['accessory_id'], name: 'index_parties_on_accessory_id'
-    t.index ['guidebook1_id'], name: 'index_parties_on_guidebook1_id'
-    t.index ['guidebook2_id'], name: 'index_parties_on_guidebook2_id'
-    t.index ['guidebook3_id'], name: 'index_parties_on_guidebook3_id'
-    t.index ['job_id'], name: 'index_parties_on_job_id'
-    t.index ['skill0_id'], name: 'index_parties_on_skill0_id'
-    t.index ['skill1_id'], name: 'index_parties_on_skill1_id'
-    t.index ['skill2_id'], name: 'index_parties_on_skill2_id'
-    t.index ['skill3_id'], name: 'index_parties_on_skill3_id'
-    t.index ['source_party_id'], name: 'index_parties_on_source_party_id'
-    t.index ['user_id'], name: 'index_parties_on_user_id'
+  create_table "parties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id"
+    t.string "shortcode"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "extra", default: false, null: false
+    t.string "name"
+    t.text "description"
+    t.uuid "raid_id"
+    t.integer "element"
+    t.integer "weapons_count", default: 0
+    t.uuid "job_id"
+    t.integer "master_level"
+    t.uuid "skill1_id"
+    t.uuid "skill2_id"
+    t.uuid "skill3_id"
+    t.uuid "skill0_id"
+    t.boolean "full_auto", default: false, null: false
+    t.boolean "auto_guard", default: false, null: false
+    t.boolean "charge_attack", default: true, null: false
+    t.integer "clear_time", default: 0, null: false
+    t.integer "button_count"
+    t.integer "chain_count"
+    t.integer "turn_count"
+    t.uuid "source_party_id"
+    t.uuid "accessory_id"
+    t.integer "characters_count", default: 0
+    t.integer "summons_count", default: 0
+    t.string "edit_key"
+    t.uuid "local_id"
+    t.integer "ultimate_mastery"
+    t.uuid "guidebook3_id"
+    t.uuid "guidebook1_id"
+    t.uuid "guidebook2_id"
+    t.boolean "auto_summon", default: false, null: false
+    t.boolean "remix", default: false, null: false
+    t.integer "visibility", default: 1, null: false
+    t.index ["accessory_id"], name: "index_parties_on_accessory_id"
+    t.index ["guidebook1_id"], name: "index_parties_on_guidebook1_id"
+    t.index ["guidebook2_id"], name: "index_parties_on_guidebook2_id"
+    t.index ["guidebook3_id"], name: "index_parties_on_guidebook3_id"
+    t.index ["job_id"], name: "index_parties_on_job_id"
+    t.index ["skill0_id"], name: "index_parties_on_skill0_id"
+    t.index ["skill1_id"], name: "index_parties_on_skill1_id"
+    t.index ["skill2_id"], name: "index_parties_on_skill2_id"
+    t.index ["skill3_id"], name: "index_parties_on_skill3_id"
+    t.index ["source_party_id"], name: "index_parties_on_source_party_id"
+    t.index ["user_id"], name: "index_parties_on_user_id"
   end
 
-  create_table 'pg_search_documents', force: :cascade do |t|
-    t.text 'content'
-    t.string 'granblue_id'
-    t.string 'name_en'
-    t.string 'name_jp'
-    t.integer 'element'
-    t.string 'searchable_type'
-    t.uuid 'searchable_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index %w[searchable_type searchable_id], name: 'index_pg_search_documents_on_searchable'
+  create_table "pg_search_documents", force: :cascade do |t|
+    t.text "content"
+    t.string "granblue_id"
+    t.string "name_en"
+    t.string "name_jp"
+    t.integer "element"
+    t.string "searchable_type"
+    t.uuid "searchable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable"
   end
 
-  create_table 'raid_groups', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'name_en', null: false
-    t.string 'name_jp', null: false
-    t.integer 'difficulty'
-    t.integer 'order', null: false
-    t.integer 'section', default: 1, null: false
-    t.boolean 'extra', default: false, null: false
-    t.boolean 'hl', default: true, null: false
-    t.boolean 'guidebooks', default: false, null: false
+  create_table "raid_groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en", null: false
+    t.string "name_jp", null: false
+    t.integer "difficulty"
+    t.integer "order", null: false
+    t.integer "section", default: 1, null: false
+    t.boolean "extra", default: false, null: false
+    t.boolean "hl", default: true, null: false
+    t.boolean "guidebooks", default: false, null: false
   end
 
-  create_table 'raids', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'name_en'
-    t.string 'name_jp'
-    t.integer 'level'
-    t.integer 'element'
-    t.string 'slug'
-    t.uuid 'group_id'
-    t.index ['group_id'], name: 'index_raids_on_group_id'
+  create_table "raids", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_jp"
+    t.integer "level"
+    t.integer "element"
+    t.string "slug"
+    t.uuid "group_id"
+    t.index ["group_id"], name: "index_raids_on_group_id"
   end
 
-  create_table 'sparks', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'user_id', null: false
-    t.string 'guild_ids', null: false, array: true
-    t.integer 'crystals', default: 0
-    t.integer 'tickets', default: 0
-    t.integer 'ten_tickets', default: 0
-    t.string 'target_type'
-    t.bigint 'target_id'
-    t.datetime 'updated_at', default: -> { 'CURRENT_TIMESTAMP' }, null: false
-    t.string 'target_memo'
-    t.index %w[target_type target_id], name: 'index_sparks_on_target'
-    t.index ['user_id'], name: 'index_sparks_on_user_id', unique: true
+  create_table "sparks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "user_id", null: false
+    t.string "guild_ids", null: false, array: true
+    t.integer "crystals", default: 0
+    t.integer "tickets", default: 0
+    t.integer "ten_tickets", default: 0
+    t.string "target_type"
+    t.bigint "target_id"
+    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.string "target_memo"
+    t.index ["target_type", "target_id"], name: "index_sparks_on_target"
+    t.index ["user_id"], name: "index_sparks_on_user_id", unique: true
   end
 
-  create_table 'summons', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'name_en'
-    t.string 'name_jp'
-    t.string 'granblue_id'
-    t.integer 'rarity'
-    t.integer 'element'
-    t.string 'series'
-    t.boolean 'flb', default: false, null: false
-    t.boolean 'ulb', default: false, null: false
-    t.integer 'max_level', default: 100, null: false
-    t.integer 'min_hp'
-    t.integer 'max_hp'
-    t.integer 'max_hp_flb'
-    t.integer 'max_hp_ulb'
-    t.integer 'min_atk'
-    t.integer 'max_atk'
-    t.integer 'max_atk_flb'
-    t.integer 'max_atk_ulb'
-    t.boolean 'subaura', default: false, null: false
-    t.boolean 'limit', default: false, null: false
-    t.boolean 'xlb', default: false, null: false
-    t.integer 'max_atk_xlb'
-    t.integer 'max_hp_xlb'
-    t.string 'nicknames_en', default: [], null: false, array: true
-    t.string 'nicknames_jp', default: [], null: false, array: true
-    t.integer 'summon_id'
-    t.date 'release_date'
-    t.date 'flb_date'
-    t.date 'ulb_date'
-    t.string 'wiki_en', default: ''
-    t.string 'wiki_ja', default: ''
-    t.string 'gamewith', default: ''
-    t.string 'kamigame', default: ''
-    t.date 'xlb_date'
-    t.index ['name_en'], name: 'index_summons_on_name_en', opclass: :gin_trgm_ops, using: :gin
+  create_table "summons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_jp"
+    t.string "granblue_id"
+    t.integer "rarity"
+    t.integer "element"
+    t.string "series"
+    t.boolean "flb", default: false, null: false
+    t.boolean "ulb", default: false, null: false
+    t.integer "max_level", default: 100, null: false
+    t.integer "min_hp"
+    t.integer "max_hp"
+    t.integer "max_hp_flb"
+    t.integer "max_hp_ulb"
+    t.integer "min_atk"
+    t.integer "max_atk"
+    t.integer "max_atk_flb"
+    t.integer "max_atk_ulb"
+    t.boolean "subaura", default: false, null: false
+    t.boolean "limit", default: false, null: false
+    t.boolean "xlb", default: false, null: false
+    t.integer "max_atk_xlb"
+    t.integer "max_hp_xlb"
+    t.string "nicknames_en", default: [], null: false, array: true
+    t.string "nicknames_jp", default: [], null: false, array: true
+    t.integer "summon_id"
+    t.date "release_date"
+    t.date "flb_date"
+    t.date "ulb_date"
+    t.string "wiki_en", default: ""
+    t.string "wiki_ja", default: ""
+    t.string "gamewith", default: ""
+    t.string "kamigame", default: ""
+    t.date "xlb_date"
+    t.index ["name_en"], name: "index_summons_on_name_en", opclass: :gin_trgm_ops, using: :gin
   end
 
-  create_table 'users', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'email'
-    t.string 'password_digest'
-    t.string 'username'
-    t.integer 'granblue_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'picture', default: 'gran'
-    t.string 'language', default: 'en', null: false
-    t.boolean 'private', default: false, null: false
-    t.string 'element', default: 'water', null: false
-    t.integer 'gender', default: 0, null: false
-    t.string 'theme', default: 'system', null: false
+  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.string "username"
+    t.integer "granblue_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "picture", default: "gran"
+    t.string "language", default: "en", null: false
+    t.boolean "private", default: false, null: false
+    t.string "element", default: "water", null: false
+    t.integer "gender", default: 0, null: false
+    t.string "theme", default: "system", null: false
+    t.integer "role", default: 1, null: false
   end
 
-  create_table 'weapon_awakenings', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.uuid 'weapon_id', null: false
-    t.uuid 'awakening_id', null: false
-    t.index ['awakening_id'], name: 'index_weapon_awakenings_on_awakening_id'
-    t.index ['weapon_id'], name: 'index_weapon_awakenings_on_weapon_id'
+  create_table "weapon_awakenings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "weapon_id", null: false
+    t.uuid "awakening_id", null: false
+    t.index ["awakening_id"], name: "index_weapon_awakenings_on_awakening_id"
+    t.index ["weapon_id"], name: "index_weapon_awakenings_on_weapon_id"
   end
 
-  create_table 'weapon_keys', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'name_en'
-    t.string 'name_jp'
-    t.integer 'series'
-    t.integer 'slot'
-    t.integer 'group'
-    t.integer 'order'
-    t.string 'slug'
-    t.integer 'granblue_id'
+  create_table "weapon_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_jp"
+    t.integer "series"
+    t.integer "slot"
+    t.integer "group"
+    t.integer "order"
+    t.string "slug"
+    t.integer "granblue_id"
   end
 
-  create_table 'weapons', id: :uuid, default: -> { 'gen_random_uuid()' }, force: :cascade do |t|
-    t.string 'name_en'
-    t.string 'name_jp'
-    t.string 'granblue_id'
-    t.integer 'rarity'
-    t.integer 'element'
-    t.integer 'proficiency'
-    t.integer 'series', default: -1, null: false
-    t.boolean 'flb', default: false, null: false
-    t.boolean 'ulb', default: false, null: false
-    t.integer 'max_level', default: 100, null: false
-    t.integer 'max_skill_level', default: 10, null: false
-    t.integer 'min_hp'
-    t.integer 'max_hp'
-    t.integer 'max_hp_flb'
-    t.integer 'max_hp_ulb'
-    t.integer 'min_atk'
-    t.integer 'max_atk'
-    t.integer 'max_atk_flb'
-    t.integer 'max_atk_ulb'
-    t.boolean 'extra', default: false, null: false
-    t.integer 'ax_type'
-    t.boolean 'limit', default: false, null: false
-    t.boolean 'ax', default: false, null: false
-    t.string 'nicknames_en', default: [], null: false, array: true
-    t.string 'nicknames_jp', default: [], null: false, array: true
-    t.uuid 'recruits_id'
-    t.integer 'max_awakening_level'
-    t.date 'release_date'
-    t.date 'flb_date'
-    t.date 'ulb_date'
-    t.string 'wiki_en', default: ''
-    t.string 'wiki_ja', default: ''
-    t.string 'gamewith', default: ''
-    t.string 'kamigame', default: ''
-    t.index ['name_en'], name: 'index_weapons_on_name_en', opclass: :gin_trgm_ops, using: :gin
-    t.index ['recruits_id'], name: 'index_weapons_on_recruits_id'
+  create_table "weapons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en"
+    t.string "name_jp"
+    t.string "granblue_id"
+    t.integer "rarity"
+    t.integer "element"
+    t.integer "proficiency"
+    t.integer "series", default: -1, null: false
+    t.boolean "flb", default: false, null: false
+    t.boolean "ulb", default: false, null: false
+    t.integer "max_level", default: 100, null: false
+    t.integer "max_skill_level", default: 10, null: false
+    t.integer "min_hp"
+    t.integer "max_hp"
+    t.integer "max_hp_flb"
+    t.integer "max_hp_ulb"
+    t.integer "min_atk"
+    t.integer "max_atk"
+    t.integer "max_atk_flb"
+    t.integer "max_atk_ulb"
+    t.boolean "extra", default: false, null: false
+    t.integer "ax_type"
+    t.boolean "limit", default: false, null: false
+    t.boolean "ax", default: false, null: false
+    t.string "nicknames_en", default: [], null: false, array: true
+    t.string "nicknames_jp", default: [], null: false, array: true
+    t.uuid "recruits_id"
+    t.integer "max_awakening_level"
+    t.date "release_date"
+    t.date "flb_date"
+    t.date "ulb_date"
+    t.string "wiki_en", default: ""
+    t.string "wiki_ja", default: ""
+    t.string "gamewith", default: ""
+    t.string "kamigame", default: ""
+    t.index ["name_en"], name: "index_weapons_on_name_en", opclass: :gin_trgm_ops, using: :gin
+    t.index ["recruits_id"], name: "index_weapons_on_recruits_id"
   end
 
-  add_foreign_key 'favorites', 'parties'
-  add_foreign_key 'favorites', 'users'
-  add_foreign_key 'grid_characters', 'awakenings'
-  add_foreign_key 'grid_characters', 'characters'
-  add_foreign_key 'grid_characters', 'parties'
-  add_foreign_key 'grid_summons', 'parties'
-  add_foreign_key 'grid_summons', 'summons'
-  add_foreign_key 'grid_weapons', 'awakenings'
-  add_foreign_key 'grid_weapons', 'parties'
-  add_foreign_key 'grid_weapons', 'weapon_keys', column: 'weapon_key3_id'
-  add_foreign_key 'grid_weapons', 'weapons'
-  add_foreign_key 'jobs', 'jobs', column: 'base_job_id'
-  add_foreign_key 'oauth_access_grants', 'oauth_applications', column: 'application_id'
-  add_foreign_key 'oauth_access_tokens', 'oauth_applications', column: 'application_id'
-  add_foreign_key 'parties', 'guidebooks', column: 'guidebook1_id'
-  add_foreign_key 'parties', 'guidebooks', column: 'guidebook2_id'
-  add_foreign_key 'parties', 'guidebooks', column: 'guidebook3_id'
-  add_foreign_key 'parties', 'job_accessories', column: 'accessory_id'
-  add_foreign_key 'parties', 'job_skills', column: 'skill0_id'
-  add_foreign_key 'parties', 'job_skills', column: 'skill1_id'
-  add_foreign_key 'parties', 'job_skills', column: 'skill2_id'
-  add_foreign_key 'parties', 'job_skills', column: 'skill3_id'
-  add_foreign_key 'parties', 'jobs'
-  add_foreign_key 'parties', 'parties', column: 'source_party_id'
-  add_foreign_key 'parties', 'raids'
-  add_foreign_key 'parties', 'users'
-  add_foreign_key 'raids', 'raid_groups', column: 'group_id'
-  add_foreign_key 'weapon_awakenings', 'awakenings'
-  add_foreign_key 'weapon_awakenings', 'weapons'
+  add_foreign_key "favorites", "parties"
+  add_foreign_key "favorites", "users"
+  add_foreign_key "grid_characters", "awakenings"
+  add_foreign_key "grid_characters", "characters"
+  add_foreign_key "grid_characters", "parties"
+  add_foreign_key "grid_summons", "parties"
+  add_foreign_key "grid_summons", "summons"
+  add_foreign_key "grid_weapons", "awakenings"
+  add_foreign_key "grid_weapons", "parties"
+  add_foreign_key "grid_weapons", "weapon_keys", column: "weapon_key3_id"
+  add_foreign_key "grid_weapons", "weapons"
+  add_foreign_key "jobs", "jobs", column: "base_job_id"
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "parties", "guidebooks", column: "guidebook1_id"
+  add_foreign_key "parties", "guidebooks", column: "guidebook2_id"
+  add_foreign_key "parties", "guidebooks", column: "guidebook3_id"
+  add_foreign_key "parties", "job_accessories", column: "accessory_id"
+  add_foreign_key "parties", "job_skills", column: "skill0_id"
+  add_foreign_key "parties", "job_skills", column: "skill1_id"
+  add_foreign_key "parties", "job_skills", column: "skill2_id"
+  add_foreign_key "parties", "job_skills", column: "skill3_id"
+  add_foreign_key "parties", "jobs"
+  add_foreign_key "parties", "parties", column: "source_party_id"
+  add_foreign_key "parties", "raids"
+  add_foreign_key "parties", "users"
+  add_foreign_key "raids", "raid_groups", column: "group_id"
+  add_foreign_key "weapon_awakenings", "awakenings"
+  add_foreign_key "weapon_awakenings", "weapons"
 end


### PR DESCRIPTION
This PR implements the backend for team visibility. We also implemented roles, which is not on the frontend yet. 

Roles will let users be separated into groups which we can then do things with, like assign administrators and moderators. In this update, "Admin mode" is a toggle that allows admins (me) see all activity on the site regardless of visibility for moderation purposes. The frontend is not built yet so it can't be enabled.