### PR TITLE
transfer phantom joined_at to membership on claim

### DIFF
--- a/app/models/phantom_player.rb
+++ b/app/models/phantom_player.rb
@@ -47,7 +47,7 @@ class PhantomPlayer < ApplicationRecord
 
     self.claim_confirmed = true
     self.deleted_at = Time.current
-    transfer_scores_to_membership!
+    transfer_to_membership!
     save!
   end
 
@@ -87,16 +87,19 @@ class PhantomPlayer < ApplicationRecord
     errors.add(:claim_confirmed, 'requires a claimed_by user')
   end
 
-  def transfer_scores_to_membership!
+  def transfer_to_membership!
     return unless claimed_by.present?
 
     membership = claimed_by.active_crew_membership
     return unless membership
 
-    # Transfer all phantom scores to the user's membership
     gw_individual_scores.update_all(
       crew_membership_id: membership.id,
       phantom_player_id: nil
     )
+
+    if joined_at.present? && (membership.joined_at.nil? || joined_at < membership.joined_at)
+      membership.update_columns(joined_at: joined_at)
+    end
   end
 end

--- a/db/migrate/20260419045519_backfill_membership_joined_at_from_claimed_phantoms.rb
+++ b/db/migrate/20260419045519_backfill_membership_joined_at_from_claimed_phantoms.rb
@@ -1,0 +1,27 @@
+class BackfillMembershipJoinedAtFromClaimedPhantoms < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      UPDATE crew_memberships cm
+      SET joined_at = sub.earliest_joined_at
+      FROM (
+        SELECT
+          pp.claimed_by_id AS user_id,
+          pp.crew_id       AS crew_id,
+          MIN(pp.joined_at) AS earliest_joined_at
+        FROM phantom_players pp
+        WHERE pp.claim_confirmed = TRUE
+          AND pp.claimed_by_id IS NOT NULL
+          AND pp.joined_at IS NOT NULL
+        GROUP BY pp.claimed_by_id, pp.crew_id
+      ) sub
+      WHERE cm.user_id = sub.user_id
+        AND cm.crew_id = sub.crew_id
+        AND cm.retired = FALSE
+        AND (cm.joined_at IS NULL OR sub.earliest_joined_at < cm.joined_at);
+    SQL
+  end
+
+  def down
+    # Not reversible — original joined_at values aren't retained.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_02_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/spec/models/phantom_player_spec.rb
+++ b/spec/models/phantom_player_spec.rb
@@ -145,6 +145,26 @@ RSpec.describe PhantomPlayer, type: :model do
         expect(phantom_score.phantom_player).to be_nil
       end
     end
+
+    context 'joined_at transfer' do
+      it "copies the phantom's joined_at to the membership when earlier" do
+        earlier = 1.year.ago
+        phantom.update!(joined_at: earlier)
+        membership.update!(joined_at: 1.day.ago)
+
+        phantom.confirm_claim!(member)
+        expect(membership.reload.joined_at).to be_within(1.second).of(earlier)
+      end
+
+      it 'does not overwrite a membership joined_at that is already earlier' do
+        phantom.update!(joined_at: 1.day.ago)
+        older = 2.years.ago
+        membership.update!(joined_at: older)
+
+        phantom.confirm_claim!(member)
+        expect(membership.reload.joined_at).to be_within(1.second).of(older)
+      end
+    end
   end
 
   describe '#unassign!' do


### PR DESCRIPTION
## Summary
- When a user confirms a phantom claim, `PhantomPlayer#confirm_claim!` now copies the phantom's `joined_at` onto the user's active `CrewMembership` (only when strictly earlier, so long-tenured members claiming a later-dated phantom aren't clobbered).
- Adds a data migration that backfills `joined_at` for memberships of users who already confirmed a phantom claim, using the earliest `joined_at` across their claimed phantoms in that crew.

## Why
Phantoms represent a user's historical presence in a crew. `CrewMembership.active_during` (and other join-date-aware scopes) use `joined_at`, so without this, a user who claims a phantom looks like they just joined even though their scores go back months.

## Test plan
- [x] `bundle exec rspec spec/models/phantom_player_spec.rb spec/requests/api/v1/phantom_claims_spec.rb spec/requests/api/v1/crew_invitations_spec.rb` (48 examples, 0 failures)
- [x] `bundle exec rubocop` on touched files
- [ ] Run migration on staging, spot-check that memberships for confirmed claimers now have earlier `joined_at` values matching their phantom(s)