### PR TITLE
Render the correct view when updating jobs

### DIFF
--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -131,6 +131,7 @@ module Api
         fields :edit_key
       end
 
+      # Remixed view
       view :remixed do
         include_view :created
         include_view :source_party

--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -34,10 +34,10 @@ module Api
 
           # Remove extra subskills if necessary
           if old_job &&
-             %w[1 2 3].include?(old_job.row) &&
-             %w[4 5 ex2].include?(job.row) &&
-             @party.skill1 && @party.skill2 && @party.skill3 &&
-             @party.skill1.sub && @party.skill2.sub && @party.skill3.sub
+            %w[1 2 3].include?(old_job.row) &&
+            %w[4 5 ex2].include?(job.row) &&
+            @party.skill1 && @party.skill2 && @party.skill3 &&
+            @party.skill1.sub && @party.skill2.sub && @party.skill3.sub
             @party['skill3_id'] = nil
           end
         else
@@ -47,7 +47,7 @@ module Api
           end
         end
 
-        render json: PartyBlueprint.render(@party, view: :jobs) if @party.save!
+        render json: PartyBlueprint.render(@party, view: :job_metadata) if @party.save!
       end
 
       def update_job_skills


### PR DESCRIPTION
We were referencing an old view in `PartiesController#update_job`. This has been corrected.