### PR TITLE
Allow PartiesController to accept nested attributes

### DIFF
--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -395,7 +395,20 @@ module Api
           :chain_count,
           :guidebook1_id,
           :guidebook2_id,
-          :guidebook3_id
+          :guidebook3_id,
+          characters_attributes: [:id, :party_id, :character_id, :position,
+                                  :uncap_level, :transcendence_step, :perpetuity,
+                                  :awakening_id, :awakening_level,
+                                  { ring1: %i[modifier strength], ring2: %i[modifier strength],
+                                    ring3: %i[modifier strength], ring4: %i[modifier strength],
+                                    earring: %i[modifier strength] }],
+          summons_attributes: %i[id party_id summon_id position main friend
+                                 quick_summon uncap_level transcendence_step],
+          weapons_attributes: %i[id party_id weapon_id
+                                 position mainhand uncap_level element
+                                 weapon_key1_id weapon_key2_id weapon_key3_id
+                                 ax_modifier1 ax_modifier2 ax_strength1 ax_strength2
+                                 awakening_id awakening_level]
         )
       end
     end

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -77,6 +77,10 @@ class Party < ApplicationRecord
 
   has_many :favorites, dependent: :destroy
 
+  accepts_nested_attributes_for :characters
+  accepts_nested_attributes_for :summons
+  accepts_nested_attributes_for :weapons
+
   before_create :set_shortcode
   before_create :set_edit_key
 


### PR DESCRIPTION
APIs can now send all data for a party at once using `character_attributes`, `weapon_attributes` and `summon_attributes` keys, which accept an array of objects.