### PR TITLE
Parallelize downloaders and update sizes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,10 +76,13 @@ gem 'strscan'
 # New Relic Ruby Agent
 gem 'newrelic_rpm'
 
+# Parallel processing made simple and fast
+gem 'parallel'
+
 # The Sentry SDK for Rails
-gem "stackprof"
-gem "sentry-ruby"
-gem "sentry-rails"
+gem 'sentry-rails'
+gem 'sentry-ruby'
+gem 'stackprof'
 
 group :doc do
   gem 'apipie-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,6 +482,7 @@ DEPENDENCIES
   mini_magick
   newrelic_rpm
   oj
+  parallel
   pg
   pg_query
   pg_search

--- a/lib/granblue/downloaders/base_downloader.rb
+++ b/lib/granblue/downloaders/base_downloader.rb
@@ -35,12 +35,13 @@ module Granblue
       # @param verbose [Boolean] When true, enables detailed logging
       # @param storage [Symbol] Storage mode (:local, :s3, or :both)
       # @return [void]
-      def initialize(id, test_mode: false, verbose: false, storage: :both)
+      def initialize(id, test_mode: false, verbose: false, storage: :both, logger: nil)
         @id = id
         @base_url = base_url
         @test_mode = test_mode
         @verbose = verbose
         @storage = storage
+        @logger = logger || Logger.new($stdout) # fallback logger
         @aws_service = AwsService.new
         ensure_directories_exist unless @test_mode
       end
@@ -132,9 +133,9 @@ module Granblue
         download.rewind
 
         # Upload to S3 if it doesn't exist
-        unless @aws_service.file_exists?(s3_key)
-          @aws_service.upload_stream(download, s3_key)
-        end
+        return if @aws_service.file_exists?(s3_key)
+
+        @aws_service.upload_stream(download, s3_key)
       end
 
       # Check if file should be downloaded based on storage mode

--- a/lib/granblue/downloaders/base_downloader.rb
+++ b/lib/granblue/downloaders/base_downloader.rb
@@ -46,15 +46,19 @@ module Granblue
       end
 
       # Download images for all sizes
+      # @param selected_size [String] The size to download
       # @return [void]
-      def download
-        log_info "-> #{@id}"
+      def download(selected_size = nil)
+        log_info("-> #{@id}")
         return if @test_mode
 
-        SIZES.each_with_index do |size, index|
+        # If a specific size is provided, use only that; otherwise, use all available sizes.
+        sizes = selected_size ? [selected_size] : SIZES
+
+        sizes.each_with_index do |size, index|
           path = download_path(size)
           url = build_url(size)
-          process_download(url, size, path, last: index == SIZES.size - 1)
+          process_download(url, size, path, last: index == sizes.size - 1)
         end
       end
 
@@ -182,7 +186,7 @@ module Granblue
       # Log informational message if verbose
       # @param message [String] Message
       def log_info(message)
-        puts message if @verbose
+        @logger.info(message) if @verbose
       end
 
       # Download elemental variant image
@@ -197,12 +201,10 @@ module Granblue
         filepath = "#{path}/#{filename}"
         URI.open(url) do |file|
           content = file.read
-          if content
-            File.open(filepath, 'wb') do |output|
-              output.write(content)
-            end
-          else
-            raise "Failed to read content from #{url}"
+          raise "Failed to read content from #{url}" unless content
+
+          File.open(filepath, 'wb') do |output|
+            output.write(content)
           end
         end
         log_info "-> #{size}:\t#{url}..."

--- a/lib/granblue/downloaders/character_downloader.rb
+++ b/lib/granblue/downloaders/character_downloader.rb
@@ -77,7 +77,12 @@ module Granblue
       # @return [String] Complete URL for downloading the image
       def build_variant_url(variant_id, size)
         directory = directory_for_size(size)
-        "#{@base_url}/#{directory}/#{variant_id}.jpg"
+
+        if size == 'detail'
+          "#{@base_url}/#{directory}/#{variant_id}.png"
+        else
+          "#{@base_url}/#{directory}/#{variant_id}.jpg"
+        end
       end
 
       # Gets object type for file paths and storage keys
@@ -102,6 +107,7 @@ module Granblue
         when 'main' then 'f'
         when 'grid' then 'm'
         when 'square' then 's'
+        when 'detail' then 'detail'
         end
       end
     end

--- a/lib/granblue/downloaders/character_downloader.rb
+++ b/lib/granblue/downloaders/character_downloader.rb
@@ -15,24 +15,27 @@ module Granblue
       # Downloads images for all variants of a character based on their uncap status.
       # Overrides {BaseDownloader#download} to handle character-specific variants.
       #
+      # @param selected_size [String] The size to download. If nil, downloads all sizes.
       # @return [void]
       # @note Skips download if character is not found in database
       # @note Downloads FLB/ULB variants only if character has those uncaps
       # @see #download_variants
-      def download
+      def download(selected_size = nil)
         character = Character.find_by(granblue_id: @id)
         return unless character
 
-        download_variants(character)
+        download_variants(character, selected_size)
       end
 
       private
 
       # Downloads all variants of a character's images
+      #
       # @param character [Character] Character model instance to download images for
+      # @param selected_size [String] The size to download. If nil, downloads all sizes.
       # @return [void]
       # @note Only downloads variants that should exist based on character uncap status
-      def download_variants(character)
+      def download_variants(character, selected_size = nil)
         # All characters have 01 and 02 variants
         variants = %W[#{@id}_01 #{@id}_02]
 
@@ -45,18 +48,22 @@ module Granblue
         log_info "Downloading character variants: #{variants.join(', ')}" if @verbose
 
         variants.each do |variant_id|
-          download_variant(variant_id)
+          download_variant(variant_id, selected_size)
         end
       end
 
       # Downloads a specific variant's images in all sizes
+      #
       # @param variant_id [String] Character variant ID (e.g., "3040001000_01")
+      # @param selected_size [String] The size to download. If nil, downloads all sizes.
       # @return [void]
-      def download_variant(variant_id)
+      def download_variant(variant_id, selected_size = nil)
         log_info "-> #{variant_id}" if @verbose
         return if @test_mode
 
-        SIZES.each_with_index do |size, index|
+        sizes = selected_size ? [selected_size] : SIZES
+
+        sizes.each_with_index do |size, index|
           path = download_path(size)
           url = build_variant_url(variant_id, size)
           process_download(url, size, path, last: index == SIZES.size - 1)
@@ -64,8 +71,9 @@ module Granblue
       end
 
       # Builds URL for a specific variant and size
+      #
       # @param variant_id [String] Character variant ID
-      # @param size [String] Image size variant ("main", "grid", or "square")
+      # @param size [String] Image size variant ("main", "grid", "square", or "detail")
       # @return [String] Complete URL for downloading the image
       def build_variant_url(variant_id, size)
         directory = directory_for_size(size)
@@ -85,6 +93,7 @@ module Granblue
       end
 
       # Gets directory name for a size variant
+      #
       # @param size [String] Image size variant
       # @return [String] Directory name in game asset URL structure
       # @note Maps "main" -> "f", "grid" -> "m", "square" -> "s"

--- a/lib/granblue/downloaders/summon_downloader.rb
+++ b/lib/granblue/downloaders/summon_downloader.rb
@@ -79,7 +79,11 @@ module Granblue
       # @return [String] Complete URL for downloading the image
       def build_variant_url(variant_id, size)
         directory = directory_for_size(size)
-        "#{@base_url}/#{directory}/#{variant_id}.jpg"
+        if size == 'detail'
+          "#{@base_url}/#{directory}/#{variant_id}.png"
+        else
+          "#{@base_url}/#{directory}/#{variant_id}.jpg"
+        end
       end
 
       # Gets object type for file paths and storage keys
@@ -95,14 +99,16 @@ module Granblue
       end
 
       # Gets directory name for a size variant
+      #
       # @param size [String] Image size variant
       # @return [String] Directory name in game asset URL structure
       # @note Maps "main" -> "party_main", "grid" -> "party_sub", "square" -> "s"
       def directory_for_size(size)
         case size.to_s
-        when 'main' then 'party_main'
-        when 'grid' then 'party_sub'
+        when 'main' then 'ls'
+        when 'grid' then 'm'
         when 'square' then 's'
+        when 'detail' then 'detail'
         end
       end
     end

--- a/lib/granblue/downloaders/weapon_downloader.rb
+++ b/lib/granblue/downloaders/weapon_downloader.rb
@@ -42,9 +42,7 @@ module Granblue
         variants = [@id]
 
         # Add transcendence variants if available
-        if weapon.transcendence
-          variants.push("#{@id}_02", "#{@id}_03")
-        end
+        variants.push("#{@id}_02", "#{@id}_03") if weapon.transcendence
 
         log_info "Downloading weapon variants: #{variants.join(', ')}" if @verbose
 
@@ -79,7 +77,11 @@ module Granblue
       # @return [String] Complete URL for downloading the image
       def build_variant_url(variant_id, size)
         directory = directory_for_size(size)
-        "#{@base_url}/#{directory}/#{variant_id}.jpg"
+        if size == 'raw'
+          "#{@base_url}/#{directory}/#{variant_id}.png"
+        else
+          "#{@base_url}/#{directory}/#{variant_id}.jpg"
+        end
       end
 
       # Gets object type for file paths and storage keys
@@ -95,6 +97,7 @@ module Granblue
       end
 
       # Gets directory name for a size variant
+      #
       # @param size [String] Image size variant
       # @return [String] Directory name in game asset URL structure
       # @note Maps "main" -> "ls", "grid" -> "m", "square" -> "s"
@@ -103,6 +106,7 @@ module Granblue
         when 'main' then 'ls'
         when 'grid' then 'm'
         when 'square' then 's'
+        when 'raw' then 'b'
         end
       end
     end


### PR DESCRIPTION
This PR adds parallelization to our downloader utility classes. This allows us to download images from the game much faster by downloading many at once. The user can specify how many parallel processes to run.

We also added image sizes for all major objects. Weapon gets a raw image size, while Character and Summon get a detail image size. Summon also switches out its current tall and wide image sizes for a different one on Cygames servers that matches the weapon aspect ratios.