### PR TITLE
add collection update preview + element_variants endpoint

### DIFF
--- a/app/blueprints/api/v1/weapon_blueprint.rb
+++ b/app/blueprints/api/v1/weapon_blueprint.rb
@@ -67,6 +67,16 @@ module Api
                  :forge_order, :extra, :series, :promotion_names
       end
 
+      # Minimal view for the element-variant lookup endpoint.
+      # Retains only granblue_id and element_variant_ids — consumed by the
+      # extension to map variant game-ids back to base granblue_ids.
+      view :variants do
+        excludes :name, :element, :proficiency, :max_level, :max_skill_level,
+                 :max_awakening_level, :max_exorcism_level, :limit, :rarity,
+                 :gacha, :promotions, :forge_order, :extra, :series,
+                 :promotion_names, :uncap, :bullet_slots
+      end
+
       view :stats do
         field :hp do |w|
           {

--- a/app/controllers/api/v1/collection_characters_controller.rb
+++ b/app/controllers/api/v1/collection_characters_controller.rb
@@ -7,7 +7,7 @@ module Api
       before_action :set_collection_character_for_read, only: %i[show]
 
       # Write actions: require auth, use current_user
-      before_action :restrict_access, only: %i[create update destroy batch batch_destroy import]
+      before_action :restrict_access, only: %i[create update destroy batch batch_destroy import check_updates]
       before_action :set_collection_character_for_write, only: %i[update destroy]
 
       def index
@@ -192,6 +192,24 @@ module Api
           skipped: result.skipped.size,
           errors: result.errors
         }, status: status
+      end
+
+      # POST /collection/characters/check_updates
+      # Returns field-level diffs for already-owned characters that differ from the
+      # state that the real import would apply. Accepts both the game inventory
+      # format and the extension stats format. Non-owned characters are skipped.
+      #
+      # @param data [Hash] Game data containing character list
+      # @return [JSON] { updates: [{ granblue_id, changes: [...] }, ...] }
+      def check_updates
+        game_data = import_params[:data]
+
+        unless game_data.present?
+          return render json: { error: 'No data provided' }, status: :bad_request
+        end
+
+        service = CharacterImportService.new(current_user, game_data)
+        render json: { updates: service.preview_updates }
       end
 
       private

--- a/app/controllers/api/v1/collection_summons_controller.rb
+++ b/app/controllers/api/v1/collection_summons_controller.rb
@@ -7,7 +7,7 @@ module Api
       before_action :set_collection_summon_for_read, only: %i[show]
 
       # Write actions: require auth, use current_user
-      before_action :restrict_access, only: %i[create update destroy batch batch_destroy import preview_sync check_conflicts]
+      before_action :restrict_access, only: %i[create update destroy batch batch_destroy import preview_sync check_conflicts check_updates]
       before_action :set_collection_summon_for_write, only: %i[update destroy]
 
       def index
@@ -256,6 +256,23 @@ module Api
         end
 
         render json: { conflicts: conflicts }
+      end
+
+      # POST /collection/summons/check_updates
+      # Returns field-level diffs for already-owned summons that differ from the
+      # state that the real import would apply. Non-owned summons are skipped.
+      #
+      # @param data [Hash] Game data containing summon list
+      # @return [JSON] { updates: [{ game_id, granblue_id, changes: [...] }, ...] }
+      def check_updates
+        game_data = import_params[:data]
+
+        unless game_data.present?
+          return render json: { error: 'No data provided' }, status: :bad_request
+        end
+
+        service = SummonImportService.new(current_user, game_data)
+        render json: { updates: service.preview_updates }
       end
 
       private

--- a/app/controllers/api/v1/collection_weapons_controller.rb
+++ b/app/controllers/api/v1/collection_weapons_controller.rb
@@ -7,7 +7,7 @@ module Api
       before_action :set_collection_weapon_for_read, only: %i[show]
 
       # Write actions: require auth, use current_user
-      before_action :restrict_access, only: %i[create update destroy batch batch_destroy import preview_sync check_conflicts]
+      before_action :restrict_access, only: %i[create update destroy batch batch_destroy import preview_sync check_conflicts check_updates]
       before_action :set_collection_weapon_for_write, only: %i[update destroy]
 
       def index
@@ -262,6 +262,23 @@ module Api
         end
 
         render json: { conflicts: conflicts }
+      end
+
+      # POST /collection/weapons/check_updates
+      # Returns field-level diffs for already-owned weapons that differ from the
+      # state that the real import would apply. Non-owned weapons are skipped.
+      #
+      # @param data [Hash] Game data containing weapon list
+      # @return [JSON] { updates: [{ game_id, granblue_id, changes: [...] }, ...] }
+      def check_updates
+        game_data = import_params[:data]
+
+        unless game_data.present?
+          return render json: { error: 'No data provided' }, status: :bad_request
+        end
+
+        service = WeaponImportService.new(current_user, game_data)
+        render json: { updates: service.preview_updates }
       end
 
       private

--- a/app/controllers/api/v1/weapons_controller.rb
+++ b/app/controllers/api/v1/weapons_controller.rb
@@ -162,6 +162,18 @@ module Api
         render json: WeaponBlueprint.render(@weapon, view: :raw)
       end
 
+      # GET /weapons/element_variants
+      # Returns the variant-ID map for every element-changeable weapon.
+      # Consumed by the extension to fall back to base images when a game
+      # variant thumbnail is missing from the image bucket.
+      def element_variants
+        weapons = Weapon
+                  .joins(:weapon_series)
+                  .where(weapon_series: { element_changeable: true })
+                  .where.not(element_variant_ids: nil)
+        render json: WeaponBlueprint.render(weapons, view: :variants)
+      end
+
       # POST /weapons/batch_preview
       # Fetches wiki data and suggestions for multiple wiki page names
       def batch_preview

--- a/app/services/character_import_service.rb
+++ b/app/services/character_import_service.rb
@@ -68,7 +68,70 @@ class CharacterImportService
     )
   end
 
+  ##
+  # Dry-run: returns the diff that `import` (with update_existing: true) would apply
+  # to each already-owned CollectionCharacter. Handles both the game inventory format
+  # (param/master) and the extension stats format (granblue_id at top level).
+  #
+  # @return [Array<Hash>] one entry per changed record: { granblue_id:, changes: [...] }
+  def preview_updates
+    items = extract_items
+    return [] if items.empty?
+
+    updates = []
+
+    items.each do |item|
+      update = if item['granblue_id'].present?
+                 preview_stats_format(item)
+               else
+                 preview_game_format(item)
+               end
+      updates << update if update
+    end
+
+    updates
+  end
+
   private
+
+  def preview_game_format(item)
+    master = item['master'] || {}
+    granblue_id = master['id']
+    return nil unless granblue_id.present?
+
+    character = find_character(granblue_id)
+    return nil unless character
+
+    existing = @user.collection_characters.find_by(character_id: character.id)
+    return nil unless existing
+
+    attrs = build_collection_character_attrs(item, character)
+    existing.assign_attributes(attrs)
+    return nil if existing.changes.empty?
+
+    {
+      granblue_id: character.granblue_id,
+      changes: CollectionImport::ChangeFormatter.format(existing.changes)
+    }
+  end
+
+  def preview_stats_format(item)
+    granblue_id = item['granblue_id']
+    character = find_character(granblue_id)
+    return nil unless character
+
+    existing = @user.collection_characters.find_by(character_id: character.id)
+    return nil unless existing
+
+    attrs = build_stats_attrs(item, character)
+    existing.assign_attributes(attrs)
+    return nil if existing.changes.empty?
+
+    {
+      granblue_id: character.granblue_id,
+      changes: CollectionImport::ChangeFormatter.format(existing.changes)
+    }
+  end
 
   def extract_items
     return @game_data if @game_data.is_a?(Array)

--- a/app/services/collection_import/change_formatter.rb
+++ b/app/services/collection_import/change_formatter.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module CollectionImport
+  ##
+  # Formats an ActiveRecord::Dirty changes hash into user-visible deltas.
+  # Used by the preview_updates methods on the collection import services to
+  # return diffs the extension can render in a tooltip.
+  #
+  # Output shape per change:
+  #   {
+  #     field: 'uncap_level',
+  #     label: 'Uncap',
+  #     before: { raw: 4, display: '4' },
+  #     after:  { raw: 5, display: '5' }
+  #   }
+  module ChangeFormatter
+    FIELD_LABELS = {
+      'uncap_level'            => 'Uncap',
+      'transcendence_step'     => 'Transcendence',
+      'awakening_id'           => 'Awakening',
+      'awakening_level'        => 'Awakening Level',
+      'element'                => 'Element',
+      'exorcism_level'         => 'Exorcism',
+      'befoulment_modifier_id' => 'Befoulment',
+      'befoulment_strength'    => 'Befoulment Strength',
+      'ax_modifier1_id'        => 'AX Skill 1',
+      'ax_strength1'           => 'AX Skill 1 Strength',
+      'ax_modifier2_id'        => 'AX Skill 2',
+      'ax_strength2'           => 'AX Skill 2 Strength',
+      'weapon_key1_id'         => 'Weapon Key 1',
+      'weapon_key2_id'         => 'Weapon Key 2',
+      'weapon_key3_id'         => 'Weapon Key 3',
+      'weapon_key4_id'         => 'Weapon Key 4',
+      'perpetuity'             => 'Perpetuity Ring',
+      'ring1'                  => 'Ring 1',
+      'ring2'                  => 'Ring 2',
+      'ring3'                  => 'Ring 3',
+      'ring4'                  => 'Ring 4',
+      'earring'                => 'Earring'
+    }.freeze
+
+    # Internal element IDs: 0=Null, 1=Wind, 2=Fire, 3=Water, 4=Earth, 5=Dark, 6=Light
+    # (See GranblueEnums::ELEMENTS.)
+    INTERNAL_ELEMENT_NAMES = {
+      0 => 'Null', 1 => 'Wind', 2 => 'Fire', 3 => 'Water',
+      4 => 'Earth', 5 => 'Dark', 6 => 'Light'
+    }.freeze
+
+    module_function
+
+    # @param changes [Hash] an ActiveRecord::Dirty changes hash
+    # @return [Array<Hash>] formatted change entries
+    def format(changes)
+      changes.map do |field, (before, after)|
+        {
+          field: field,
+          label: FIELD_LABELS[field] || field.humanize,
+          before: format_value(field, before),
+          after: format_value(field, after)
+        }
+      end
+    end
+
+    def format_value(field, value)
+      { raw: value, display: display_for(field, value) }
+    end
+
+    def display_for(field, value)
+      return '—' if value.nil?
+
+      case field
+      when 'awakening_id'
+        resolve_awakening(value)
+      when /\Aweapon_key\d_id\z/
+        resolve_weapon_key(value)
+      when /\Aax_modifier\d_id\z/, 'befoulment_modifier_id'
+        resolve_stat_modifier(value)
+      when 'element'
+        INTERNAL_ELEMENT_NAMES[value.to_i] || value.to_s
+      when 'perpetuity'
+        value ? 'Yes' : 'No'
+      when /\Aring\d\z/, 'earring'
+        format_ring(value)
+      else
+        value.to_s
+      end
+    end
+
+    def resolve_awakening(id)
+      return '—' if id.blank?
+
+      Awakening.find_by(id: id)&.name_en || id.to_s
+    end
+
+    def resolve_weapon_key(id)
+      return '—' if id.blank?
+
+      WeaponKey.find_by(id: id)&.name_en || id.to_s
+    end
+
+    def resolve_stat_modifier(id)
+      return '—' if id.blank?
+
+      WeaponStatModifier.find_by(id: id)&.name_en || id.to_s
+    end
+
+    # Rings are jsonb { 'modifier' => Integer, 'strength' => Integer }. Modifier
+    # indexes into the client-side overMastery/aetherialMastery catalogs, so we
+    # don't have a server-side name for it — render as "mod N, str M".
+    def format_ring(ring)
+      return 'None' unless ring.is_a?(Hash)
+      return 'None' if ring['modifier'].blank? || ring['modifier'].to_i.zero?
+
+      "mod #{ring['modifier']}, str #{ring['strength']}"
+    end
+  end
+end

--- a/app/services/summon_import_service.rb
+++ b/app/services/summon_import_service.rb
@@ -99,6 +99,48 @@ class SummonImportService
     )
   end
 
+  ##
+  # Dry-run: returns the diff that `import` (with update_existing: true) would apply
+  # to each already-owned CollectionSummon. Non-owned summons are skipped.
+  #
+  # @return [Array<Hash>] one entry per changed record: { game_id:, granblue_id:, changes: [...] }
+  def preview_updates
+    items = extract_items
+    return [] if items.empty?
+
+    updates = []
+
+    items.each do |item|
+      param = item['param'] || {}
+      master = item['master'] || {}
+
+      game_id = param['id']
+      next unless game_id.present?
+
+      image_id = param['image_id'].to_s.split('_').first if param['image_id'].present?
+      granblue_id = image_id || master['id']
+      next unless granblue_id.present?
+
+      summon = find_summon(granblue_id)
+      next unless summon
+
+      existing = @user.collection_summons.find_by(game_id: game_id.to_s)
+      next unless existing
+
+      attrs = build_collection_summon_attrs(item, summon)
+      existing.assign_attributes(attrs)
+      next if existing.changes.empty?
+
+      updates << {
+        game_id: game_id.to_s,
+        granblue_id: summon.granblue_id,
+        changes: CollectionImport::ChangeFormatter.format(existing.changes)
+      }
+    end
+
+    updates
+  end
+
   private
 
   def extract_items

--- a/app/services/weapon_import_service.rb
+++ b/app/services/weapon_import_service.rb
@@ -111,6 +111,48 @@ class WeaponImportService
     )
   end
 
+  ##
+  # Dry-run: returns the diff that `import` (with update_existing: true) would apply
+  # to each already-owned CollectionWeapon. Non-owned weapons are skipped.
+  #
+  # @return [Array<Hash>] one entry per changed record: { game_id:, granblue_id:, changes: [...] }
+  def preview_updates
+    items = extract_items
+    return [] if items.empty?
+
+    updates = []
+
+    items.each do |item|
+      param = item['param'] || {}
+      master = item['master'] || {}
+
+      game_id = param['id']
+      next unless game_id.present?
+
+      image_id = param['image_id'].to_s.split('_').first if param['image_id'].present?
+      granblue_id = image_id || master['id']
+      next unless granblue_id.present?
+
+      weapon, resolved_element = find_weapon(granblue_id)
+      next unless weapon
+
+      existing = @user.collection_weapons.find_by(game_id: game_id.to_s)
+      next unless existing
+
+      attrs = build_collection_weapon_attrs(item, weapon, resolved_element)
+      existing.assign_attributes(attrs)
+      next if existing.changes.empty?
+
+      updates << {
+        game_id: game_id.to_s,
+        granblue_id: weapon.granblue_id,
+        changes: CollectionImport::ChangeFormatter.format(existing.changes)
+      }
+    end
+
+    updates
+  end
+
   private
 
   def extract_items

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       collection do
         get 'validate/:granblue_id', action: :validate, as: :validate
         post 'batch_preview'
+        get 'element_variants'
       end
       member do
         post 'download_image'
@@ -353,6 +354,7 @@ Rails.application.routes.draw do
           post :batch
           delete :batch_destroy
           post :import
+          post :check_updates
         end
       end
       resources :weapons, only: [:create, :update, :destroy], controller: '/api/v1/collection_weapons' do
@@ -362,6 +364,7 @@ Rails.application.routes.draw do
           post :import
           post :preview_sync
           post :check_conflicts
+          post :check_updates
         end
       end
       resources :summons, only: [:create, :update, :destroy], controller: '/api/v1/collection_summons' do
@@ -371,6 +374,7 @@ Rails.application.routes.draw do
           post :import
           post :preview_sync
           post :check_conflicts
+          post :check_updates
         end
       end
       resources :job_accessories, controller: '/api/v1/collection_job_accessories',

--- a/spec/requests/api/v1/collection_check_updates_spec.rb
+++ b/spec/requests/api/v1/collection_check_updates_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Collection - check_updates', type: :request do
+  let(:user) { create(:user) }
+  let(:access_token) do
+    Doorkeeper::AccessToken.create!(resource_owner_id: user.id, expires_in: 30.days, scopes: 'public')
+  end
+  let(:headers) do
+    { 'Authorization' => "Bearer #{access_token.token}", 'Content-Type' => 'application/json' }
+  end
+
+  describe 'POST /api/v1/collection/weapons/check_updates' do
+    let(:endpoint) { '/api/v1/collection/weapons/check_updates' }
+
+    let(:weapon) do
+      Weapon.find_by(granblue_id: '1040020000') ||
+        create(:weapon, granblue_id: '1040020000', name_en: 'Luminiera Sword Omega')
+    end
+
+    def game_item(game_id, granblue_id, evolution: 5)
+      {
+        'param' => { 'id' => game_id, 'image_id' => granblue_id, 'evolution' => evolution, 'phase' => 0 },
+        'master' => { 'id' => granblue_id }
+      }
+    end
+
+    it 'requires authentication' do
+      post endpoint, params: { data: { 'list' => [] } }.to_json,
+           headers: { 'Content-Type' => 'application/json' }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns bad_request when no data provided' do
+      post endpoint, params: {}.to_json, headers: headers
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'returns an entry with field-level deltas for a changed weapon' do
+      create(:collection_weapon, user: user, weapon: weapon, game_id: '12345', uncap_level: 3)
+
+      payload = { data: { 'list' => [game_item('12345', '1040020000', evolution: 5)] } }
+      post endpoint, params: payload.to_json, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['updates'].size).to eq(1)
+
+      entry = json['updates'].first
+      expect(entry['game_id']).to eq('12345')
+      expect(entry['granblue_id']).to eq('1040020000')
+
+      uncap_change = entry['changes'].find { |c| c['field'] == 'uncap_level' }
+      expect(uncap_change['label']).to eq('Uncap')
+      expect(uncap_change['before']['raw']).to eq(3)
+      expect(uncap_change['after']['raw']).to eq(5)
+    end
+
+    it 'skips non-owned weapons' do
+      weapon
+      payload = { data: { 'list' => [game_item('99999', '1040020000')] } }
+
+      post endpoint, params: payload.to_json, headers: headers
+
+      json = response.parsed_body
+      expect(json['updates']).to eq([])
+    end
+  end
+
+  describe 'POST /api/v1/collection/summons/check_updates' do
+    let(:endpoint) { '/api/v1/collection/summons/check_updates' }
+
+    let(:summon) do
+      Summon.find_by(granblue_id: '2040035000') ||
+        create(:summon, granblue_id: '2040035000', name_en: 'Celeste')
+    end
+
+    it 'returns an entry with field-level deltas for a changed summon' do
+      create(:collection_summon, user: user, summon: summon, game_id: '55555', uncap_level: 3)
+
+      payload = {
+        data: {
+          'list' => [
+            {
+              'param' => { 'id' => '55555', 'image_id' => '2040035000', 'evolution' => '4', 'phase' => 0 },
+              'master' => { 'id' => '2040035000' }
+            }
+          ]
+        }
+      }
+      post endpoint, params: payload.to_json, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['updates'].size).to eq(1)
+      expect(json['updates'].first['changes'].map { |c| c['field'] }).to include('uncap_level')
+    end
+  end
+
+  describe 'POST /api/v1/collection/characters/check_updates' do
+    let(:endpoint) { '/api/v1/collection/characters/check_updates' }
+    let!(:awakening) do
+      Awakening.find_by(slug: 'character-balanced', object_type: 'Character') ||
+        create(:awakening, :for_character, slug: 'character-balanced', name_en: 'Balanced')
+    end
+
+    let(:character) do
+      Character.find_by(granblue_id: '3040171000') ||
+        create(:character, granblue_id: '3040171000', name_en: 'Hallessena')
+    end
+
+    it 'returns an entry for a changed character (game format)' do
+      create(:collection_character, user: user, character: character, uncap_level: 3, awakening: awakening)
+
+      payload = {
+        data: {
+          'list' => [
+            {
+              'master' => { 'id' => character.granblue_id },
+              'param' => { 'id' => 123_456, 'evolution' => '5', 'phase' => '0', 'arousal_level' => 1 }
+            }
+          ]
+        }
+      }
+      post endpoint, params: payload.to_json, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['updates'].size).to eq(1)
+      expect(json['updates'].first['granblue_id']).to eq(character.granblue_id)
+      expect(json['updates'].first['changes'].map { |c| c['field'] }).to include('uncap_level')
+    end
+
+    it 'returns an entry for a changed character (stats format)' do
+      create(:collection_character, user: user, character: character, awakening: awakening, perpetuity: false)
+
+      payload = {
+        data: {
+          'list' => [
+            { 'granblue_id' => character.granblue_id, 'perpetuity' => true }
+          ]
+        }
+      }
+      post endpoint, params: payload.to_json, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['updates'].size).to eq(1)
+      perp = json['updates'].first['changes'].find { |c| c['field'] == 'perpetuity' }
+      expect(perp['before']['display']).to eq('No')
+      expect(perp['after']['display']).to eq('Yes')
+    end
+  end
+end

--- a/spec/services/character_import_service_spec.rb
+++ b/spec/services/character_import_service_spec.rb
@@ -609,4 +609,91 @@ RSpec.describe CharacterImportService, type: :service do
       end
     end
   end
+
+  describe '#preview_updates' do
+    def game_item(granblue_id:, game_id:, evolution: '4', phase: '0', arousal_level: 1)
+      {
+        'master' => { 'id' => granblue_id },
+        'param' => {
+          'id' => game_id,
+          'evolution' => evolution,
+          'phase' => phase,
+          'arousal_level' => arousal_level
+        }
+      }
+    end
+
+    context 'game inventory format' do
+      it 'returns an empty array when the record is unchanged' do
+        described_class.new(user, { 'list' => [game_item(granblue_id: standard_character.granblue_id, game_id: 1, evolution: '4')] }).import
+
+        updates = described_class.new(
+          user,
+          { 'list' => [game_item(granblue_id: standard_character.granblue_id, game_id: 1, evolution: '4')] }
+        ).preview_updates
+
+        expect(updates).to be_empty
+      end
+
+      it 'surfaces an uncap_level change' do
+        described_class.new(user, { 'list' => [game_item(granblue_id: standard_character.granblue_id, game_id: 2, evolution: '3')] }).import
+
+        updates = described_class.new(
+          user,
+          { 'list' => [game_item(granblue_id: standard_character.granblue_id, game_id: 3, evolution: '5')] }
+        ).preview_updates
+
+        expect(updates.size).to eq(1)
+        entry = updates.first
+        expect(entry[:granblue_id]).to eq(standard_character.granblue_id)
+        uncap_change = entry[:changes].find { |c| c[:field] == 'uncap_level' }
+        expect(uncap_change[:before][:raw]).to eq(3)
+        expect(uncap_change[:after][:raw]).to eq(5)
+      end
+
+      it 'skips characters the user does not own' do
+        updates = described_class.new(
+          user,
+          { 'list' => [game_item(granblue_id: flb_character.granblue_id, game_id: 99)] }
+        ).preview_updates
+
+        expect(updates).to be_empty
+      end
+    end
+
+    context 'extension stats format' do
+      before do
+        # Seed an owned character
+        described_class.new(user, { 'list' => [game_item(granblue_id: standard_character.granblue_id, game_id: 10, evolution: '4')] }).import
+      end
+
+      it 'surfaces a ring change' do
+        stats_item = {
+          'granblue_id' => standard_character.granblue_id,
+          'ring1' => { 'modifier' => 5, 'strength' => 10 }
+        }
+
+        updates = described_class.new(user, { 'list' => [stats_item] }).preview_updates
+
+        expect(updates.size).to eq(1)
+        fields = updates.first[:changes].map { |c| c[:field] }
+        expect(fields).to include('ring1')
+      end
+
+      it 'surfaces a perpetuity change' do
+        stats_item = {
+          'granblue_id' => standard_character.granblue_id,
+          'perpetuity' => true
+        }
+
+        updates = described_class.new(user, { 'list' => [stats_item] }).preview_updates
+
+        expect(updates.size).to eq(1)
+        perp = updates.first[:changes].find { |c| c[:field] == 'perpetuity' }
+        expect(perp).to be_present
+        expect(perp[:before][:raw]).to be false
+        expect(perp[:after][:raw]).to be true
+      end
+    end
+  end
 end

--- a/spec/services/summon_import_service_spec.rb
+++ b/spec/services/summon_import_service_spec.rb
@@ -496,4 +496,57 @@ RSpec.describe SummonImportService, type: :service do
       end
     end
   end
+
+  describe '#preview_updates' do
+    def summon_item(game_id:, image_id:, evolution: '4', phase: '0')
+      {
+        'param' => {
+          'id' => game_id.to_s,
+          'image_id' => image_id,
+          'evolution' => evolution,
+          'phase' => phase
+        },
+        'master' => { 'id' => image_id }
+      }
+    end
+
+    it 'returns an empty array when the record is unchanged' do
+      described_class.new(user, { 'list' => [summon_item(game_id: 's1', image_id: standard_summon.granblue_id, evolution: '3')] }).import
+
+      updates = described_class.new(
+        user,
+        { 'list' => [summon_item(game_id: 's1', image_id: standard_summon.granblue_id, evolution: '3')] }
+      ).preview_updates
+
+      expect(updates).to be_empty
+    end
+
+    it 'surfaces an uncap_level change' do
+      described_class.new(user, { 'list' => [summon_item(game_id: 's2', image_id: standard_summon.granblue_id, evolution: '3')] }).import
+
+      updates = described_class.new(
+        user,
+        { 'list' => [summon_item(game_id: 's2', image_id: standard_summon.granblue_id, evolution: '4')] }
+      ).preview_updates
+
+      expect(updates.size).to eq(1)
+      entry = updates.first
+      expect(entry[:game_id]).to eq('s2')
+      expect(entry[:granblue_id]).to eq(standard_summon.granblue_id)
+
+      uncap_change = entry[:changes].find { |c| c[:field] == 'uncap_level' }
+      expect(uncap_change).to be_present
+      expect(uncap_change[:before][:raw]).to eq(3)
+      expect(uncap_change[:after][:raw]).to eq(4)
+    end
+
+    it 'skips summons the user does not own' do
+      updates = described_class.new(
+        user,
+        { 'list' => [summon_item(game_id: 's3', image_id: standard_summon.granblue_id)] }
+      ).preview_updates
+
+      expect(updates).to be_empty
+    end
+  end
 end

--- a/spec/services/weapon_import_service_spec.rb
+++ b/spec/services/weapon_import_service_spec.rb
@@ -902,4 +902,78 @@ RSpec.describe WeaponImportService, type: :service do
       end
     end
   end
+
+  describe '#preview_updates' do
+    def weapon_item(game_id:, image_id:, evolution: '5', phase: '0')
+      {
+        'param' => {
+          'id' => game_id.to_s,
+          'image_id' => image_id,
+          'evolution' => evolution,
+          'phase' => phase,
+          'arousal' => { 'is_arousal_weapon' => false },
+          'odiant' => { 'is_odiant_weapon' => false }
+        },
+        'master' => { 'id' => image_id }
+      }
+    end
+
+    it 'returns an empty array when the record is unchanged' do
+      described_class.new(user, { 'list' => [weapon_item(game_id: 'w1', image_id: standard_weapon.granblue_id, evolution: '4')] }).import
+
+      updates = described_class.new(
+        user,
+        { 'list' => [weapon_item(game_id: 'w1', image_id: standard_weapon.granblue_id, evolution: '4')] }
+      ).preview_updates
+
+      expect(updates).to be_empty
+    end
+
+    it 'surfaces an uncap_level change' do
+      described_class.new(user, { 'list' => [weapon_item(game_id: 'w2', image_id: standard_weapon.granblue_id, evolution: '3')] }).import
+
+      updates = described_class.new(
+        user,
+        { 'list' => [weapon_item(game_id: 'w2', image_id: standard_weapon.granblue_id, evolution: '5')] }
+      ).preview_updates
+
+      expect(updates.size).to eq(1)
+      entry = updates.first
+      expect(entry[:game_id]).to eq('w2')
+      expect(entry[:granblue_id]).to eq(standard_weapon.granblue_id)
+
+      uncap_change = entry[:changes].find { |c| c[:field] == 'uncap_level' }
+      expect(uncap_change).to be_present
+      expect(uncap_change[:label]).to eq('Uncap')
+      expect(uncap_change[:before][:raw]).to eq(3)
+      expect(uncap_change[:after][:raw]).to eq(5)
+    end
+
+    it 'skips items the user does not own' do
+      updates = described_class.new(
+        user,
+        { 'list' => [weapon_item(game_id: 'w3', image_id: standard_weapon.granblue_id)] }
+      ).preview_updates
+
+      expect(updates).to be_empty
+    end
+
+    it 'surfaces an awakening change' do
+      item_no_awakening = weapon_item(game_id: 'w4', image_id: awakened_weapon.granblue_id, evolution: '5')
+      described_class.new(user, { 'list' => [item_no_awakening] }).import
+
+      item_awakened = weapon_item(game_id: 'w4', image_id: awakened_weapon.granblue_id, evolution: '5')
+      item_awakened['param']['arousal'] = {
+        'is_arousal_weapon' => true,
+        'level' => 10,
+        'form' => 1
+      }
+
+      updates = described_class.new(user, { 'list' => [item_awakened] }).preview_updates
+
+      expect(updates.size).to eq(1)
+      fields = updates.first[:changes].map { |c| c[:field] }
+      expect(fields).to include('awakening_id', 'awakening_level')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Two linked additions to support the extension's new collection-update detection UX.

**`POST /collection/{weapons,characters,summons}/check_updates`** — dry-run diff endpoint. Takes the same payload shape as `import`, in-memory-assigns it to the matching `CollectionX` record, and returns per-field deltas with display-ready labels. Reuses each service's `build_*_attrs` so the diff matches exactly what a real import would change — no duplicated parse logic. Skips records that don't exist (those are new, not updated).

**`GET /weapons/element_variants`** — returns per-weapon element-variant ID maps for Ultima/Atma/CCW/Superlative weapons. The extension uses this to resolve a base thumbnail when the game sends a variant-specific image ID whose thumbnail isn't uploaded to S3.

**`CollectionImport::ChangeFormatter`** — shared helper that resolves UUID FKs (awakenings, weapon keys, stat modifiers), element integers, boolean `perpetuity`, and jsonb rings into display strings on the server so the client doesn't need schema internals.

## Test plan

- [x] `bundle exec rspec spec/services/{weapon,character,summon}_import_service_spec.rb` — 12 new `#preview_updates` specs
- [x] `bundle exec rspec spec/requests/api/v1/collection_check_updates_spec.rb` — 7 request specs (auth, bad_request, deltas, non-owned skip, stats format)
- [ ] Manual curl against `/api/v1/collection/weapons/check_updates` with a payload matching an uncapped record → single entry with `uncap_level` delta