### PR TITLE
Add GW event status endpoint

### DIFF
--- a/app/controllers/api/v1/gw_events_controller.rb
+++ b/app/controllers/api/v1/gw_events_controller.rb
@@ -7,6 +7,21 @@ module Api
       before_action :require_admin!, only: %i[create update]
       before_action :set_event, only: %i[show update]
 
+      # GET /gw_events/status
+      def status
+        upcoming = GwEvent.upcoming.first
+
+        today = Time.current.in_time_zone('Asia/Tokyo').to_date
+        recent = GwEvent.where('start_date <= ? AND end_date >= ?', today, today)
+                        .order(start_date: :desc).first
+        recent ||= GwEvent.recently_ended.first
+
+        render json: {
+          upcoming: upcoming ? GwEventBlueprint.render_as_hash(upcoming) : nil,
+          recent: recent ? GwEventBlueprint.render_as_hash(recent) : nil
+        }
+      end
+
       # GET /gw_events
       def index
         events = GwEvent.order(start_date: :desc)

--- a/app/models/gw_event.rb
+++ b/app/models/gw_event.rb
@@ -18,6 +18,11 @@ class GwEvent < ApplicationRecord
   scope :upcoming, -> { where('start_date > ?', Date.current).order(start_date: :asc) }
   scope :past, -> { where('end_date < ?', Date.current).order(start_date: :desc) }
   scope :current, -> { where('start_date <= ? AND end_date >= ?', Date.current, Date.current) }
+  scope :recently_ended, lambda { |days: 7|
+    today = Time.current.in_time_zone('Asia/Tokyo').to_date
+    cutoff = today - days.days
+    where('end_date >= ? AND end_date < ?', cutoff, today).order(start_date: :desc)
+  }
 
   def active?
     start_date <= Date.current && end_date >= Date.current

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,6 +290,9 @@ Rails.application.routes.draw do
 
     # GW Events (public read, admin write)
     resources :gw_events, only: %i[index show create update] do
+      collection do
+        get :status
+      end
       member do
         post :participations, to: 'crew_gw_participations#create'
       end


### PR DESCRIPTION
## Description

Adds a lightweight `GET /api/v1/gw_events/status` endpoint that returns the upcoming GW event and the most recent active/recently-ended event (within 7 days JST).

## Changes Made

- Added `status` action to `GwEventsController` (public, no auth)
- Added `recently_ended` scope to `GwEvent` model using JST timezone
- Added collection route for the new endpoint

## Checklist

- [x] I have tested my changes
- [x] My changes generate no new warnings