### PR TITLE
Allow World Weapons in Extra slots

### DIFF
--- a/app/models/grid_weapon.rb
+++ b/app/models/grid_weapon.rb
@@ -60,7 +60,7 @@ class GridWeapon < ApplicationRecord
 
   # Validates whether the weapon can be added to the desired position
   def compatible_with_position
-    return unless [9, 10, 11].include?(position.to_i) && ![11, 16, 17, 28, 29].include?(weapon.series)
+    return unless [9, 10, 11].include?(position.to_i) && ![11, 16, 17, 28, 29, 32].include?(weapon.series)
 
     errors.add(:series, 'must be compatible with position')
   end


### PR DESCRIPTION
The series for World Weapons was not included in the validation method for `GridWeapon`.