### PR TITLE
Allow non-owners to query unowned collection items

### DIFF
--- a/app/controllers/api/v1/collection_characters_controller.rb
+++ b/app/controllers/api/v1/collection_characters_controller.rb
@@ -12,8 +12,6 @@ module Api
 
       def index
         if params[:unowned].present?
-          return head :forbidden unless current_user && @target_user.id == current_user.id
-
           owned_ids = @target_user.collection_characters.select(:character_id)
           @characters = Character.where.not(id: owned_ids)
                                  .includes(:character_series_records)

--- a/app/controllers/api/v1/collection_summons_controller.rb
+++ b/app/controllers/api/v1/collection_summons_controller.rb
@@ -12,8 +12,6 @@ module Api
 
       def index
         if params[:unowned].present?
-          return head :forbidden unless current_user && @target_user.id == current_user.id
-
           owned_ids = @target_user.collection_summons.select(:summon_id).distinct
           @summons = Summon.where.not(id: owned_ids)
                            .includes(:summon_series)

--- a/app/controllers/api/v1/collection_weapons_controller.rb
+++ b/app/controllers/api/v1/collection_weapons_controller.rb
@@ -12,8 +12,6 @@ module Api
 
       def index
         if params[:unowned].present?
-          return head :forbidden unless current_user && @target_user.id == current_user.id
-
           owned_ids = @target_user.collection_weapons.select(:weapon_id).distinct
           @weapons = Weapon.where.not(id: owned_ids)
                            .includes(:weapon_series, :weapon_series_variant)

--- a/spec/requests/api/v1/collection_characters_spec.rb
+++ b/spec/requests/api/v1/collection_characters_spec.rb
@@ -134,8 +134,24 @@ RSpec.describe 'Collection Characters API', type: :request do
       expect(returned_ids).not_to include(owned_char.id)
     end
 
-    it 'returns 403 when requesting another user\'s unowned characters' do
+    it 'returns unowned characters when requesting another user with public collection' do
+      owned_char = create(:character)
+      unowned_char = create(:character)
+      create(:collection_character, user: other_user, character: owned_char)
+
       get "/api/v1/users/#{other_user.id}/collection/characters", params: { unowned: true }, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      returned_ids = json['characters'].map { |c| c['id'] }
+      expect(returned_ids).to include(unowned_char.id)
+      expect(returned_ids).not_to include(owned_char.id)
+    end
+
+    it 'returns 403 when requesting unowned characters from a private collection' do
+      private_user = create(:user, collection_privacy: :private_collection)
+
+      get "/api/v1/users/#{private_user.id}/collection/characters", params: { unowned: true }, headers: headers
 
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/api/v1/collection_summons_spec.rb
+++ b/spec/requests/api/v1/collection_summons_spec.rb
@@ -106,8 +106,24 @@ RSpec.describe 'Collection Summons API', type: :request do
       expect(json['meta']['count']).to eq(0)
     end
 
-    it 'returns 403 when requesting another user\'s unowned summons' do
+    it 'returns unowned summons when requesting another user with public collection' do
+      owned_smn = create(:summon)
+      unowned_smn = create(:summon)
+      create(:collection_summon, user: other_user, summon: owned_smn)
+
       get "/api/v1/users/#{other_user.id}/collection/summons", params: { unowned: true }, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      returned_ids = json['summons'].map { |s| s['id'] }
+      expect(returned_ids).to include(unowned_smn.id)
+      expect(returned_ids).not_to include(owned_smn.id)
+    end
+
+    it 'returns 403 when requesting unowned summons from a private collection' do
+      private_user = create(:user, collection_privacy: :private_collection)
+
+      get "/api/v1/users/#{private_user.id}/collection/summons", params: { unowned: true }, headers: headers
 
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/api/v1/collection_weapons_spec.rb
+++ b/spec/requests/api/v1/collection_weapons_spec.rb
@@ -108,8 +108,24 @@ RSpec.describe 'Collection Weapons API', type: :request do
       expect(json['meta']['count']).to eq(0)
     end
 
-    it 'returns 403 when requesting another user\'s unowned weapons' do
+    it 'returns unowned weapons when requesting another user with public collection' do
+      owned_wpn = create(:weapon)
+      unowned_wpn = create(:weapon)
+      create(:collection_weapon, user: other_user, weapon: owned_wpn)
+
       get "/api/v1/users/#{other_user.id}/collection/weapons", params: { unowned: true }, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      returned_ids = json['weapons'].map { |w| w['id'] }
+      expect(returned_ids).to include(unowned_wpn.id)
+      expect(returned_ids).not_to include(owned_wpn.id)
+    end
+
+    it 'returns 403 when requesting unowned weapons from a private collection' do
+      private_user = create(:user, collection_privacy: :private_collection)
+
+      get "/api/v1/users/#{private_user.id}/collection/weapons", params: { unowned: true }, headers: headers
 
       expect(response).to have_http_status(:forbidden)
     end


### PR DESCRIPTION
## Summary
- Removes the owner-only gate on `unowned=true` for `/api/v1/users/:user_id/collection/{characters,weapons,summons}`.
- Privacy is still enforced via the existing `check_collection_access` before_action, so viewers who can already see the owned list (public, or crew-only if in same crew) can now also see the missing list.
- Paired with hensei-svelte PR #840 which shows the Owned|Missing toggle to all viewers.

## Test plan
- [x] `bundle exec rspec spec/requests/api/v1/collection_{characters,weapons,summons}_spec.rb` — 78 examples, 0 failures
- [x] Updated specs: non-owner with public collection returns unowned items; non-owner with `private_collection` still gets 403