### PR TITLE
Migrate substitution_note to jsonb for rich-text notes

### DIFF
--- a/app/blueprints/api/v1/character_blueprint.rb
+++ b/app/blueprints/api/v1/character_blueprint.rb
@@ -40,11 +40,9 @@ module Api
       end
 
       field :series do |c|
-        # Use new lookup table if available
-        records = c.character_series_records
-        if records.loaded? ? records.any? : records.exists?
-          sorted = records.loaded? ? records.sort_by(&:order) : records.ordered
-          sorted.map do |cs|
+        records = c.ordered_series_records
+        if records.any?
+          records.map do |cs|
             {
               id: cs.id,
               slug: cs.slug,
@@ -55,7 +53,7 @@ module Api
             }
           end
         else
-          # Legacy fallback - return integer array
+          # Legacy fallback for rows that haven't been migrated to the lookup table.
           c.series
         end
       end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -198,6 +198,18 @@ module Api
         raise UnauthorizedError unless current_user
       end
 
+      # Strong params can't deeply permit arbitrary nested JSON, so accept the
+      # rich-text Tiptap doc by re-attaching the raw value (hash, string, or nil)
+      # after the standard `permit` call.
+      def permit_substitution_note(permitted, raw_params)
+        return permitted unless raw_params.is_a?(ActionController::Parameters) || raw_params.is_a?(Hash)
+        return permitted unless raw_params.key?(:substitution_note)
+
+        value = raw_params[:substitution_note]
+        permitted[:substitution_note] = value.is_a?(ActionController::Parameters) ? value.to_unsafe_h : value
+        permitted
+      end
+
       # Returns the requested page size within valid bounds
       # Falls back to default if not specified or invalid
       # Reads from X-Per-Page header

--- a/app/controllers/api/v1/grid_characters_controller.rb
+++ b/app/controllers/api/v1/grid_characters_controller.rb
@@ -16,6 +16,7 @@ module Api
       include IdResolvable
       include CollectionSourceConcern
       include PartyAuthorizationConcern
+      include SubstituteGridPreloading
 
       before_action :find_grid_character,
                     only: %i[update update_uncap_level update_position destroy resolve sync sync_to_collection switch_style]
@@ -506,8 +507,12 @@ module Api
       # @return [void]
       def find_grid_character
         grid_character_id = params[:id] || params.dig(:character, :id) || params.dig(:resolve, :conflicting)
-        @grid_character = GridCharacter.includes(:awakening).find_by(id: grid_character_id)
-        render_not_found_response('grid_character') unless @grid_character
+        @grid_character = GridCharacter
+                          .includes(*GridCharacter::NESTED_BLUEPRINT_PRELOADS, :substitutions)
+                          .find_by(id: grid_character_id)
+        return render_not_found_response('grid_character') unless @grid_character
+
+        preload_substitute_grids!([@grid_character])
       end
 
       ##

--- a/app/controllers/api/v1/grid_characters_controller.rb
+++ b/app/controllers/api/v1/grid_characters_controller.rb
@@ -579,11 +579,10 @@ module Api
           :transcendence_step,
           :perpetuity,
           :role_id,
-          :substitution_note,
           awakening: %i[id level],
           rings: %i[modifier strength],
           earring: %i[modifier strength]
-        )
+        ).then { |p| permit_substitution_note(p, params[:character]) }
       end
 
       ##

--- a/app/controllers/api/v1/grid_summons_controller.rb
+++ b/app/controllers/api/v1/grid_summons_controller.rb
@@ -521,10 +521,11 @@ module Api
       #
       # @return [ActionController::Parameters] The permitted parameters.
       def summon_params
-        params.require(:summon).permit(:id, :party_id, :summon_id, :collection_summon_id,
-                                       :position, :main, :friend, :quick_summon,
-                                       :uncap_level, :transcendence_step,
-                                       :role_id, :substitution_note)
+        permitted = params.require(:summon).permit(:id, :party_id, :summon_id, :collection_summon_id,
+                                                   :position, :main, :friend, :quick_summon,
+                                                   :uncap_level, :transcendence_step,
+                                                   :role_id)
+        permit_substitution_note(permitted, params[:summon])
       end
 
       ##

--- a/app/controllers/api/v1/grid_summons_controller.rb
+++ b/app/controllers/api/v1/grid_summons_controller.rb
@@ -13,6 +13,7 @@ module Api
       include IdResolvable
       include CollectionSourceConcern
       include PartyAuthorizationConcern
+      include SubstituteGridPreloading
 
       attr_reader :party, :incoming_summon
 
@@ -419,8 +420,12 @@ module Api
       # @return [void]
       def find_grid_summon
         grid_summon_id = params[:id] || params.dig(:summon, :id) || params.dig(:resolve, :conflicting)
-        @grid_summon = GridSummon.find_by(id: grid_summon_id)
-        render_not_found_response('grid_summon') unless @grid_summon
+        @grid_summon = GridSummon
+                       .includes(*GridSummon::NESTED_BLUEPRINT_PRELOADS, :substitutions)
+                       .find_by(id: grid_summon_id)
+        return render_not_found_response('grid_summon') unless @grid_summon
+
+        preload_substitute_grids!([@grid_summon])
       end
 
       ##

--- a/app/controllers/api/v1/grid_weapons_controller.rb
+++ b/app/controllers/api/v1/grid_weapons_controller.rb
@@ -13,6 +13,7 @@ module Api
       include IdResolvable
       include CollectionSourceConcern
       include PartyAuthorizationConcern
+      include SubstituteGridPreloading
 
       before_action :find_grid_weapon, only: %i[update update_uncap_level update_position resolve destroy sync sync_to_collection duplicate]
       before_action :find_party, only: %i[create update update_uncap_level update_position swap resolve destroy sync sync_to_collection duplicate]
@@ -504,8 +505,12 @@ module Api
       # @return [void]
       def find_grid_weapon
         grid_weapon_id = params[:id] || params.dig(:weapon, :id) || params.dig(:resolve, :conflicting)
-        @grid_weapon = GridWeapon.find_by(id: grid_weapon_id)
-        render_not_found_response('grid_weapon') unless @grid_weapon
+        @grid_weapon = GridWeapon
+                       .includes(*GridWeapon::NESTED_BLUEPRINT_PRELOADS, :substitutions)
+                       .find_by(id: grid_weapon_id)
+        return render_not_found_response('grid_weapon') unless @grid_weapon
+
+        preload_substitute_grids!([@grid_weapon])
       end
 
       ##

--- a/app/controllers/api/v1/grid_weapons_controller.rb
+++ b/app/controllers/api/v1/grid_weapons_controller.rb
@@ -586,9 +586,9 @@ module Api
           :ax_modifier1_id, :ax_modifier2_id, :ax_strength1, :ax_strength2,
           :befoulment_modifier_id, :befoulment_strength, :exorcism_level,
           :awakening_id, :awakening_level,
-          :role_id, :substitution_note,
+          :role_id,
           bullets: [:position, :bullet_id]
-        )
+        ).then { |p| permit_substitution_note(p, params[:weapon]) }
       end
 
       ##

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -8,6 +8,7 @@ module Api
       include PartyAuthorizationConcern
       include PartyQueryingConcern
       include PartyPreviewConcern
+      include SubstituteGridPreloading
 
       # Constants used for filtering validations.
 
@@ -431,26 +432,9 @@ module Api
       def set_from_slug
         @party = Party.includes(
           :user, :job, { raid: :group },
-          { characters: [
-            { character: [:character_series_records, :style_swap_variants] },
-            :awakening, :grid_artifact, :collection_character, :role,
-            { substitutions: :substitute_grid }
-          ] },
-          { weapons: {
-            weapon: [:awakenings, :weapon_series, :weapon_series_variant, :weapon_skills, :recruited_character, :base_weapon, :forge_chain_weapons],
-            collection_weapon: { collection_weapon_bullets: {} },
-            awakening: {},
-            weapon_key1: {},
-            weapon_key2: {},
-            weapon_key3: {},
-            ax_modifier1: {},
-            ax_modifier2: {},
-            befoulment_modifier: {},
-            grid_weapon_bullets: :bullet,
-            role: {},
-            substitutions: :substitute_grid
-          } },
-          { summons: [{ summon: :summon_series }, :collection_summon, :role, { substitutions: :substitute_grid }] },
+          { characters: GridCharacter::NESTED_BLUEPRINT_PRELOADS + [{ substitutions: :substitute_grid }] },
+          { weapons: GridWeapon::NESTED_BLUEPRINT_PRELOADS + [{ substitutions: :substitute_grid }] },
+          { summons: GridSummon::NESTED_BLUEPRINT_PRELOADS + [{ substitutions: :substitute_grid }] },
           :guidebook1, :guidebook2, :guidebook3,
           { source_party: [{ characters: :character }, { weapons: :weapon }, { summons: :summon }] },
           { remixes: [{ characters: :character }, { weapons: :weapon }, { summons: :summon }] },
@@ -460,56 +444,7 @@ module Api
 
         return render_not_found_response('party') unless @party
 
-        preload_substitute_grids!(@party)
-      end
-
-      # The polymorphic `substitutions.substitute_grid` association can't carry
-      # nested preloads through `includes`, so each substitute renders as its own
-      # N+1 fan-out (character → series, weapon → keys, etc.). Group the
-      # already-loaded substitute_grid records by type and run a typed preload
-      # against each group so the nested-blueprint render is hot.
-      def preload_substitute_grids!(party)
-        all_substitutions = (party.characters + party.weapons + party.summons).flat_map(&:substitutions)
-        return if all_substitutions.empty?
-
-        char_subs = filter_substitute_grids(all_substitutions, GridCharacter)
-        weapon_subs = filter_substitute_grids(all_substitutions, GridWeapon)
-        summon_subs = filter_substitute_grids(all_substitutions, GridSummon)
-
-        if char_subs.any?
-          ActiveRecord::Associations::Preloader.new(
-            records: char_subs,
-            associations: [
-              { character: [:character_series_records, :style_swap_variants] },
-              :awakening, :grid_artifact, :role
-            ]
-          ).call
-        end
-
-        if weapon_subs.any?
-          ActiveRecord::Associations::Preloader.new(
-            records: weapon_subs,
-            associations: [
-              { weapon: [:awakenings, :weapon_series, :weapon_series_variant, :weapon_skills, :recruited_character, :base_weapon, :forge_chain_weapons] },
-              :awakening, :weapon_key1, :weapon_key2, :weapon_key3,
-              :ax_modifier1, :ax_modifier2, :befoulment_modifier,
-              { grid_weapon_bullets: :bullet }, :role
-            ]
-          ).call
-        end
-
-        return unless summon_subs.any?
-
-        ActiveRecord::Associations::Preloader.new(
-          records: summon_subs,
-          associations: [{ summon: :summon_series }, :role]
-        ).call
-      end
-
-      def filter_substitute_grids(substitutions, klass)
-        substitutions
-          .select { |s| s.substitute_grid_type == klass.name }
-          .filter_map(&:substitute_grid)
+        preload_substitute_grids!(@party.characters + @party.weapons + @party.summons)
       end
 
       # Loads the party by its id.

--- a/app/controllers/concerns/substitute_grid_preloading.rb
+++ b/app/controllers/concerns/substitute_grid_preloading.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Shared helper for hydrating the polymorphic substitute_grid records that
+# hang off a substitution row.
+#
+# `includes(substitutions: :substitute_grid)` cannot carry nested preloads
+# through the polymorphic association, so each substitute would otherwise
+# fan out into its own per-record N+1 (character → series, weapon → keys,
+# summon → series). Group the already-loaded substitutes by type and run a
+# typed Preloader against each group using the per-grid
+# `NESTED_BLUEPRINT_PRELOADS` constants.
+module SubstituteGridPreloading
+  extend ActiveSupport::Concern
+
+  GRID_KLASSES = [GridCharacter, GridWeapon, GridSummon].freeze
+
+  # Hydrate the substitute_grid records nested inside the given grids'
+  # substitutions, in-place.
+  #
+  # @param grids [Enumerable<GridCharacter, GridWeapon, GridSummon>] grids
+  #   whose `substitutions` association is already loaded.
+  def preload_substitute_grids!(grids)
+    substitutions = Array(grids).flat_map(&:substitutions)
+    return if substitutions.empty?
+
+    GRID_KLASSES.each do |klass|
+      records = substitutions
+                .select { |s| s.substitute_grid_type == klass.name }
+                .filter_map(&:substitute_grid)
+      next if records.empty?
+
+      ActiveRecord::Associations::Preloader.new(
+        records: records,
+        associations: klass::NESTED_BLUEPRINT_PRELOADS
+      ).call
+    end
+  end
+end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -85,20 +85,24 @@ class Character < ApplicationRecord
     GranblueEnums::CHARACTER_SEASONS.key(season)&.to_s
   end
 
-  def series_names
-    # Use new lookup table if available
-    if character_series_records.loaded? ? character_series_records.any? : character_series_records.exists?
-      if character_series_records.loaded?
-        character_series_records.sort_by(&:order).map(&:name_en)
-      else
-        character_series_records.ordered.pluck(:name_en)
-      end
-    elsif series.present?
-      # Legacy fallback
-      series.filter_map { |s| GranblueEnums::CHARACTER_SERIES.key(s)&.to_s }
+  # Returns character_series_records sorted by `order`, reusing the loaded
+  # association when preloaded. Both the `series` and `series_names` blueprint
+  # fields read through here so a single query (or cache hit) feeds both.
+  def ordered_series_records
+    if character_series_records.loaded?
+      character_series_records.sort_by(&:order)
     else
-      []
+      character_series_records.ordered.to_a
     end
+  end
+
+  def series_names
+    records = ordered_series_records
+    return records.map(&:name_en) if records.any?
+    return [] unless series.present?
+
+    # Legacy fallback for rows that haven't been migrated to the lookup table.
+    series.filter_map { |s| GranblueEnums::CHARACTER_SERIES.key(s)&.to_s }
   end
 
   def series_objects

--- a/app/models/grid_character.rb
+++ b/app/models/grid_character.rb
@@ -29,6 +29,14 @@ class GridCharacter < ApplicationRecord
 
   has_one :grid_artifact, dependent: :destroy
 
+  # Associations the nested blueprint walks. Reused by controllers and the
+  # polymorphic substitute-grid preloader so a single source of truth keeps
+  # them in sync as the blueprint evolves.
+  NESTED_BLUEPRINT_PRELOADS = [
+    :awakening, :grid_artifact, :role, :collection_character,
+    { character: [:character_series_records, :style_swap_variants] }
+  ].freeze
+
   # Validations
   validates_presence_of :party
 

--- a/app/models/grid_summon.rb
+++ b/app/models/grid_summon.rb
@@ -21,6 +21,14 @@ class GridSummon < ApplicationRecord
   has_many :substitutions, as: :grid, dependent: :destroy
   validates_presence_of :party
 
+  # Associations the nested blueprint walks. Reused by controllers and the
+  # polymorphic substitute-grid preloader so a single source of truth keeps
+  # them in sync as the blueprint evolves.
+  NESTED_BLUEPRINT_PRELOADS = [
+    :role, :collection_summon,
+    { summon: :summon_series }
+  ].freeze
+
   # Orphan status scopes
   scope :orphaned, -> { where(orphaned: true) }
   scope :not_orphaned, -> { where(orphaned: false) }

--- a/app/models/grid_weapon.rb
+++ b/app/models/grid_weapon.rb
@@ -50,6 +50,19 @@ class GridWeapon < ApplicationRecord
   has_many :grid_weapon_bullets, dependent: :destroy
   has_many :bullets, through: :grid_weapon_bullets
 
+  # Associations the nested blueprint walks. Reused by controllers and the
+  # polymorphic substitute-grid preloader so a single source of truth keeps
+  # them in sync as the blueprint evolves.
+  NESTED_BLUEPRINT_PRELOADS = [
+    :awakening, :role,
+    :weapon_key1, :weapon_key2, :weapon_key3,
+    :ax_modifier1, :ax_modifier2, :befoulment_modifier,
+    { grid_weapon_bullets: :bullet },
+    { collection_weapon: :collection_weapon_bullets },
+    { weapon: %i[awakenings weapon_series weapon_series_variant weapon_skills
+                 recruited_character base_weapon forge_chain_weapons] }
+  ].freeze
+
   # Orphan status scopes
   scope :orphaned, -> { where(orphaned: true) }
   scope :not_orphaned, -> { where(orphaned: false) }

--- a/db/migrate/20260510000000_change_substitution_note_to_jsonb.rb
+++ b/db/migrate/20260510000000_change_substitution_note_to_jsonb.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class ChangeSubstitutionNoteToJsonb < ActiveRecord::Migration[8.0]
+  TABLES = %i[grid_characters grid_weapons grid_summons].freeze
+
+  def up
+    TABLES.each do |table|
+      # Existing values are plain text. Wrap each non-null string into a Tiptap
+      # doc shape so the frontend doesn't have to special-case legacy rows.
+      change_column(
+        table,
+        :substitution_note,
+        :jsonb,
+        using: <<~SQL.squish
+          CASE
+            WHEN substitution_note IS NULL OR substitution_note = '' THEN NULL
+            ELSE jsonb_build_object(
+              'type', 'doc',
+              'content', jsonb_build_array(
+                jsonb_build_object(
+                  'type', 'paragraph',
+                  'content', jsonb_build_array(
+                    jsonb_build_object('type', 'text', 'text', substitution_note)
+                  )
+                )
+              )
+            )
+          END
+        SQL
+      )
+    end
+  end
+
+  def down
+    TABLES.each do |table|
+      change_column(
+        table,
+        :substitution_note,
+        :text,
+        using: 'substitution_note::text'
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -485,7 +485,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.uuid "collection_character_id"
     t.boolean "is_substitute", default: false, null: false
     t.uuid "role_id"
-    t.text "substitution_note"
+    t.jsonb "substitution_note"
     t.index ["awakening_id"], name: "index_grid_characters_on_awakening_id"
     t.index ["character_id"], name: "index_grid_characters_on_character_id"
     t.index ["collection_character_id"], name: "index_grid_characters_on_collection_character_id"
@@ -509,7 +509,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.boolean "orphaned", default: false, null: false
     t.boolean "is_substitute", default: false, null: false
     t.uuid "role_id"
-    t.text "substitution_note"
+    t.jsonb "substitution_note"
     t.index ["collection_summon_id"], name: "index_grid_summons_on_collection_summon_id"
     t.index ["orphaned"], name: "index_grid_summons_on_orphaned"
     t.index ["party_id", "position"], name: "index_grid_summons_on_party_id_and_position"
@@ -556,7 +556,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.integer "exorcism_level", default: 0
     t.boolean "is_substitute", default: false, null: false
     t.uuid "role_id"
-    t.text "substitution_note"
+    t.jsonb "substitution_note"
     t.index ["awakening_id"], name: "index_grid_weapons_on_awakening_id"
     t.index ["ax_modifier1_id"], name: "index_grid_weapons_on_ax_modifier1_id"
     t.index ["ax_modifier2_id"], name: "index_grid_weapons_on_ax_modifier2_id"

--- a/spec/requests/api/v1/grid_characters_spec.rb
+++ b/spec/requests/api/v1/grid_characters_spec.rb
@@ -447,4 +447,32 @@ RSpec.describe 'GridCharacters API', type: :request do
       expect { existing.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  describe 'rich-text substitution_note round-trip' do
+    let(:tiptap_doc) do
+      {
+        'type' => 'doc',
+        'content' => [
+          {
+            'type' => 'paragraph',
+            'content' => [
+              { 'type' => 'text', 'marks' => [{ 'type' => 'bold' }], 'text' => 'Swap' },
+              { 'type' => 'text', 'text' => ' for fire teams' }
+            ]
+          }
+        ]
+      }
+    end
+
+    it 'persists and reads back a Tiptap document on substitution_note' do
+      grid_character = create(:grid_character, party: party)
+
+      put "/api/v1/grid_characters/#{grid_character.id}",
+          params: { character: { substitution_note: tiptap_doc } }.to_json,
+          headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(grid_character.reload.substitution_note).to eq(tiptap_doc)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Migrates `substitution_note` from `text` to `jsonb` on `grid_characters`, `grid_weapons`, `grid_summons`. Existing string values are wrapped into a minimal Tiptap doc (`{ type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: <legacy> }] }] }`) so the frontend doesn't have to special-case legacy rows.
- Updates the three grid item controllers' permit lists to accept a hash for `substitution_note` via a new shared `permit_substitution_note(permitted, raw_params)` helper on `ApiController`. Strong params can't deeply permit arbitrary nested JSON, so we re-attach the raw value (hash, string, or nil) after the standard `permit` call.
- Adds a request spec asserting that posting a Tiptap doc to `PUT /grid_characters/:id` round-trips correctly.

Stacked on top of #369. Required by the upcoming role-tab UI which writes rich-text Tiptap JSON instead of plain strings.

## Test plan
- [x] `rails db:migrate` succeeds; legacy string values become valid Tiptap docs
- [x] `bundle exec rspec` full suite green
- [x] `bundle exec rubocop` clean on changed files
- [ ] Manual: round-trip a Tiptap doc via the upcoming web UI
- [ ] Manual: existing string-only notes still render as paragraphs in the new editor