### PR TITLE
track last extension version per user

### DIFF
--- a/app/blueprints/api/v1/user_blueprint.rb
+++ b/app/blueprints/api/v1/user_blueprint.rb
@@ -54,7 +54,8 @@ module Api
       # Settings view includes all user data + email (only for authenticated user viewing own settings)
       view :settings do
         include_view :minimal
-        fields :email, :email_verified, :import_weapons, :default_import_visibility
+        fields :email, :email_verified, :import_weapons, :default_import_visibility,
+               :last_extension_version, :last_extension_version_at
         field :has_crew do |user|
           user.crew.present?
         end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -59,6 +59,7 @@ module Api
       ##### Hooks
       before_action :current_user
       before_action :default_content_type
+      before_action :record_extension_version
       around_action :n_plus_one_detection, if: -> { Rails.env.development? }
 
       ##### Responders
@@ -88,6 +89,27 @@ module Api
         @current_user ||= User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
 
         @current_user
+      end
+
+      # Capture the X-Extension-Version header on each request and persist it
+      # as the user's last-seen extension version. Debounced so we only write
+      # when the version changes or the timestamp is more than an hour stale.
+      def record_extension_version
+        return unless current_user
+
+        version = request.headers['X-Extension-Version'].presence
+        return unless version
+
+        last_at = current_user.last_extension_version_at
+        return if current_user.last_extension_version == version &&
+                  last_at && last_at > 1.hour.ago
+
+        current_user.update_columns(
+          last_extension_version: version,
+          last_extension_version_at: Time.current
+        )
+      rescue StandardError => e
+        Rails.logger.warn "[record_extension_version] #{e.class}: #{e.message}"
       end
 
       def admin_mode

--- a/db/migrate/20260418000000_add_extension_version_tracking_to_users.rb
+++ b/db/migrate/20260418000000_add_extension_version_tracking_to_users.rb
@@ -1,0 +1,6 @@
+class AddExtensionVersionTrackingToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :last_extension_version, :string
+    add_column :users, :last_extension_version_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_02_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_18_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -1048,6 +1048,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_02_000000) do
     t.boolean "simple_portraits", default: false, null: false
     t.string "default_rep_view", default: "weapons", null: false
     t.string "timezone"
+    t.string "last_extension_version"
+    t.datetime "last_extension_version_at"
     t.index "lower((username)::text)", name: "index_users_on_lower_username", unique: true
     t.index ["collection_privacy"], name: "index_users_on_collection_privacy"
   end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -78,6 +78,47 @@ RSpec.describe 'Api::V1::Users', type: :request do
     end
   end
 
+  describe 'X-Extension-Version capture' do
+    let(:version_headers) { auth_headers.merge('X-Extension-Version' => '42') }
+
+    it 'records the version on the user when the header is present' do
+      get '/api/v1/users/me', headers: version_headers
+      expect(response).to have_http_status(:ok)
+      user.reload
+      expect(user.last_extension_version).to eq('42')
+      expect(user.last_extension_version_at).to be_within(5.seconds).of(Time.current)
+    end
+
+    it 'does not refresh the timestamp on a same-version request within an hour' do
+      get '/api/v1/users/me', headers: version_headers
+      original_at = user.reload.last_extension_version_at
+
+      travel 5.minutes do
+        get '/api/v1/users/me', headers: version_headers
+      end
+
+      expect(user.reload.last_extension_version_at).to be_within(1.second).of(original_at)
+    end
+
+    it 'updates immediately when the version changes' do
+      get '/api/v1/users/me', headers: version_headers
+      get '/api/v1/users/me', headers: auth_headers.merge('X-Extension-Version' => '43')
+
+      user.reload
+      expect(user.last_extension_version).to eq('43')
+    end
+
+    it 'is a no-op when the header is missing' do
+      get '/api/v1/users/me', headers: auth_headers
+      expect(user.reload.last_extension_version).to be_nil
+    end
+
+    it 'is a no-op when unauthenticated' do
+      get '/api/v1/users/info/' + user.username, headers: { 'X-Extension-Version' => '42' }
+      expect(user.reload.last_extension_version).to be_nil
+    end
+  end
+
   describe 'POST /api/v1/check/email' do
     it 'checks email availability' do
       post '/api/v1/check/email', params: { email: 'available@example.com' }.to_json,

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
     end
 
     it 'is a no-op when unauthenticated' do
-      get '/api/v1/users/info/' + user.username, headers: { 'X-Extension-Version' => '42' }
+      get "/api/v1/users/info/#{user.username}", headers: { 'X-Extension-Version' => '42' }
       expect(user.reload.last_extension_version).to be_nil
     end
   end


### PR DESCRIPTION
## Summary
- Adds `users.last_extension_version` (string) and `users.last_extension_version_at` (datetime).
- `Api::V1::ApiController` now reads `X-Extension-Version` on every request and writes the pair via `update_columns` for the current user. Debounced — only writes when the version changed or the timestamp is more than an hour stale.
- `UserBlueprint :settings` view exposes both fields so `/users/me` returns them.

The header is sent by the extension in https://github.com/jedmund/hensei-extractor/pull/81. Existing users will fill in naturally as they reopen the extension.

## Test plan
- [x] `bundle exec rspec spec/requests/api/v1/users_spec.rb` (14 examples, 0 failures — 5 new specs cover capture, debounce, version-change, missing header, unauthenticated)
- [ ] Manual: `curl -H "Authorization: Bearer <token>" -H "X-Extension-Version: 42" $API/users/me` → `User.find(...).reload.last_extension_version == "42"`
- [ ] After deploying both repos: open released extension while signed in, confirm row reflects the actual `github.run_number`