### PR TITLE
add phantom preview endpoint for gw score imports

### DIFF
--- a/app/controllers/api/v1/gw_score_imports_controller.rb
+++ b/app/controllers/api/v1/gw_score_imports_controller.rb
@@ -61,6 +61,32 @@ module Api
         }, status: errors.empty? ? :created : :multi_status
       end
 
+      # POST /crew/preview_gw_phantoms
+      # Params: { granblue_ids: ["12345", "67890", ...] }
+      def preview
+        membership_map = build_membership_map
+        phantom_map = build_phantom_map
+
+        existing_phantom_ids = []
+        new_phantom_ids = []
+
+        params[:granblue_ids].each do |gbf_id|
+          id = gbf_id.to_s
+          next if membership_map[id]
+
+          if phantom_map[id]
+            existing_phantom_ids << id
+          else
+            new_phantom_ids << id
+          end
+        end
+
+        render json: {
+          existing_phantom_ids: existing_phantom_ids,
+          new_phantom_ids: new_phantom_ids
+        }
+      end
+
       private
 
       def set_crew

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -316,6 +316,7 @@ Rails.application.routes.draw do
 
       # Unified GW score import from game data
       post 'import_gw_scores', to: 'gw_score_imports#create'
+      post 'preview_gw_phantoms', to: 'gw_score_imports#preview'
 
       # Member/phantom GW score history
       get 'memberships/:id/gw_scores', to: 'crew_memberships#gw_scores'


### PR DESCRIPTION
## Summary
- Adds `POST /crew/preview_gw_phantoms` to check which members are known, existing phantoms, or new phantoms before importing scores
- Reuses `build_membership_map` and `build_phantom_map` from the import controller
- Returns `existing_phantom_ids` and `new_phantom_ids` arrays