### PR TITLE
Add substitutions feature

### DIFF
--- a/app/blueprints/api/v1/grid_character_blueprint.rb
+++ b/app/blueprints/api/v1/grid_character_blueprint.rb
@@ -23,6 +23,11 @@ module Api
         association :character, blueprint: CharacterBlueprint, view: :full
         association :grid_artifact, blueprint: GridArtifactBlueprint, view: :nested,
                     if: ->(_field_name, gc, _options) { gc.grid_artifact.present? }
+        association :role, blueprint: RoleBlueprint,
+                    if: ->(_fn, gc, _opt) { gc.role.present? }
+        field :substitution_note, if: ->(_fn, gc, _opt) { gc.substitution_note.present? }
+        association :substitutions, blueprint: SubstitutionBlueprint,
+                    if: ->(_fn, gc, _opt) { !gc.is_substitute? && gc.substitutions.any? }
       end
 
       view :full do

--- a/app/blueprints/api/v1/grid_summon_blueprint.rb
+++ b/app/blueprints/api/v1/grid_summon_blueprint.rb
@@ -16,6 +16,11 @@ module Api
 
       view :nested do
         association :summon, blueprint: SummonBlueprint, view: :full
+        association :role, blueprint: RoleBlueprint,
+                    if: ->(_fn, gs, _opt) { gs.role.present? }
+        field :substitution_note, if: ->(_fn, gs, _opt) { gs.substitution_note.present? }
+        association :substitutions, blueprint: SubstitutionBlueprint,
+                    if: ->(_fn, gs, _opt) { !gs.is_substitute? && gs.substitutions.any? }
       end
 
       view :full do

--- a/app/blueprints/api/v1/grid_weapon_blueprint.rb
+++ b/app/blueprints/api/v1/grid_weapon_blueprint.rb
@@ -57,6 +57,11 @@ module Api
                         w.weapon.weapon_series.present? &&
                         w.weapon.weapon_series.has_weapon_keys
                     }
+        association :role, blueprint: RoleBlueprint,
+                    if: ->(_fn, gw, _opt) { gw.role.present? }
+        field :substitution_note, if: ->(_fn, gw, _opt) { gw.substitution_note.present? }
+        association :substitutions, blueprint: SubstitutionBlueprint,
+                    if: ->(_fn, gw, _opt) { !gw.is_substitute? && gw.substitutions.any? }
       end
 
       view :full do

--- a/app/blueprints/api/v1/role_blueprint.rb
+++ b/app/blueprints/api/v1/role_blueprint.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class RoleBlueprint < ApiBlueprint
+      fields :name_en, :name_jp, :slot_type, :sort_order
+    end
+  end
+end

--- a/app/blueprints/api/v1/substitution_blueprint.rb
+++ b/app/blueprints/api/v1/substitution_blueprint.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SubstitutionBlueprint < ApiBlueprint
+      field :position
+
+      field :grid_character, if: ->(_fn, sub, _opt) { sub.grid_type == 'GridCharacter' } do |sub|
+        GridCharacterBlueprint.render_as_hash(sub.substitute_grid, view: :nested)
+      end
+
+      field :grid_weapon, if: ->(_fn, sub, _opt) { sub.grid_type == 'GridWeapon' } do |sub|
+        GridWeaponBlueprint.render_as_hash(sub.substitute_grid, view: :nested)
+      end
+
+      field :grid_summon, if: ->(_fn, sub, _opt) { sub.grid_type == 'GridSummon' } do |sub|
+        GridSummonBlueprint.render_as_hash(sub.substitute_grid, view: :nested)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/grid_characters_controller.rb
+++ b/app/controllers/api/v1/grid_characters_controller.rb
@@ -590,6 +590,8 @@ module Api
           :uncap_level,
           :transcendence_step,
           :perpetuity,
+          :role_id,
+          :substitution_note,
           awakening: %i[id level],
           rings: %i[modifier strength],
           earring: %i[modifier strength]

--- a/app/controllers/api/v1/grid_summons_controller.rb
+++ b/app/controllers/api/v1/grid_summons_controller.rb
@@ -535,7 +535,8 @@ module Api
       def summon_params
         params.require(:summon).permit(:id, :party_id, :summon_id, :collection_summon_id,
                                        :position, :main, :friend, :quick_summon,
-                                       :uncap_level, :transcendence_step)
+                                       :uncap_level, :transcendence_step,
+                                       :role_id, :substitution_note)
       end
 
       ##

--- a/app/controllers/api/v1/grid_weapons_controller.rb
+++ b/app/controllers/api/v1/grid_weapons_controller.rb
@@ -572,7 +572,8 @@ module Api
           :weapon_key1_id, :weapon_key2_id, :weapon_key3_id,
           :ax_modifier1_id, :ax_modifier2_id, :ax_strength1, :ax_strength2,
           :befoulment_modifier_id, :befoulment_strength, :exorcism_level,
-          :awakening_id, :awakening_level
+          :awakening_id, :awakening_level,
+          :role_id, :substitution_note
         )
       end
 

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -112,6 +112,7 @@ module Api
       # Creates a remixed copy of an existing party.
       def remix
         new_party = @party.amoeba_dup
+        new_party._source_party_for_remap = @party
         new_party.attributes = { user: current_user, name: remixed_name(@party.name), source_party: @party,
                                  remix: true }
         new_party.local_id = party_params[:local_id] if party_params

--- a/app/controllers/api/v1/roles_controller.rb
+++ b/app/controllers/api/v1/roles_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class RolesController < Api::V1::ApiController
+      def index
+        roles = Role.all
+        roles = roles.for_slot(params[:slot_type]) if params[:slot_type].present?
+        render json: RoleBlueprint.render(roles)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/substitutions_controller.rb
+++ b/app/controllers/api/v1/substitutions_controller.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SubstitutionsController < Api::V1::ApiController
+      before_action :find_substitution, only: %i[update destroy]
+      before_action :find_primary_grid_item, only: :create
+      before_action :find_party
+      before_action :authorize_party_edit!
+
+      def create
+        grid_type = substitution_params[:grid_type]
+        item_id = substitution_params[:item_id]
+        position = substitution_params[:position]
+
+        # Find the canonical item
+        item_class = item_class_for(grid_type)
+        item = item_class&.find_by(id: item_id)
+        return render_not_found_response(item_class&.name&.underscore || 'item') unless item
+
+        # Create the substitute grid item
+        grid_class = grid_type.constantize
+        substitute = grid_class.create!(
+          party: @party,
+          item_fk_for(grid_type) => item_id,
+          is_substitute: true,
+          position: 0,
+          uncap_level: 0
+        )
+
+        # Create the substitution join record
+        substitution = Substitution.create!(
+          grid_type: grid_type,
+          grid_id: @primary_grid_item.id,
+          substitute_grid_type: grid_type,
+          substitute_grid_id: substitute.id,
+          position: position.to_i
+        )
+
+        render json: SubstitutionBlueprint.render(substitution, root: :substitution),
+               status: :created
+      end
+
+      def update
+        @substitution.update!(position: substitution_params[:position])
+        render json: SubstitutionBlueprint.render(@substitution, root: :substitution)
+      end
+
+      def destroy
+        substitute_grid_item = @substitution.substitute_grid
+        @substitution.destroy!
+        substitute_grid_item&.destroy!
+        head :no_content
+      end
+
+      private
+
+      def find_substitution
+        @substitution = Substitution.find_by(id: params[:id])
+        render_not_found_response('substitution') unless @substitution
+      end
+
+      def find_primary_grid_item
+        grid_type = substitution_params[:grid_type]
+        grid_id = substitution_params[:grid_id]
+
+        return render_not_found_response('grid_item') unless Substitution::GRID_TYPES.include?(grid_type)
+
+        @primary_grid_item = grid_type.constantize.find_by(id: grid_id)
+        render_not_found_response('grid_item') unless @primary_grid_item
+      end
+
+      def find_party
+        @party = if @primary_grid_item
+                   @primary_grid_item.party
+                 elsif @substitution
+                   @substitution.grid&.party
+                 end
+        render_not_found_response('party') unless @party
+      end
+
+      def authorize_party_edit!
+        if @party.user.present?
+          return if current_user.present? && @party.user == current_user
+
+          render_unauthorized_response
+        else
+          provided_edit_key = edit_key.to_s.strip.force_encoding('UTF-8')
+          party_edit_key = @party.edit_key.to_s.strip.force_encoding('UTF-8')
+          return if provided_edit_key.present? &&
+                    provided_edit_key.bytesize == party_edit_key.bytesize &&
+                    ActiveSupport::SecurityUtils.secure_compare(provided_edit_key, party_edit_key)
+
+          render_unauthorized_response
+        end
+      end
+
+      def substitution_params
+        params.require(:substitution).permit(:grid_type, :grid_id, :item_id, :position)
+      end
+
+      def item_class_for(grid_type)
+        case grid_type
+        when 'GridCharacter' then Character
+        when 'GridWeapon' then Weapon
+        when 'GridSummon' then Summon
+        end
+      end
+
+      def item_fk_for(grid_type)
+        case grid_type
+        when 'GridCharacter' then :character_id
+        when 'GridWeapon' then :weapon_id
+        when 'GridSummon' then :summon_id
+        end
+      end
+    end
+  end
+end

--- a/app/models/grid_character.rb
+++ b/app/models/grid_character.rb
@@ -20,12 +20,12 @@ class GridCharacter < ApplicationRecord
   # Associations
   belongs_to :character, foreign_key: :character_id, primary_key: :id
   belongs_to :awakening, optional: true
-  belongs_to :party,
-             counter_cache: :characters_count,
-             inverse_of: :characters
+  belongs_to :party, inverse_of: :characters
   belongs_to :collection_character, optional: true
+  belongs_to :role, optional: true
 
   has_one :grid_artifact, dependent: :destroy
+  has_many :substitutions, as: :grid, dependent: :destroy
 
   # Validations
   validates_presence_of :party
@@ -43,6 +43,8 @@ class GridCharacter < ApplicationRecord
   attr_accessor :new_rings
   attr_accessor :new_awakening
 
+  validate :role_slot_type_matches
+
   ##### Amoeba configuration
   amoeba do
     enable
@@ -53,12 +55,21 @@ class GridCharacter < ApplicationRecord
     set ring4: { modifier: nil, strength: nil }
     set earring: { modifier: nil, strength: nil }
     set perpetuity: false
+    nullify :role_id
+    nullify :substitution_note
   end
 
   # Hooks
   before_validation :apply_new_rings, if: -> { new_rings.present? }
   before_validation :apply_new_awakening, if: -> { new_awakening.present? }
   before_save :add_awakening
+
+  after_create :increment_party_counter, unless: :is_substitute?
+  after_destroy :decrement_party_counter, unless: :is_substitute?
+
+  def substitute?
+    is_substitute?
+  end
 
   ##
   # Validates the awakening level to ensure it falls within the allowed range.
@@ -438,5 +449,20 @@ class GridCharacter < ApplicationRecord
   # @return [Array<Integer>] list of allowed HP values.
   def hp_values
     [150, 300, 450, 600, 750, 900, 1050, 1200, 1350, 1500]
+  end
+
+  def role_slot_type_matches
+    return unless role.present?
+    return if role.slot_type == 'Character'
+
+    errors.add(:role, 'must be a Character role')
+  end
+
+  def increment_party_counter
+    Party.increment_counter(:characters_count, party_id)
+  end
+
+  def decrement_party_counter
+    Party.decrement_counter(:characters_count, party_id)
   end
 end

--- a/app/models/grid_summon.rb
+++ b/app/models/grid_summon.rb
@@ -13,10 +13,12 @@
 class GridSummon < ApplicationRecord
   belongs_to :summon, foreign_key: :summon_id, primary_key: :id
 
-  belongs_to :party,
-             counter_cache: :summons_count,
-             inverse_of: :summons
+  belongs_to :party, inverse_of: :summons
   belongs_to :collection_summon, optional: true
+  belongs_to :role, optional: true
+
+  has_many :substitutions, as: :grid, dependent: :destroy
+
   validates_presence_of :party
 
   # Orphan status scopes
@@ -25,7 +27,7 @@ class GridSummon < ApplicationRecord
 
   # Validate that position is provided.
   validates :position, presence: true
-  validate :compatible_with_position, on: :create
+  validate :compatible_with_position, on: :create, unless: :is_substitute?
 
   # Validate that uncap_level is present and numeric, transcendence_step is optional but must be numeric if present.
   validates :uncap_level, presence: true, numericality: { only_integer: true }
@@ -34,11 +36,21 @@ class GridSummon < ApplicationRecord
   # Custom validation to enforce maximum uncap_level based on the associated Summon’s flags.
   validate :validate_uncap_level_based_on_summon_flags
 
-  validate :no_conflicts, on: :create
+  validate :no_conflicts, on: :create, unless: :is_substitute?
+  validate :role_slot_type_matches
 
   before_validation :set_default_uncap_level, on: :create
 
   after_commit :recompute_party_boost!, on: %i[create update destroy]
+
+  after_create :increment_party_counter, unless: :is_substitute?
+  after_destroy :decrement_party_counter, unless: :is_substitute?
+
+  ##### Amoeba configuration
+  amoeba do
+    nullify :role_id
+    nullify :substitution_note
+  end
 
   ##
   # Returns the blueprint for rendering the grid summon.
@@ -106,6 +118,7 @@ class GridSummon < ApplicationRecord
   end
 
   def recompute_party_boost!
+    return if is_substitute?
     return unless main? || friend?
 
     party.reload
@@ -182,6 +195,25 @@ class GridSummon < ApplicationRecord
   # Friend summons are exempt from this check.
   #
   # @return [void]
+  def substitute?
+    is_substitute?
+  end
+
+  def role_slot_type_matches
+    return unless role.present?
+    return if role.slot_type == 'Summon'
+
+    errors.add(:role, 'must be a Summon role')
+  end
+
+  def increment_party_counter
+    Party.increment_counter(:summons_count, party_id)
+  end
+
+  def decrement_party_counter
+    Party.decrement_counter(:summons_count, party_id)
+  end
+
   def compatible_with_position
     return unless summon && !friend && position.to_i.in?(4..5) && !summon.subaura
 

--- a/app/models/grid_weapon.rb
+++ b/app/models/grid_weapon.rb
@@ -26,9 +26,11 @@ class GridWeapon < ApplicationRecord
 
   belongs_to :weapon, foreign_key: :weapon_id, primary_key: :id
 
-  belongs_to :party,
-             counter_cache: :weapons_count,
-             inverse_of: :weapons
+  belongs_to :party, inverse_of: :weapons
+  belongs_to :role, optional: true
+
+  has_many :substitutions, as: :grid, dependent: :destroy
+
   validates_presence_of :party
 
   belongs_to :weapon_key1, class_name: 'WeaponKey', foreign_key: :weapon_key1_id, optional: true
@@ -51,13 +53,17 @@ class GridWeapon < ApplicationRecord
   validates :uncap_level, presence: true, numericality: { only_integer: true }
   validates :transcendence_step, numericality: { only_integer: true }, allow_nil: true
 
-  validate :compatible_with_position, on: :create
-  validate :compatible_with_job_proficiency, on: :create
-  validate :no_conflicts, on: :create
+  validate :compatible_with_position, on: :create, unless: :is_substitute?
+  validate :compatible_with_job_proficiency, on: :create, unless: :is_substitute?
+  validate :no_conflicts, on: :create, unless: :is_substitute?
+  validate :role_slot_type_matches
 
   before_save :assign_mainhand
   before_validation :set_default_uncap_level, on: :create
   before_validation :set_default_exorcism_level, on: :create
+
+  after_create :increment_party_counter, unless: :is_substitute?
+  after_destroy :decrement_party_counter, unless: :is_substitute?
 
   ##### Amoeba configuration
   amoeba do
@@ -68,6 +74,8 @@ class GridWeapon < ApplicationRecord
     nullify :befoulment_modifier_id
     nullify :befoulment_strength
     nullify :exorcism_level
+    nullify :role_id
+    nullify :substitution_note
   end
 
   ##
@@ -254,6 +262,25 @@ class GridWeapon < ApplicationRecord
   # @return [void]
   def set_default_uncap_level
     self.uncap_level ||= 0
+  end
+
+  def substitute?
+    is_substitute?
+  end
+
+  def role_slot_type_matches
+    return unless role.present?
+    return if role.slot_type == 'Weapon'
+
+    errors.add(:role, 'must be a Weapon role')
+  end
+
+  def increment_party_counter
+    Party.increment_counter(:weapons_count, party_id)
+  end
+
+  def decrement_party_counter
+    Party.decrement_counter(:weapons_count, party_id)
   end
 
   def set_default_exorcism_level

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -145,31 +145,43 @@ class Party < ApplicationRecord
              class_name: 'Guidebook',
              optional: true
 
-  has_many :characters,
+  has_many :characters, -> { where(is_substitute: false) },
            foreign_key: 'party_id',
            class_name: 'GridCharacter',
-           dependent: :delete_all,
            inverse_of: :party
 
-  has_many :weapons,
+  has_many :weapons, -> { where(is_substitute: false) },
            foreign_key: 'party_id',
            class_name: 'GridWeapon',
-           dependent: :delete_all,
            inverse_of: :party
 
-  has_many :summons,
+  has_many :summons, -> { where(is_substitute: false) },
            foreign_key: 'party_id',
            class_name: 'GridSummon',
-           dependent: :delete_all,
            inverse_of: :party
+
+  has_many :all_characters,
+           foreign_key: 'party_id',
+           class_name: 'GridCharacter',
+           dependent: :delete_all
+
+  has_many :all_weapons,
+           foreign_key: 'party_id',
+           class_name: 'GridWeapon',
+           dependent: :delete_all
+
+  has_many :all_summons,
+           foreign_key: 'party_id',
+           class_name: 'GridSummon',
+           dependent: :delete_all
 
   has_many :favorites, dependent: :destroy
   has_many :party_shares, dependent: :destroy
   has_many :shared_crews, through: :party_shares, source: :shareable, source_type: 'Crew'
 
-  accepts_nested_attributes_for :characters
-  accepts_nested_attributes_for :summons
-  accepts_nested_attributes_for :weapons
+  accepts_nested_attributes_for :all_characters
+  accepts_nested_attributes_for :all_summons
+  accepts_nested_attributes_for :all_weapons
 
   before_create :set_shortcode
   before_create :set_edit_key
@@ -187,10 +199,12 @@ class Party < ApplicationRecord
     nullify :shortcode
     nullify :edit_key
 
-    include_association :characters
-    include_association :weapons
-    include_association :summons
+    include_association :all_characters
+    include_association :all_weapons
+    include_association :all_summons
   end
+
+  after_create :create_remapped_substitutions, if: -> { @_source_party_for_remap.present? }
 
   # ActiveRecord Validations
   validate :skills_are_unique
@@ -235,6 +249,8 @@ class Party < ApplicationRecord
   # Checks if the party is a remix of another party.
   #
   # @return [Boolean] true if the party is a remix; false otherwise.
+  attr_writer :_source_party_for_remap
+
   def remix?
     !source_party.nil?
   end
@@ -512,6 +528,55 @@ class Party < ApplicationRecord
       name job_id element weapons_count characters_count summons_count
       full_auto auto_guard charge_attack clear_time
     ]
+  end
+
+  #########################
+  # Substitution Remapping
+  #########################
+
+  def create_remapped_substitutions
+    source = @_source_party_for_remap
+    return unless source
+
+    subs = Substitution.where(grid_type: 'GridCharacter', grid_id: source.all_characters.select(:id))
+                       .or(Substitution.where(grid_type: 'GridWeapon', grid_id: source.all_weapons.select(:id)))
+                       .or(Substitution.where(grid_type: 'GridSummon', grid_id: source.all_summons.select(:id)))
+                       .to_a
+    return if subs.empty?
+
+    remap_for_type(subs, 'GridCharacter', all_characters.reload, source.all_characters, :character_id)
+    remap_for_type(subs, 'GridWeapon', all_weapons.reload, source.all_weapons, :weapon_id)
+    remap_for_type(subs, 'GridSummon', all_summons.reload, source.all_summons, :summon_id)
+  end
+
+  def remap_for_type(subs, grid_type, new_items, old_items, item_fk)
+    type_subs = subs.select { |s| s.grid_type == grid_type }
+    return if type_subs.empty?
+
+    # Map old grid item ID → new grid item by matching item FK + position + is_substitute
+    id_map = {}
+    old_items.each do |old_item|
+      new_item = new_items.detect do |ni|
+        ni.send(item_fk) == old_item.send(item_fk) &&
+          ni.position == old_item.position &&
+          ni.is_substitute? == old_item.is_substitute?
+      end
+      id_map[old_item.id] = new_item.id if new_item
+    end
+
+    type_subs.each do |sub|
+      new_grid_id = id_map[sub.grid_id]
+      new_sub_grid_id = id_map[sub.substitute_grid_id]
+      next unless new_grid_id && new_sub_grid_id
+
+      Substitution.create!(
+        grid_type: grid_type,
+        grid_id: new_grid_id,
+        substitute_grid_type: sub.substitute_grid_type,
+        substitute_grid_id: new_sub_grid_id,
+        position: sub.position
+      )
+    end
   end
 
   #########################

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Role < ApplicationRecord
+  SLOT_TYPES = %w[Character Weapon Summon].freeze
+
+  validates :name_en, presence: true
+  validates :slot_type, presence: true, inclusion: { in: SLOT_TYPES }
+
+  scope :for_slot, ->(type) { where(slot_type: type) }
+end

--- a/app/models/substitution.rb
+++ b/app/models/substitution.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Substitution < ApplicationRecord
+  GRID_TYPES = %w[GridCharacter GridWeapon GridSummon].freeze
+  MAX_PER_GRID_ITEM = 10
+
+  belongs_to :grid, polymorphic: true
+  belongs_to :substitute_grid, polymorphic: true
+
+  validates :position, presence: true,
+                       numericality: { only_integer: true,
+                                       greater_than_or_equal_to: 0,
+                                       less_than: MAX_PER_GRID_ITEM }
+  validates :grid_type, inclusion: { in: GRID_TYPES }
+
+  validate :types_must_match
+  validate :substitution_limit
+
+  private
+
+  def types_must_match
+    return if grid_type == substitute_grid_type
+
+    errors.add(:substitute_grid_type, 'must match grid_type')
+  end
+
+  def substitution_limit
+    return unless grid_id.present? && grid_type.present?
+
+    count = Substitution.where(grid_type: grid_type, grid_id: grid_id).count
+    count -= 1 if persisted? # don't count self on update
+    return unless count >= MAX_PER_GRID_ITEM
+
+    errors.add(:base, "cannot have more than #{MAX_PER_GRID_ITEM} substitutions per grid item")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,12 @@ Rails.application.routes.draw do
 
     get 'weapon_keys', to: 'weapon_keys#all'
 
+    # Roles (read-only)
+    get 'roles', to: 'roles#index'
+
+    # Substitutions
+    resources :substitutions, only: %i[create update destroy]
+
     resources :weapon_series, only: %i[index show create update destroy]
     resources :character_series, only: %i[index show create update destroy]
     resources :summon_series, only: %i[index show create update destroy]

--- a/db/migrate/20260315010000_create_roles.rb
+++ b/db/migrate/20260315010000_create_roles.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateRoles < ActiveRecord::Migration[8.0]
+  def change
+    create_table :roles, id: :uuid, default: -> { 'gen_random_uuid()' } do |t|
+      t.string :name_en, null: false
+      t.string :name_jp
+      t.string :slot_type, null: false
+      t.integer :sort_order, default: 0
+
+      t.timestamps
+    end
+
+    add_index :roles, :slot_type
+  end
+end

--- a/db/migrate/20260315010001_create_substitutions.rb
+++ b/db/migrate/20260315010001_create_substitutions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateSubstitutions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :substitutions, id: :uuid, default: -> { 'gen_random_uuid()' } do |t|
+      t.string :grid_type, null: false
+      t.uuid :grid_id, null: false
+      t.string :substitute_grid_type, null: false
+      t.uuid :substitute_grid_id, null: false
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+
+    add_index :substitutions, [:grid_type, :grid_id]
+    add_index :substitutions, [:grid_type, :grid_id, :position], unique: true
+  end
+end

--- a/db/migrate/20260315010002_add_substitution_fields_to_grid_items.rb
+++ b/db/migrate/20260315010002_add_substitution_fields_to_grid_items.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddSubstitutionFieldsToGridItems < ActiveRecord::Migration[8.0]
+  def change
+    %i[grid_characters grid_weapons grid_summons].each do |table|
+      change_table table do |t|
+        t.boolean :is_substitute, default: false, null: false
+        t.references :role, type: :uuid, foreign_key: true, null: true
+        t.text :substitution_note
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_14_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_15_010002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -140,9 +140,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_14_120000) do
     t.integer "series", default: [], null: false, array: true
     t.boolean "style_swap", default: false, null: false
     t.string "style_name_en"
-    t.uuid "base_character_id"
     t.string "style_name_jp"
-    t.index ["base_character_id"], name: "index_characters_on_base_character_id"
     t.index ["granblue_id"], name: "index_characters_on_granblue_id"
     t.index ["name_en"], name: "index_characters_on_name_en", opclass: :gin_trgm_ops, using: :gin
     t.index ["season"], name: "index_characters_on_season"
@@ -423,11 +421,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_14_120000) do
     t.uuid "awakening_id"
     t.integer "awakening_level", default: 1
     t.uuid "collection_character_id"
+    t.boolean "is_substitute", default: false, null: false
+    t.uuid "role_id"
+    t.text "substitution_note"
     t.index ["awakening_id"], name: "index_grid_characters_on_awakening_id"
     t.index ["character_id"], name: "index_grid_characters_on_character_id"
     t.index ["collection_character_id"], name: "index_grid_characters_on_collection_character_id"
     t.index ["party_id", "position"], name: "index_grid_characters_on_party_id_and_position"
     t.index ["party_id"], name: "index_grid_characters_on_party_id"
+    t.index ["role_id"], name: "index_grid_characters_on_role_id"
   end
 
   create_table "grid_summons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -443,10 +445,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_14_120000) do
     t.boolean "quick_summon", default: false
     t.uuid "collection_summon_id"
     t.boolean "orphaned", default: false, null: false
+    t.boolean "is_substitute", default: false, null: false
+    t.uuid "role_id"
+    t.text "substitution_note"
     t.index ["collection_summon_id"], name: "index_grid_summons_on_collection_summon_id"
     t.index ["orphaned"], name: "index_grid_summons_on_orphaned"
     t.index ["party_id", "position"], name: "index_grid_summons_on_party_id_and_position"
     t.index ["party_id"], name: "index_grid_summons_on_party_id"
+    t.index ["role_id"], name: "index_grid_summons_on_role_id"
     t.index ["summon_id"], name: "index_grid_summons_on_summon_id"
   end
 
@@ -475,6 +481,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_14_120000) do
     t.bigint "befoulment_modifier_id"
     t.float "befoulment_strength"
     t.integer "exorcism_level", default: 0
+    t.boolean "is_substitute", default: false, null: false
+    t.uuid "role_id"
+    t.text "substitution_note"
     t.index ["awakening_id"], name: "index_grid_weapons_on_awakening_id"
     t.index ["ax_modifier1_id"], name: "index_grid_weapons_on_ax_modifier1_id"
     t.index ["ax_modifier2_id"], name: "index_grid_weapons_on_ax_modifier2_id"
@@ -483,6 +492,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_14_120000) do
     t.index ["orphaned"], name: "index_grid_weapons_on_orphaned"
     t.index ["party_id", "position"], name: "index_grid_weapons_on_party_id_and_position"
     t.index ["party_id"], name: "index_grid_weapons_on_party_id"
+    t.index ["role_id"], name: "index_grid_weapons_on_role_id"
     t.index ["weapon_id"], name: "index_grid_weapons_on_weapon_id"
     t.index ["weapon_key1_id"], name: "index_grid_weapons_on_weapon_key1_id"
     t.index ["weapon_key2_id"], name: "index_grid_weapons_on_weapon_key2_id"
@@ -779,6 +789,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_14_120000) do
     t.integer "player_count", default: 18, null: false
   end
 
+  create_table "roles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en", null: false
+    t.string "name_jp"
+    t.string "slot_type", null: false
+    t.integer "sort_order", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slot_type"], name: "index_roles_on_slot_type"
+  end
+
   create_table "skill_effects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "skill_id", null: false
     t.uuid "effect_id", null: false
@@ -834,6 +854,18 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_14_120000) do
     t.string "target_memo"
     t.index ["target_type", "target_id"], name: "index_sparks_on_target"
     t.index ["user_id"], name: "index_sparks_on_user_id", unique: true
+  end
+
+  create_table "substitutions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "grid_type", null: false
+    t.uuid "grid_id", null: false
+    t.string "substitute_grid_type", null: false
+    t.uuid "substitute_grid_id", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_type", "grid_id", "position"], name: "index_substitutions_on_grid_type_and_grid_id_and_position", unique: true
+    t.index ["grid_type", "grid_id"], name: "index_substitutions_on_grid_type_and_grid_id"
   end
 
   create_table "summon_auras", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1114,7 +1146,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_14_120000) do
   add_foreign_key "character_series_memberships", "characters"
   add_foreign_key "character_skills", "skills"
   add_foreign_key "character_skills", "skills", column: "alt_skill_id"
-  add_foreign_key "characters", "characters", column: "base_character_id"
   add_foreign_key "charge_attacks", "skills"
   add_foreign_key "charge_attacks", "skills", column: "alt_skill_id"
   add_foreign_key "collection_artifacts", "artifacts"
@@ -1154,12 +1185,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_14_120000) do
   add_foreign_key "grid_characters", "characters"
   add_foreign_key "grid_characters", "collection_characters"
   add_foreign_key "grid_characters", "parties"
+  add_foreign_key "grid_characters", "roles"
   add_foreign_key "grid_summons", "collection_summons"
   add_foreign_key "grid_summons", "parties"
+  add_foreign_key "grid_summons", "roles"
   add_foreign_key "grid_summons", "summons"
   add_foreign_key "grid_weapons", "awakenings"
   add_foreign_key "grid_weapons", "collection_weapons"
   add_foreign_key "grid_weapons", "parties"
+  add_foreign_key "grid_weapons", "roles"
   add_foreign_key "grid_weapons", "weapon_keys", column: "weapon_key3_id"
   add_foreign_key "grid_weapons", "weapon_stat_modifiers", column: "ax_modifier1_id"
   add_foreign_key "grid_weapons", "weapon_stat_modifiers", column: "ax_modifier2_id"

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :role do
+    name_en { 'Buffer' }
+    slot_type { 'Character' }
+    sort_order { 0 }
+
+    trait :weapon do
+      name_en { 'Main damage' }
+      slot_type { 'Weapon' }
+    end
+
+    trait :summon do
+      name_en { 'Stat stick' }
+      slot_type { 'Summon' }
+    end
+  end
+end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Role, type: :model do
+  describe 'validations' do
+    it 'is valid with name_en and slot_type' do
+      role = Role.new(name_en: 'Buffer', slot_type: 'Character')
+      expect(role).to be_valid
+    end
+
+    it 'is invalid without name_en' do
+      role = Role.new(slot_type: 'Character')
+      expect(role).not_to be_valid
+    end
+
+    it 'is invalid with bad slot_type' do
+      role = Role.new(name_en: 'Buffer', slot_type: 'Invalid')
+      expect(role).not_to be_valid
+    end
+  end
+
+  describe '.for_slot' do
+    it 'filters by slot_type' do
+      char_role = create(:role, slot_type: 'Character')
+      weapon_role = create(:role, :weapon)
+
+      results = Role.for_slot('Character')
+      expect(results).to include(char_role)
+      expect(results).not_to include(weapon_role)
+    end
+  end
+end

--- a/spec/models/substitution_spec.rb
+++ b/spec/models/substitution_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Substitution, type: :model do
+  let(:party) { create(:party) }
+  let(:character) { Character.find_by!(granblue_id: '3040087000') }
+  let(:character2) { Character.find_by!(granblue_id: '3040036000') }
+
+  let(:primary) do
+    create(:grid_character, party: party, character: character, position: 0)
+  end
+
+  let(:substitute) do
+    create(:grid_character, party: party, character: character2, position: 0, is_substitute: true)
+  end
+
+  describe 'validations' do
+    it 'is valid with matching grid types' do
+      sub = Substitution.new(
+        grid_type: 'GridCharacter', grid_id: primary.id,
+        substitute_grid_type: 'GridCharacter', substitute_grid_id: substitute.id,
+        position: 0
+      )
+      expect(sub).to be_valid
+    end
+
+    it 'rejects mismatched grid types' do
+      weapon = create(:grid_weapon, party: party)
+      sub = Substitution.new(
+        grid_type: 'GridCharacter', grid_id: primary.id,
+        substitute_grid_type: 'GridWeapon', substitute_grid_id: weapon.id,
+        position: 0
+      )
+      expect(sub).not_to be_valid
+      expect(sub.errors[:substitute_grid_type]).to include('must match grid_type')
+    end
+
+    it 'rejects position below 0' do
+      sub = Substitution.new(
+        grid_type: 'GridCharacter', grid_id: primary.id,
+        substitute_grid_type: 'GridCharacter', substitute_grid_id: substitute.id,
+        position: -1
+      )
+      expect(sub).not_to be_valid
+    end
+
+    it 'rejects position >= 10' do
+      sub = Substitution.new(
+        grid_type: 'GridCharacter', grid_id: primary.id,
+        substitute_grid_type: 'GridCharacter', substitute_grid_id: substitute.id,
+        position: 10
+      )
+      expect(sub).not_to be_valid
+    end
+
+    it 'accepts position 9' do
+      sub = Substitution.new(
+        grid_type: 'GridCharacter', grid_id: primary.id,
+        substitute_grid_type: 'GridCharacter', substitute_grid_id: substitute.id,
+        position: 9
+      )
+      expect(sub).to be_valid
+    end
+
+    it 'enforces 10-substitution cap' do
+      10.times do |i|
+        sub_char = create(:grid_character, party: party, character: character2, position: 0, is_substitute: true)
+        Substitution.create!(
+          grid_type: 'GridCharacter', grid_id: primary.id,
+          substitute_grid_type: 'GridCharacter', substitute_grid_id: sub_char.id,
+          position: i
+        )
+      end
+
+      eleventh = create(:grid_character, party: party, character: character2, position: 0, is_substitute: true)
+      sub = Substitution.new(
+        grid_type: 'GridCharacter', grid_id: primary.id,
+        substitute_grid_type: 'GridCharacter', substitute_grid_id: eleventh.id,
+        position: 0 # position 0 is taken, but the limit check fires first
+      )
+      expect(sub).not_to be_valid
+      expect(sub.errors[:base].join).to match(/cannot have more than 10/)
+    end
+  end
+
+  describe 'cascade on primary deletion' do
+    it 'destroys substitutions and substitute grid items when primary is destroyed' do
+      Substitution.create!(
+        grid_type: 'GridCharacter', grid_id: primary.id,
+        substitute_grid_type: 'GridCharacter', substitute_grid_id: substitute.id,
+        position: 0
+      )
+
+      expect { primary.destroy! }.to change(Substitution, :count).by(-1)
+    end
+  end
+end

--- a/spec/requests/api/v1/roles_spec.rb
+++ b/spec/requests/api/v1/roles_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Roles API', type: :request do
+  describe 'GET /api/v1/roles' do
+    it 'returns all roles' do
+      create(:role, name_en: 'Buffer', slot_type: 'Character')
+      create(:role, :weapon)
+      create(:role, :summon)
+
+      get '/api/v1/roles'
+      expect(response).to have_http_status(:ok)
+
+      body = JSON.parse(response.body)
+      expect(body.length).to eq(3)
+    end
+
+    it 'filters by slot_type' do
+      create(:role, name_en: 'Buffer', slot_type: 'Character')
+      create(:role, :weapon)
+
+      get '/api/v1/roles', params: { slot_type: 'Character' }
+      expect(response).to have_http_status(:ok)
+
+      body = JSON.parse(response.body)
+      expect(body.length).to eq(1)
+      expect(body.first['name_en']).to eq('Buffer')
+    end
+
+    it 'works without auth' do
+      get '/api/v1/roles'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/v1/substitutions_spec.rb
+++ b/spec/requests/api/v1/substitutions_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Substitutions API', type: :request do
+  let(:user) { create(:user) }
+  let(:access_token) do
+    Doorkeeper::AccessToken.create!(
+      resource_owner_id: user.id,
+      expires_in: 30.days,
+      scopes: 'public'
+    )
+  end
+  let(:headers) do
+    {
+      'Authorization' => "Bearer #{access_token.token}",
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  let(:party) { create(:party, user: user) }
+  let(:character) { Character.find_by!(granblue_id: '3040087000') }
+  let(:character2) { Character.find_by!(granblue_id: '3040036000') }
+  let(:primary_gc) { create(:grid_character, party: party, character: character, position: 0) }
+
+  describe 'POST /api/v1/substitutions' do
+    it 'creates a substitution' do
+      primary_gc # ensure it exists
+
+      params = {
+        substitution: {
+          grid_type: 'GridCharacter',
+          grid_id: primary_gc.id,
+          item_id: character2.id,
+          position: 0
+        }
+      }
+
+      expect {
+        post '/api/v1/substitutions', params: params.to_json, headers: headers
+      }.to change(Substitution, :count).by(1)
+        .and change(GridCharacter, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body['substitution']).to be_present
+      expect(body['substitution']['position']).to eq(0)
+    end
+
+    it 'rejects when not authorized' do
+      other_user = create(:user)
+      other_party = create(:party, user: other_user)
+      other_gc = create(:grid_character, party: other_party, character: character, position: 0)
+
+      params = {
+        substitution: {
+          grid_type: 'GridCharacter',
+          grid_id: other_gc.id,
+          item_id: character2.id,
+          position: 0
+        }
+      }
+
+      post '/api/v1/substitutions', params: params.to_json, headers: headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'PUT /api/v1/substitutions/:id' do
+    it 'updates position' do
+      primary_gc
+      sub_gc = create(:grid_character, party: party, character: character2, position: 0, is_substitute: true)
+      substitution = Substitution.create!(
+        grid_type: 'GridCharacter', grid_id: primary_gc.id,
+        substitute_grid_type: 'GridCharacter', substitute_grid_id: sub_gc.id,
+        position: 0
+      )
+
+      put "/api/v1/substitutions/#{substitution.id}",
+          params: { substitution: { position: 5 } }.to_json,
+          headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(substitution.reload.position).to eq(5)
+    end
+  end
+
+  describe 'DELETE /api/v1/substitutions/:id' do
+    it 'destroys the substitution and substitute grid item' do
+      primary_gc
+      sub_gc = create(:grid_character, party: party, character: character2, position: 0, is_substitute: true)
+      substitution = Substitution.create!(
+        grid_type: 'GridCharacter', grid_id: primary_gc.id,
+        substitute_grid_type: 'GridCharacter', substitute_grid_id: sub_gc.id,
+        position: 0
+      )
+
+      expect {
+        delete "/api/v1/substitutions/#{substitution.id}", headers: headers
+      }.to change(Substitution, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+      expect(GridCharacter.find_by(id: sub_gc.id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `roles` table (admin-managed predefined roles per slot type) and `substitutions` join table linking primary grid items to substitute grid items
- Adds `is_substitute`, `role_id`, `substitution_note` columns to all three grid tables
- Substitutes are full grid records with `is_substitute: true`, skipping position/conflict validations and counter cache updates
- Party associations scoped to exclude substitutes; `all_*` unscoped associations for amoeba/remix
- Remix remapping rebuilds substitution join records by matching item FK + position + is_substitute
- Guard on `recompute_party_boost!` so substitute summons don't trigger boost recomputation
- Read-only roles endpoint, full CRUD substitutions endpoint
- Role, substitution_note, and substitutions array wired into grid blueprints (nested view)

## Test plan
- [x] Model specs for Role and Substitution validations
- [x] Request specs for roles index (with slot_type filter, no auth required)
- [x] Request specs for substitutions create/update/destroy (with auth)
- [x] Full test suite passes (no new failures)