### PR TITLE
Link Character and Weapon tables with granblue_id

### DIFF
--- a/db/data/20250115094623_populate_weapon_recruits.rb
+++ b/db/data/20250115094623_populate_weapon_recruits.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class PopulateWeaponRecruits < ActiveRecord::Migration[7.0]
+  def up
+    # Get all character mappings and convert to hash properly
+    results = execute(<<-SQL)
+      SELECT id, granblue_id 
+      FROM characters 
+      WHERE granblue_id IS NOT NULL
+    SQL
+
+    character_mapping = {}
+    results.each do |row|
+      character_mapping[row['id']] = row['granblue_id']
+    end
+
+    # Update weapons table using the mapping
+    character_mapping.each do |char_id, granblue_id|
+      execute(<<-SQL)
+        UPDATE weapons 
+        SET recruits = #{connection.quote(granblue_id)} 
+        WHERE recruits_id = #{connection.quote(char_id)}
+      SQL
+    end
+  end
+
+  def down
+    execute("UPDATE weapons SET recruits = NULL")
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20231119051223)
+DataMigrate::Data.define(version: 20250115094623)

--- a/db/migrate/20250115094528_add_recruits_to_weapons.rb
+++ b/db/migrate/20250115094528_add_recruits_to_weapons.rb
@@ -1,0 +1,5 @@
+class AddRecruitsToWeapons < ActiveRecord::Migration[7.0]
+  def change
+    add_column :weapons, :recruits, :string
+  end
+end

--- a/db/migrate/20250115100327_remove_recruits_id_from_weapons.rb
+++ b/db/migrate/20250115100327_remove_recruits_id_from_weapons.rb
@@ -1,0 +1,6 @@
+class RemoveRecruitsIdFromWeapons < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :weapons, :recruits_id, :uuid
+    remove_index :weapons, :recruits_id if index_exists?(:weapons, :recruits_id)
+  end
+end

--- a/db/migrate/20250115100356_add_index_to_weapon_recruits.rb
+++ b/db/migrate/20250115100356_add_index_to_weapon_recruits.rb
@@ -1,0 +1,5 @@
+class AddIndexToWeaponRecruits < ActiveRecord::Migration[7.0]
+  def change
+    add_index :weapons, :recruits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_15_094528) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_15_100356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -456,7 +456,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_15_094528) do
     t.integer "ax_type"
     t.boolean "limit", default: false, null: false
     t.boolean "ax", default: false, null: false
-    t.uuid "recruits_id"
     t.integer "max_awakening_level"
     t.date "release_date"
     t.date "flb_date"
@@ -471,7 +470,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_15_094528) do
     t.date "transcendence_date"
     t.string "recruits"
     t.index ["name_en"], name: "index_weapons_on_name_en", opclass: :gin_trgm_ops, using: :gin
-    t.index ["recruits_id"], name: "index_weapons_on_recruits_id"
+    t.index ["recruits"], name: "index_weapons_on_recruits"
   end
 
   add_foreign_key "favorites", "parties"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_10_070255) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_15_094528) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_trgm"
@@ -469,6 +469,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_10_070255) do
     t.string "nicknames_jp", default: [], null: false, array: true
     t.boolean "transcendence", default: false
     t.date "transcendence_date"
+    t.string "recruits"
     t.index ["name_en"], name: "index_weapons_on_name_en", opclass: :gin_trgm_ops, using: :gin
     t.index ["recruits_id"], name: "index_weapons_on_recruits_id"
   end


### PR DESCRIPTION
We ran into a race condition issue where when adding items, you couldn't link characters with their recruit weapon because the database uses the UUID, and that won't be created yet. 

We've changed this by creating a new field called `recruits` that has been populated using `granblue_id`. The `recruits_id` column has been removed.

There is probably a good case to use `granblue_id` for all associations, but that is a much bigger project.