### PR TITLE
Allow LAN IPs for mobile dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,6 +4,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
   config.hosts << 'staging-api.granblue.team'
   config.hosts << 'next-api.granblue.team'
+  config.hosts << /\A192\.168\.\d+\.\d+\z/
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -20,7 +20,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
         127.0.0.1:1234
         game.granbluefantasy.jp
         chrome-extension://ahacbogimbikgiodaahmacboojcpdfpf
-      ]
+      ] + [/\A192\.168\.\d+\.\d+:(5173|5174)\z/]
     end
 
     resource '*',

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -20,7 +20,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
         127.0.0.1:1234
         game.granbluefantasy.jp
         chrome-extension://ahacbogimbikgiodaahmacboojcpdfpf
-      ] + [/\A192\.168\.\d+\.\d+:(5173|5174)\z/]
+      ] + [/\Ahttps?:\/\/192\.168\.\d+\.\d+:(5173|5174)\z/]
     end
 
     resource '*',


### PR DESCRIPTION
## Summary
- Adds `192.168.*` regex to CORS origins in dev (ports 5173/5174)
- Adds `192.168.*` regex to `config.hosts` so Rails accepts LAN requests

Companion to jedmund/hensei-web#830 for iPhone debugging on LAN.