### PR TITLE
Nullify edit key when party is remixed

### DIFF
--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -88,6 +88,7 @@ class Party < ApplicationRecord
 
     nullify :description
     nullify :shortcode
+    nullify :edit_key
 
     include_association :characters
     include_association :weapons


### PR DESCRIPTION
This stops logged in users from editing remixed parties