### PR TITLE
(Hotfix) Fix summon transcendence

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -51,7 +51,7 @@ module Api
       end
 
       def admin_mode
-        if current_user && current_user.admin? && request.headers['X-Admin-Mode']
+        if current_user&.admin? && request.headers['X-Admin-Mode']
           @admin_mode ||= request.headers['X-Admin-Mode'] == 'true'
         end
 

--- a/app/controllers/api/v1/grid_summons_controller.rb
+++ b/app/controllers/api/v1/grid_summons_controller.rb
@@ -114,12 +114,11 @@ module Api
       private
 
       def max_uncap_level(summon)
-        object = summon.summon
-        if object.flb && !object.ulb && !object.xlb
+        if summon.flb && !summon.ulb && !summon.xlb
           4
-        elsif object.ulb && !object.xlb
+        elsif summon.ulb && !summon.xlb
           5
-        elsif object.xlb
+        elsif summon.xlb
           6
         else
           3


### PR DESCRIPTION
Manually setting summon transcendence was not working due to a change that passed in the canonical object instead of the grid object to `max_uncap_level`