### PR TITLE
accept raid slug in import assign_raid

### DIFF
--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -371,10 +371,10 @@ module Api
       # Assigns an explicitly selected raid to the party.
       #
       # @param party [Party] the party record.
-      # @param raid_id [String] the raid ID from the request body.
+      # @param raid_identifier [String] the raid UUID or slug from the request body.
       # @return [void]
-      def assign_raid(party, raid_id)
-        raid = Raid.find_by(id: raid_id)
+      def assign_raid(party, raid_identifier)
+        raid = Raid.find_by(id: raid_identifier) || Raid.find_by(slug: raid_identifier)
         return unless raid
 
         party.update!(raid: raid, extra: raid.group.extra)


### PR DESCRIPTION
## Summary

`assign_raid` on party import only looked up the raid by UUID, so any request sending a slug (older extension builds were doing this and silently losing the raid) fell through to nil. Now we fall back to slug lookup, matching the pattern already in `raids_controller`, `character`, `weapon`, and `summon`.

Fixes the extension bug where users selected a raid in the picker but the imported party had no raid set. Paired with a frontend fix in the extension that switches to sending UUIDs, but this keeps older extension versions working.

## Test plan

- [ ] POST `/import` with `raid_id` = UUID — raid assigned
- [ ] POST `/import` with `raid_id` = slug (e.g. `"pbhl"`) — raid assigned
- [ ] POST `/import` with no `raid_id` — auto-detect still runs
- [ ] POST `/import` with bogus `raid_id` — no raid, no crash