### PR TITLE
Let captains re-invite after expiration

### DIFF
--- a/app/controllers/api/v1/crew_invitations_controller.rb
+++ b/app/controllers/api/v1/crew_invitations_controller.rb
@@ -25,9 +25,15 @@ module Api
         raise CrewErrors::CannotInviteSelfError if user.id == current_user.id
         raise CrewErrors::AlreadyInCrewError if user.crew.present?
 
-        # Check for existing pending invitation
+        # Check for an existing pending invitation. Stale records still carry
+        # status :pending until something flips them, so transition expired ones
+        # before letting a fresh invite through.
         existing = @crew.crew_invitations.pending.find_by(user: user)
-        raise CrewErrors::UserAlreadyInvitedError if existing
+        if existing
+          raise CrewErrors::UserAlreadyInvitedError if existing.active?
+
+          existing.update!(status: :expired)
+        end
 
         invitation = @crew.crew_invitations.build(
           user: user,

--- a/spec/requests/api/v1/crew_invitations_spec.rb
+++ b/spec/requests/api/v1/crew_invitations_spec.rb
@@ -108,6 +108,24 @@ RSpec.describe 'Api::V1::CrewInvitations', type: :request do
         expect(json['code']).to eq('user_already_invited')
       end
 
+      it 'allows a fresh invite when the previous one expired' do
+        stale = create(:crew_invitation,
+                       crew: crew,
+                       user: invitee,
+                       invited_by: user,
+                       status: :pending,
+                       expires_at: 1.day.ago)
+
+        expect {
+          post "/api/v1/crews/#{crew.id}/invitations",
+               params: { user_id: invitee.id },
+               headers: auth_headers
+        }.to change(CrewInvitation, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(stale.reload.status).to eq('expired')
+      end
+
       context 'with phantom_player_id' do
         let!(:phantom) { create(:phantom_player, crew: crew) }
 


### PR DESCRIPTION
## Summary
- Fixes a bug where captains/vice captains couldn't re-invite a user whose previous invitation had expired
- `CrewInvitation` expiration is virtual (computed from `expires_at`), so a stale record's status stays `pending`. The controller's "already invited?" check matched it and returned 409 forever
- Now: if the existing pending invite is past `expires_at`, transition it to `status: :expired` (which clears the model's pending-scoped uniqueness validation) and let the new invite save

## Test plan
- [x] New RSpec covers "captain can re-invite after the previous invite has expired" — 21/21 pass
- [x] Existing "user already invited" case still returns 409 for active invites
- [ ] Manual: invite a user, backdate `expires_at`, send another invite — succeeds; old record now has `status: 'expired'`

Pairs with frontend PR jedmund/hensei-web#843.