### PR TITLE
Hide own private/unlisted parties from gallery

### DIFF
--- a/app/services/party_query_builder.rb
+++ b/app/services/party_query_builder.rb
@@ -77,14 +77,13 @@ class PartyQueryBuilder
 
     # Build conditions for what the user can see:
     # 1. Public parties (visibility = 1)
-    # 2. Parties shared with their crew (if they're in a crew)
+    # 2. Crew-shared parties from other users (excludes own non-public parties)
     if @current_user&.crew
-      # User is in a crew - include public parties OR parties shared with their crew
-      query.where(<<-SQL.squish, 1, 'Crew', @current_user.crew.id)
-        visibility = ? OR parties.id IN (
+      query.where(<<-SQL.squish, 1, @current_user.id, 'Crew', @current_user.crew.id)
+        visibility = ? OR (parties.user_id != ? AND parties.id IN (
           SELECT party_id FROM party_shares
           WHERE shareable_type = ? AND shareable_id = ?
-        )
+        ))
       SQL
     else
       # User is not in a crew - only show public parties

--- a/spec/services/party_query_builder_spec.rb
+++ b/spec/services/party_query_builder_spec.rb
@@ -169,11 +169,33 @@ RSpec.describe PartyQueryBuilder, type: :model do
         create(:party_share, party: shared_party, shareable: crew, shared_by: shared_party.user)
       end
 
-      it 'returns public parties and crew-shared parties' do
+      it 'returns public parties and crew-shared parties from other users' do
         results = subject.build
         expect(results).to include(public_party)
         expect(results).to include(shared_party)
         expect(results).not_to include(private_party)
+      end
+    end
+
+    context 'when user has their own non-public parties shared with crew' do
+      let(:crew) { create(:crew) }
+      let(:current_user) { create(:user, crew: crew) }
+      let!(:own_private_party) { create(:party, user: current_user, visibility: 3) }
+      let!(:own_unlisted_party) { create(:party, user: current_user, visibility: 2) }
+      let!(:own_public_party) { create(:party, user: current_user, visibility: 1) }
+
+      before do
+        create(:crew_membership, crew: crew, user: current_user) unless crew.crew_memberships.exists?(user: current_user)
+        create(:party_share, party: own_private_party, shareable: crew, shared_by: current_user)
+        create(:party_share, party: own_unlisted_party, shareable: crew, shared_by: current_user)
+      end
+
+      it 'excludes own private and unlisted parties even when crew-shared' do
+        results = subject.build
+        expect(results).to include(public_party)
+        expect(results).to include(own_public_party)
+        expect(results).not_to include(own_private_party)
+        expect(results).not_to include(own_unlisted_party)
       end
     end
   end


### PR DESCRIPTION
## Summary
- When a crew member views the gallery, their own private/unlisted parties no longer appear even if shared with their crew
- Other users' crew-shared parties still show up as expected

## Test plan
- [x] `bundle exec rspec spec/services/party_query_builder_spec.rb` — 32 examples, 0 failures
- [ ] Log in as a crew member with private parties shared to crew, verify they don't appear in explore