### PR TITLE
Accept raid slugs in party query builder

### DIFF
--- a/app/services/party_query_builder.rb
+++ b/app/services/party_query_builder.rb
@@ -97,7 +97,7 @@ class PartyQueryBuilder
   def build_filters
     {
       element: build_element_filter,
-      raid_id: @params[:raid],
+      raid_id: resolve_raid_id,
       created_at: build_date_range,
       full_auto: build_option(@params[:full_auto]),
       auto_guard: build_option(@params[:auto_guard]),
@@ -114,6 +114,18 @@ class PartyQueryBuilder
 
     values = @params[:element].to_s.split(',').map(&:to_i)
     values.length == 1 ? values.first : values
+  end
+
+  # Resolves the raid parameter to a UUID.
+  # Accepts either a UUID directly or a slug (e.g. "proto-bahamut-hl").
+  UUID_REGEX = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
+  def resolve_raid_id
+    value = @params[:raid]
+    return nil unless value.present?
+    return value if value.match?(UUID_REGEX)
+
+    Raid.find_by(slug: value)&.id
   end
 
   # Returns a date range based on the 'recency' parameter.

--- a/spec/services/party_query_builder_spec.rb
+++ b/spec/services/party_query_builder_spec.rb
@@ -31,12 +31,25 @@ RSpec.describe PartyQueryBuilder, type: :model do
       let(:raid) { create(:raid) }
       let!(:matching_party) { create(:party, raid: raid, visibility: 1) }
       let!(:other_party) { create(:party, visibility: 1) }
-      let(:params) { { raid: raid.id } }
 
-      it 'returns only parties for the specified raid' do
-        results = subject.build
-        expect(results).to include(matching_party)
-        expect(results).not_to include(other_party)
+      context 'by UUID' do
+        let(:params) { { raid: raid.id } }
+
+        it 'returns only parties for the specified raid' do
+          results = subject.build
+          expect(results).to include(matching_party)
+          expect(results).not_to include(other_party)
+        end
+      end
+
+      context 'by slug' do
+        let(:params) { { raid: raid.slug } }
+
+        it 'resolves the slug and returns matching parties' do
+          results = subject.build
+          expect(results).to include(matching_party)
+          expect(results).not_to include(other_party)
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
- PartyQueryBuilder now accepts raid slugs (e.g. `proto-bahamut-hl`) in addition to UUIDs
- Needed for SSR filter resolution where the frontend sends slug-based raid params from URLs

## Test plan
- [ ] Filter parties by raid UUID — still works
- [ ] Filter parties by raid slug — resolves to UUID and filters correctly
- [ ] Invalid slug returns no results (not an error)