### PR TITLE
Add 4 new races to enum

### DIFF
--- a/app/models/concerns/granblue_enums.rb
+++ b/app/models/concerns/granblue_enums.rb
@@ -40,7 +40,11 @@ module GranblueEnums
     Draph: 3,
     Harvin: 4,
     Primal: 5,
-    None: 6
+    None: 6,
+    Geonoid: 7,
+    Levleath: 8,
+    Grokkle: 9,
+    Wolvir: 10
   }.freeze
 
   # Character seasons - display disambiguation for seasonal variants (e.g., "Vane [Halloween]")


### PR DESCRIPTION
## Summary
- Extend `GranblueEnums::RACES` with Geonoid (7), Levleath (8), Grokkle (9), Wolvir (10)

No migration needed — race1/race2 are permissive integer columns and existing serializers/filters work for any int. Frontend counterpart in jedmund/hensei-web.

## Test plan
- [ ] `GranblueEnums::RACES[:Geonoid]` returns 7 (and matches for the other 3)
- [ ] Character with `race1: 7, race2: 8` saves; blueprint returns `[7, 8]`
- [ ] Search/collection race filter returns matches for `race=7..10`