### PR TITLE
add party difficulty scoring engine

### DIFF
--- a/app/blueprints/api/v1/difficulty_blueprint.rb
+++ b/app/blueprints/api/v1/difficulty_blueprint.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class DifficultyBlueprint < ApiBlueprint
+      fields :name, :slug, :description, :min_score, :max_score, :sort_order, :color
+
+      view :nested do
+        fields :name, :slug, :color, :sort_order
+      end
+
+      view :list do
+        include_view :nested
+        fields :description, :min_score, :max_score
+      end
+
+      view :full do
+        fields :created_at, :updated_at
+      end
+    end
+  end
+end

--- a/app/blueprints/api/v1/difficulty_component_blueprint.rb
+++ b/app/blueprints/api/v1/difficulty_component_blueprint.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class DifficultyComponentBlueprint < ApiBlueprint
+      fields :name, :weight, :enabled, :min_count_to_score,
+             :created_at, :updated_at
+    end
+  end
+end

--- a/app/blueprints/api/v1/difficulty_component_blueprint.rb
+++ b/app/blueprints/api/v1/difficulty_component_blueprint.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class DifficultyComponentBlueprint < ApiBlueprint
-      fields :name, :weight, :enabled, :min_count_to_score,
+      fields :name, :weight, :enabled, :min_count_to_score, :target_max,
              :created_at, :updated_at
     end
   end

--- a/app/blueprints/api/v1/difficulty_rule_blueprint.rb
+++ b/app/blueprints/api/v1/difficulty_rule_blueprint.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class DifficultyRuleBlueprint < ApiBlueprint
+      fields :name, :description, :component, :rule_type, :params, :weight, :active,
+             :created_at, :updated_at
+
+      view :nested do
+        fields :name, :component, :rule_type, :weight, :active
+      end
+    end
+  end
+end

--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -36,6 +36,17 @@ module Api
         { mod: party.boost_mod, side: party.boost_side }
       end
 
+      field :difficulty do |party|
+        next nil unless party.difficulty_score.present?
+
+        {
+          tier: party.difficulty ? DifficultyBlueprint.render_as_hash(party.difficulty, view: :nested) : nil,
+          score: party.difficulty_score.to_f,
+          breakdown: party.difficulty_breakdown,
+          computed_at: party.difficulty_computed_at
+        }
+      end
+
       # Minimal view for embedding in grid item responses
       view :collection_source do
         field :collection_source_user_id

--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -36,6 +36,12 @@ module Api
         { mod: party.boost_mod, side: party.boost_side }
       end
 
+      # `score` is a weighted average over only those components whose
+      # weighted_score is strictly positive — components that are present but
+      # fired no rules are excluded from the denominator (see Calculator
+      # #composite_score). One consequence: adding a rule that fires for the
+      # first time on a previously-empty component can *lower* the score if
+      # that component's raw_score is below the existing composite.
       field :difficulty do |party|
         next nil unless party.difficulty_score.present?
 

--- a/app/jobs/party_difficulty/score_job.rb
+++ b/app/jobs/party_difficulty/score_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  class ScoreJob < ApplicationJob
+    queue_as :maintenance
+
+    discard_on ActiveRecord::RecordNotFound
+
+    def perform(party_id)
+      Persister.call(party_id)
+    end
+  end
+end

--- a/app/jobs/party_difficulty/sweep_job.rb
+++ b/app/jobs/party_difficulty/sweep_job.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  ##
+  # Daily sweep that recomputes difficulty for parties with a stale value.
+  # A party is considered stale when:
+  #   - difficulty_computed_at is older than STALE_AFTER (30 days), OR
+  #   - difficulty_ruleset_version is below the current version (rules changed), OR
+  #   - the party has never been scored AND meets the scoreability threshold
+  #
+  # Pages through stale parties in batches and enqueues a ScoreJob for each.
+  # The actual scoring happens in ScoreJob so failures are isolated per-party.
+  class SweepJob < ApplicationJob
+    queue_as :maintenance
+
+    STALE_AFTER = 30.days
+    BATCH_SIZE = 500
+
+    def perform
+      current_version = DifficultyConfig.current_version
+      stale_cutoff = STALE_AFTER.ago
+
+      stale_scope(current_version, stale_cutoff).find_in_batches(batch_size: BATCH_SIZE) do |batch|
+        batch.each { |party| ScoreJob.perform_later(party.id) }
+      end
+    end
+
+    private
+
+    def stale_scope(current_version, stale_cutoff)
+      enabled = DifficultyComponent.enabled.index_by(&:name)
+      min_weapons = enabled['weapon']&.min_count_to_score.to_i
+      min_chars = enabled['character']&.min_count_to_score.to_i
+      min_summons = enabled['summon']&.min_count_to_score.to_i
+
+      Party
+        .where('weapons_count >= ? AND characters_count >= ? AND summons_count >= ?',
+               min_weapons, min_chars, min_summons)
+        .where(
+          'difficulty_computed_at IS NULL OR difficulty_computed_at < ? OR difficulty_ruleset_version IS NULL OR difficulty_ruleset_version < ?',
+          stale_cutoff, current_version
+        )
+    end
+  end
+end

--- a/app/models/difficulty.rb
+++ b/app/models/difficulty.rb
@@ -9,6 +9,7 @@ class Difficulty < ApplicationRecord
   validates :min_score, :max_score, presence: true,
                                     numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
   validate :max_score_greater_than_min_score
+  validate :tier_coverage_complete
 
   after_save :bump_ruleset_version
   after_destroy :bump_ruleset_version
@@ -31,6 +32,38 @@ class Difficulty < ApplicationRecord
     return if min_score.blank? || max_score.blank?
 
     errors.add(:max_score, 'must be greater than min_score') if max_score <= min_score
+  end
+
+  # The set of all tiers must tile [0, 100] with no overlaps and no gaps wider
+  # than one score quantum (Calculator#composite_score rounds to 2 decimals, so
+  # adjacent tiers may sit at .99 / .00 with a 0.01 difference). For multi-tier
+  # edits (e.g. splitting one tier in two), batch the changes through
+  # PartyDifficulty::DraftWorkspace so the intermediate state isn't persisted.
+  TIER_QUANTUM = 0.01
+
+  def tier_coverage_complete
+    return if min_score.blank? || max_score.blank? || max_score <= min_score
+
+    proposed = (Difficulty.where.not(id: id).to_a + [self]).sort_by { |t| t.min_score.to_f }
+
+    if proposed.first.min_score.to_f.abs > TIER_QUANTUM
+      errors.add(:base, 'tier coverage must start at 0.00')
+      return
+    end
+    if (100.0 - proposed.last.max_score.to_f).abs > TIER_QUANTUM
+      errors.add(:base, 'tier coverage must end at 100.00')
+      return
+    end
+
+    proposed.each_cons(2).find do |prev_tier, next_tier|
+      gap = next_tier.min_score.to_f - prev_tier.max_score.to_f
+      if gap.negative?
+        errors.add(:base, "tier overlaps an existing tier near #{prev_tier.max_score}")
+      elsif gap > TIER_QUANTUM + 1e-6
+        errors.add(:base, "tier leaves a coverage gap between #{prev_tier.max_score} and #{next_tier.min_score}")
+      end
+      errors[:base].any?
+    end
   end
 
   def bump_ruleset_version

--- a/app/models/difficulty.rb
+++ b/app/models/difficulty.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Difficulty < ApplicationRecord
+  has_many :parties, dependent: :nullify
+
+  validates :name, presence: true
+  validates :slug, presence: true, uniqueness: true,
+                   format: { with: /\A[a-z0-9_-]+\z/, message: 'lowercase letters, numbers, hyphens and underscores only' }
+  validates :min_score, :max_score, presence: true,
+                                    numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
+  validate :max_score_greater_than_min_score
+
+  after_save :bump_ruleset_version
+  after_destroy :bump_ruleset_version
+
+  scope :ordered, -> { order(:sort_order, :min_score) }
+
+  def self.for_score(score)
+    return nil if score.nil?
+
+    ordered.detect { |d| score >= d.min_score && score <= d.max_score }
+  end
+
+  def blueprint
+    DifficultyBlueprint
+  end
+
+  private
+
+  def max_score_greater_than_min_score
+    return if min_score.blank? || max_score.blank?
+
+    errors.add(:max_score, 'must be greater than min_score') if max_score <= min_score
+  end
+
+  def bump_ruleset_version
+    DifficultyConfig.bump_version!
+  end
+end

--- a/app/models/difficulty_component.rb
+++ b/app/models/difficulty_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class DifficultyComponent < ApplicationRecord
+  COMPONENTS = %w[weapon character summon job accessory].freeze
+
+  validates :name, presence: true, inclusion: { in: COMPONENTS }, uniqueness: true
+  validates :weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validates :min_count_to_score, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  after_save :bump_ruleset_version
+  after_destroy :bump_ruleset_version
+
+  scope :enabled, -> { where(enabled: true) }
+
+  def self.for(name)
+    find_by(name: name.to_s)
+  end
+
+  def blueprint
+    DifficultyComponentBlueprint
+  end
+
+  private
+
+  def bump_ruleset_version
+    DifficultyConfig.bump_version!
+  end
+end

--- a/app/models/difficulty_config.rb
+++ b/app/models/difficulty_config.rb
@@ -9,6 +9,10 @@
 class DifficultyConfig < ApplicationRecord
   def self.instance
     first || create!(ruleset_version: 1)
+  rescue ActiveRecord::RecordNotUnique
+    # Two callers raced past the `first` check; one inserted, one lost the
+    # unique-index check. Re-read the winning row.
+    first
   end
 
   def self.current_version

--- a/app/models/difficulty_config.rb
+++ b/app/models/difficulty_config.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+##
+# Singleton config row for the difficulty scoring system.
+# Stores the ruleset_version counter, which is bumped any time a Difficulty,
+# DifficultyRule, or DifficultyComponent is saved or destroyed. The counter is
+# used to invalidate parties whose stored difficulty was computed under an older
+# ruleset.
+class DifficultyConfig < ApplicationRecord
+  def self.instance
+    first || create!(ruleset_version: 1)
+  end
+
+  def self.current_version
+    instance.ruleset_version
+  end
+
+  def self.bump_version!
+    record = instance
+    record.with_lock do
+      record.update_column(:ruleset_version, record.ruleset_version + 1)
+    end
+    record.ruleset_version
+  end
+end

--- a/app/models/difficulty_rule.rb
+++ b/app/models/difficulty_rule.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class DifficultyRule < ApplicationRecord
+  validates :name, presence: true
+  validates :component, presence: true, inclusion: { in: DifficultyComponent::COMPONENTS }
+  validates :rule_type, presence: true, inclusion: { in: ->(_) { PartyDifficulty::Rules.registered_types } }
+  validates :weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validate :params_valid_for_rule_type
+
+  after_save :bump_ruleset_version
+  after_destroy :bump_ruleset_version
+
+  scope :active, -> { where(active: true) }
+  scope :for_component, ->(component) { where(component: component.to_s) }
+
+  def implementation
+    @implementation ||= PartyDifficulty::Rules.build(rule_type, params)
+  end
+
+  def applies_to?(party)
+    implementation.applies?(party)
+  end
+
+  def blueprint
+    DifficultyRuleBlueprint
+  end
+
+  private
+
+  def params_valid_for_rule_type
+    return if rule_type.blank? || !PartyDifficulty::Rules.registered_types.include?(rule_type)
+
+    errors.add(:params, "invalid for rule_type #{rule_type}: #{implementation_errors.join(', ')}") unless implementation_errors.empty?
+  end
+
+  def implementation_errors
+    PartyDifficulty::Rules.validate_params(rule_type, params || {})
+  rescue StandardError => e
+    [e.message]
+  end
+
+  def bump_ruleset_version
+    DifficultyConfig.bump_version!
+  end
+end

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -179,7 +179,13 @@ class Party < ApplicationRecord
 
   after_commit :update_element!, on: %i[create update]
   after_commit :update_extra!, on: %i[create update]
-  after_commit :enqueue_difficulty_recompute!, on: %i[create update]
+  after_commit :enqueue_difficulty_recompute_if_scoring_changed!, on: %i[create update]
+
+  # Columns whose value actually affects the difficulty score. Edits to other
+  # columns (description, shortcode, boost_mod, element, …) do not need to
+  # re-trigger the scoring engine, so the after_commit guard skips them.
+  SCORING_COLUMNS = %w[weapons_count characters_count summons_count job_id accessory_id
+                       ultimate_mastery].freeze
 
   # Amoeba configuration
   amoeba do
@@ -263,12 +269,19 @@ class Party < ApplicationRecord
 
   ##
   # Enqueues a background job to recompute the party's difficulty score.
-  # Safe to call frequently — Sidekiq dedupes by argument is not used here, but
-  # the job is cheap and idempotent.
+  # Callers that bypass callbacks (update_column, counter-cache writes) must
+  # invoke this directly; the after_commit hook on the model uses the guarded
+  # variant below to avoid recomputing on unrelated edits.
   #
   # @return [void]
   def enqueue_difficulty_recompute!
     PartyDifficulty::ScoreJob.perform_later(id) if id.present?
+  end
+
+  def enqueue_difficulty_recompute_if_scoring_changed!
+    return unless previously_new_record? || saved_changes.keys.intersect?(SCORING_COLUMNS)
+
+    enqueue_difficulty_recompute!
   end
 
   ##

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -104,6 +104,7 @@ class Party < ApplicationRecord
   belongs_to :collection_source_user, class_name: 'User', optional: true
   belongs_to :raid, optional: true
   belongs_to :job, optional: true
+  belongs_to :difficulty, optional: true
 
   belongs_to :accessory,
              foreign_key: 'accessory_id',
@@ -178,6 +179,7 @@ class Party < ApplicationRecord
 
   after_commit :update_element!, on: %i[create update]
   after_commit :update_extra!, on: %i[create update]
+  after_commit :enqueue_difficulty_recompute!, on: %i[create update]
 
   # Amoeba configuration
   amoeba do
@@ -188,6 +190,11 @@ class Party < ApplicationRecord
     nullify :description
     nullify :shortcode
     nullify :edit_key
+    nullify :difficulty_id
+    nullify :difficulty_score
+    nullify :difficulty_breakdown
+    nullify :difficulty_computed_at
+    nullify :difficulty_ruleset_version
 
     include_association :characters
     include_association :weapons
@@ -249,7 +256,19 @@ class Party < ApplicationRecord
   #
   # @return [Boolean] true if the update succeeded.
   def mark_updated!
-    update_column(:last_updated, Time.current)
+    result = update_column(:last_updated, Time.current)
+    enqueue_difficulty_recompute!
+    result
+  end
+
+  ##
+  # Enqueues a background job to recompute the party's difficulty score.
+  # Safe to call frequently — Sidekiq dedupes by argument is not used here, but
+  # the job is cheap and idempotent.
+  #
+  # @return [void]
+  def enqueue_difficulty_recompute!
+    PartyDifficulty::ScoreJob.perform_later(id) if id.present?
   end
 
   ##

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -310,10 +310,20 @@ module PartyDifficulty
       []
     end
 
+    # The composite is a weighted average over only those components whose
+    # weighted_score is strictly positive. Components that are absent (no data)
+    # AND components that are present but fired zero rules are both excluded
+    # from the denominator. This is intentional: a team with a non-Origin job
+    # should not be penalized in the denominator just for having a job.
+    #
+    # NOTE — non-monotonic side effect: because zero-scoring components are
+    # excluded entirely, adding a rule that fires for the first time on a
+    # previously-empty component will *introduce* that component's weight to
+    # the denominator. If the new component's raw_score is below the current
+    # composite, the composite will *drop* even though investment grew. This
+    # is a calibrated trade-off — see DifficultyBlueprint and the difficulty
+    # scoring docs for the rationale.
     def composite_score(breakdowns)
-      # Skip components that aren't present (no data) OR that had data but
-      # fired no rules at all (raw_score == 0). A team with a non-Origin job
-      # shouldn't be penalized in the denominator just for having a job.
       contributing = breakdowns.select do |b|
         b[:weighted_score].present? && b[:weighted_score].positive?
       end

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -16,7 +16,7 @@ module PartyDifficulty
     Result = Struct.new(:scoreable, :score, :difficulty, :breakdown, :ruleset_version, keyword_init: true)
 
     EAGER_LOAD = {
-      weapons: [:awakening, :grid_weapon_bullets, { weapon: :weapon_series }],
+      weapons: [:awakening, :grid_weapon_bullets, { weapon: %i[weapon_series recruited_character] }],
       characters: [{ character: :character_series_records }],
       summons: [{ summon: :summon_series }],
       job: [],
@@ -226,11 +226,13 @@ module PartyDifficulty
 
     ##
     # Returns the actual + max contribution for a single rule, taking the
-    # scale_by_count / max_count params into account when present.
+    # scale_by_count / max_count params and any per-match decay factors into
+    # account.
     def rule_contribution(rule)
       impl = rule.implementation
       params = (rule.params || {}).with_indifferent_access
-      count = safely_count(impl)
+      factors = safely_factors(impl)
+      count = factors.size
       min_count = impl.min_count
       weight = rule.weight.to_f
 
@@ -241,23 +243,29 @@ module PartyDifficulty
       max_value = scale ? weight * max_count : weight
 
       if count < min_count
-        { rule: rule, count: count, contribution: 0.0, max: max_value,
-          base_weight: weight, scale_by_count: scale }
-      elsif scale
-        effective = [count, max_count].min
-        { rule: rule, count: count, contribution: weight * effective, max: max_value,
-          base_weight: weight, scale_by_count: scale }
-      else
-        { rule: rule, count: count, contribution: weight, max: max_value,
-          base_weight: weight, scale_by_count: scale }
+        return { rule: rule, count: count, contribution: 0.0, max: max_value,
+                 base_weight: weight, scale_by_count: scale }
       end
+
+      effective_factors = scale ? factors.first(max_count) : factors.first(1)
+      contribution = weight * effective_factors.sum
+      base_contribution = weight * (effective_factors.first || 0)
+
+      {
+        rule: rule,
+        count: count,
+        contribution: contribution,
+        max: max_value,
+        base_weight: base_contribution,
+        scale_by_count: scale
+      }
     end
 
-    def safely_count(impl)
-      impl.matching_count(@party).to_i
+    def safely_factors(impl)
+      impl.match_factors(@party)
     rescue StandardError => e
       Rails.logger.warn("[PartyDifficulty::Calculator] rule raised: #{e.class}: #{e.message}")
-      0
+      []
     end
 
     def composite_score(breakdowns)

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -212,6 +212,7 @@ module PartyDifficulty
       contribution_sum = fired.sum { |c| c[:contribution] }
       raw_score = (contribution_sum / max_weight).clamp(0.0, 1.0)
       weighted = raw_score * comp.weight.to_f
+      target_max_set = comp.respond_to?(:target_max) && comp.target_max.present? && comp.target_max.to_f.positive?
 
       {
         name: name,
@@ -219,6 +220,9 @@ module PartyDifficulty
         present: true,
         raw_score: raw_score.round(4),
         weighted_score: weighted.round(4),
+        contribution_sum: contribution_sum.round(2),
+        max_weight: max_weight.round(2),
+        target_max: target_max_set ? comp.target_max.to_f : nil,
         fired: fired.flat_map { |c| fired_entries_for(c) }
       }
     end

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -124,9 +124,19 @@ module PartyDifficulty
       case component_name
       when 'weapon', 'character', 'summon' then party_count_for(component_name).positive?
       when 'job' then @party.job_id.present?
-      when 'accessory' then @party.accessory_id.present?
+      when 'accessory' then accessory_data?
       else false
       end
+    end
+
+    # The "accessory" component covers the party's JobAccessory (manatura /
+    # shield) plus rare bullets equipped on the mainhand, so the component is
+    # considered present if either side has data.
+    def accessory_data?
+      return true if @party.accessory_id.present?
+
+      mainhand = @party.weapons.to_a.find(&:mainhand)
+      mainhand&.grid_weapon_bullets&.any? || false
     end
 
     def component_breakdowns

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -56,6 +56,12 @@ module PartyDifficulty
       end
     end
 
+    # Threshold check: the party must have at least min_count_to_score grid
+    # items for each *enabled* primary component. If a component has been
+    # disabled by an editor (comp.nil? because enabled_components_by_name
+    # filters disabled rows), its threshold doesn't apply — component_breakdowns
+    # likewise skips it, so the party can still receive a composite score from
+    # whichever components remain enabled.
     def scoreable?
       enabled = enabled_components_by_name
       %w[weapon character summon].all? do |name|

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -168,6 +168,18 @@ module PartyDifficulty
       end
     end
 
+    ##
+    # Returns the denominator for a component's raw_score. If the component
+    # has a target_max set (an editor-defined upper bound for what a top team
+    # realistically scores), use that. Otherwise fall back to the sum of
+    # every rule's max possible contribution.
+    def component_max_weight(comp, contributions)
+      configured = comp.respond_to?(:target_max) ? comp.target_max : nil
+      return configured.to_f if configured.present? && configured.to_f.positive?
+
+      contributions.sum { |c| c[:max] }
+    end
+
     def breakdown_for_component(name, comp, rules)
       present = data_for?(name)
 
@@ -183,7 +195,7 @@ module PartyDifficulty
       end
 
       contributions = rules.map { |rule| rule_contribution(rule) }
-      max_weight = contributions.sum { |c| c[:max] }
+      max_weight = component_max_weight(comp, contributions)
 
       if max_weight.zero?
         return {
@@ -291,7 +303,12 @@ module PartyDifficulty
     end
 
     def composite_score(breakdowns)
-      contributing = breakdowns.select { |b| b[:weighted_score] }
+      # Skip components that aren't present (no data) OR that had data but
+      # fired no rules at all (raw_score == 0). A team with a non-Origin job
+      # shouldn't be penalized in the denominator just for having a job.
+      contributing = breakdowns.select do |b|
+        b[:weighted_score].present? && b[:weighted_score].positive?
+      end
       return 0 if contributing.empty?
 
       weight_sum = contributing.sum { |b| b[:weight] }

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -92,9 +92,8 @@ module PartyDifficulty
 
     def breakdown_for_component(name, comp, rules)
       present = data_for?(name)
-      max_weight = rules.sum { |r| r.weight.to_f }
 
-      if !present || rules.empty? || max_weight.zero?
+      if !present || rules.empty?
         return {
           name: name,
           weight: comp.weight.to_f,
@@ -105,9 +104,23 @@ module PartyDifficulty
         }
       end
 
-      fired = rules.select { |r| safely_apply(r) }
-      contribution = fired.sum { |r| r.weight.to_f }
-      raw_score = contribution / max_weight
+      contributions = rules.map { |rule| rule_contribution(rule) }
+      max_weight = contributions.sum { |c| c[:max] }
+
+      if max_weight.zero?
+        return {
+          name: name,
+          weight: comp.weight.to_f,
+          present: present,
+          raw_score: nil,
+          weighted_score: nil,
+          fired: []
+        }
+      end
+
+      fired = contributions.select { |c| c[:contribution].positive? }
+      contribution_sum = fired.sum { |c| c[:contribution] }
+      raw_score = (contribution_sum / max_weight).clamp(0.0, 1.0)
       weighted = raw_score * comp.weight.to_f
 
       {
@@ -116,15 +129,49 @@ module PartyDifficulty
         present: true,
         raw_score: raw_score.round(4),
         weighted_score: weighted.round(4),
-        fired: fired.map { |r| { id: r.id, name: r.name, rule_type: r.rule_type, weight: r.weight.to_f } }
+        fired: fired.map { |c|
+          {
+            id: c[:rule].id,
+            name: c[:rule].name,
+            rule_type: c[:rule].rule_type,
+            weight: c[:contribution].round(2),
+            match_count: c[:count]
+          }
+        }
       }
     end
 
-    def safely_apply(rule)
-      rule.applies_to?(@party)
+    ##
+    # Returns the actual + max contribution for a single rule, taking the
+    # scale_by_count / max_count params into account when present.
+    def rule_contribution(rule)
+      impl = rule.implementation
+      params = (rule.params || {}).with_indifferent_access
+      count = safely_count(impl)
+      min_count = impl.min_count
+      weight = rule.weight.to_f
+
+      scale = [true, 'true'].include?(params[:scale_by_count])
+      max_count = params[:max_count].to_i
+      max_count = 1 if max_count <= 0
+
+      max_value = scale ? weight * max_count : weight
+
+      if count < min_count
+        { rule: rule, count: count, contribution: 0.0, max: max_value }
+      elsif scale
+        effective = [count, max_count].min
+        { rule: rule, count: count, contribution: weight * effective, max: max_value }
+      else
+        { rule: rule, count: count, contribution: weight, max: max_value }
+      end
+    end
+
+    def safely_count(impl)
+      impl.matching_count(@party).to_i
     rescue StandardError => e
-      Rails.logger.warn("[PartyDifficulty::Calculator] rule #{rule.id} (#{rule.rule_type}) raised: #{e.class}: #{e.message}")
-      false
+      Rails.logger.warn("[PartyDifficulty::Calculator] rule raised: #{e.class}: #{e.message}")
+      0
     end
 
     def composite_score(breakdowns)

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -83,9 +83,22 @@ module PartyDifficulty
     # per series type, then stashes the results in thread-local storage so the
     # individual rule instances can read them instead of hitting the DB
     # separately. Cleared in `clear_series_caches!` after scoring completes.
+    # Rule types that reference weapon series by slug, with the param key
+    # each uses. weapon_tier_match uses `series_slugs`; the existing
+    # *_series_match rules use `slugs`.
+    WEAPON_SERIES_SLUG_SOURCES = {
+      'weapon_series_match' => 'slugs',
+      'weapon_tier_match' => 'series_slugs'
+    }.freeze
+
     def preload_series_caches!
-      %w[weapon character summon].each do |kind|
-        slugs = collect_series_slugs("#{kind}_series_match")
+      slugs_by_kind = {
+        'weapon' => collect_weapon_series_slugs,
+        'character' => collect_simple_slugs('character_series_match'),
+        'summon' => collect_simple_slugs('summon_series_match')
+      }
+
+      slugs_by_kind.each do |kind, slugs|
         Thread.current[SERIES_CACHE_KEYS[kind]] = if slugs.empty?
                                                     {}
                                                   else
@@ -98,13 +111,22 @@ module PartyDifficulty
       SERIES_CACHE_KEYS.each_value { |key| Thread.current[key] = nil }
     end
 
-    def collect_series_slugs(rule_type)
+    def collect_simple_slugs(rule_type)
       @rules
         .select { |r| r.rule_type == rule_type }
         .flat_map { |r| Array(r.params&.[]('slugs')) }
         .map(&:to_s)
         .reject(&:empty?)
         .uniq
+    end
+
+    def collect_weapon_series_slugs
+      @rules.flat_map do |r|
+        param_key = WEAPON_SERIES_SLUG_SOURCES[r.rule_type]
+        next [] unless param_key
+
+        Array(r.params&.[](param_key))
+      end.map(&:to_s).reject(&:empty?).uniq
     end
 
     def enabled_components_by_name

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -285,7 +285,11 @@ module PartyDifficulty
                  base_weight: weight, scale_by_count: scale }
       end
 
-      effective_factors = scale ? factors.first(max_count) : factors.first(1)
+      # Every match contributes its full weight × decay factor. The max_count
+      # only caps the denominator (max_value), not how many matches actually
+      # count. raw_score is still clamped to 1.0 to keep things sane when a
+      # team fires more matches than the cap.
+      effective_factors = scale ? factors : factors.first(1)
       contribution = weight * effective_factors.sum
       base_contribution = weight * (effective_factors.first || 0)
 

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -38,17 +38,22 @@ module PartyDifficulty
     def call
       return Result.new(scoreable: false, ruleset_version: @ruleset_version) unless scoreable?
 
-      breakdowns = component_breakdowns
-      composite = composite_score(breakdowns)
-      tier = find_tier(composite)
+      preload_series_caches!
+      begin
+        breakdowns = component_breakdowns
+        composite = composite_score(breakdowns)
+        tier = find_tier(composite)
 
-      Result.new(
-        scoreable: true,
-        score: composite,
-        difficulty: tier,
-        breakdown: { components: breakdowns, score: composite, tier_id: tier&.id },
-        ruleset_version: @ruleset_version
-      )
+        Result.new(
+          scoreable: true,
+          score: composite,
+          difficulty: tier,
+          breakdown: { components: breakdowns, score: composite, tier_id: tier&.id },
+          ruleset_version: @ruleset_version
+        )
+      ensure
+        clear_series_caches!
+      end
     end
 
     def scoreable?
@@ -60,6 +65,47 @@ module PartyDifficulty
     end
 
     private
+
+    SERIES_CACHE_KEYS = {
+      'weapon' => :pd_weapon_series_cache,
+      'character' => :pd_character_series_cache,
+      'summon' => :pd_summon_series_cache
+    }.freeze
+
+    SERIES_MODELS = {
+      'weapon' => 'WeaponSeries',
+      'character' => 'CharacterSeries',
+      'summon' => 'SummonSeries'
+    }.freeze
+
+    ##
+    # Batches slug → id lookups for every *_series_match rule into one query
+    # per series type, then stashes the results in thread-local storage so the
+    # individual rule instances can read them instead of hitting the DB
+    # separately. Cleared in `clear_series_caches!` after scoring completes.
+    def preload_series_caches!
+      %w[weapon character summon].each do |kind|
+        slugs = collect_series_slugs("#{kind}_series_match")
+        Thread.current[SERIES_CACHE_KEYS[kind]] = if slugs.empty?
+                                                    {}
+                                                  else
+                                                    SERIES_MODELS[kind].constantize.where(slug: slugs).pluck(:slug, :id).to_h
+                                                  end
+      end
+    end
+
+    def clear_series_caches!
+      SERIES_CACHE_KEYS.each_value { |key| Thread.current[key] = nil }
+    end
+
+    def collect_series_slugs(rule_type)
+      @rules
+        .select { |r| r.rule_type == rule_type }
+        .flat_map { |r| Array(r.params&.[]('slugs')) }
+        .map(&:to_s)
+        .reject(&:empty?)
+        .uniq
+    end
 
     def enabled_components_by_name
       @enabled_components_by_name ||= @components.select(&:enabled).index_by(&:name)
@@ -129,16 +175,43 @@ module PartyDifficulty
         present: true,
         raw_score: raw_score.round(4),
         weighted_score: weighted.round(4),
-        fired: fired.map { |c|
-          {
-            id: c[:rule].id,
-            name: c[:rule].name,
-            rule_type: c[:rule].rule_type,
-            weight: c[:contribution].round(2),
-            match_count: c[:count]
-          }
-        }
+        fired: fired.flat_map { |c| fired_entries_for(c) }
       }
+    end
+
+    ##
+    # Returns one or two fired entries for a rule that fired. Scaling rules
+    # with more than one match split into a "base" row plus an "additional"
+    # row so the UI can render them separately.
+    def fired_entries_for(contribution)
+      rule = contribution[:rule]
+      count = contribution[:count]
+      base = contribution[:base_weight]
+      total = contribution[:contribution]
+
+      base_entry = {
+        id: rule.id,
+        name: rule.name,
+        rule_type: rule.rule_type,
+        weight: base.round(2),
+        match_count: 1,
+        kind: 'base'
+      }
+
+      additional = total - base
+      return [base_entry] unless contribution[:scale_by_count] && additional.positive?
+
+      [
+        base_entry,
+        {
+          id: "#{rule.id}-additional",
+          name: rule.name,
+          rule_type: rule.rule_type,
+          weight: additional.round(2),
+          match_count: count - 1,
+          kind: 'additional'
+        }
+      ]
     end
 
     ##
@@ -158,12 +231,15 @@ module PartyDifficulty
       max_value = scale ? weight * max_count : weight
 
       if count < min_count
-        { rule: rule, count: count, contribution: 0.0, max: max_value }
+        { rule: rule, count: count, contribution: 0.0, max: max_value,
+          base_weight: weight, scale_by_count: scale }
       elsif scale
         effective = [count, max_count].min
-        { rule: rule, count: count, contribution: weight * effective, max: max_value }
+        { rule: rule, count: count, contribution: weight * effective, max: max_value,
+          base_weight: weight, scale_by_count: scale }
       else
-        { rule: rule, count: count, contribution: weight, max: max_value }
+        { rule: rule, count: count, contribution: weight, max: max_value,
+          base_weight: weight, scale_by_count: scale }
       end
     end
 

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  ##
+  # Computes the difficulty score for a single Party.
+  #
+  # Pure function: does not persist anything. Use ScoreJob to compute and save.
+  #
+  #   result = PartyDifficulty::Calculator.new(party).call
+  #   result.scoreable      # => true/false
+  #   result.score          # => 0..100 (Float)
+  #   result.difficulty     # => Difficulty record (or nil if no tier matches)
+  #   result.breakdown      # => Hash with per-component fired-rule details
+  #   result.ruleset_version
+  class Calculator
+    Result = Struct.new(:scoreable, :score, :difficulty, :breakdown, :ruleset_version, keyword_init: true)
+
+    EAGER_LOAD = {
+      weapons: [:awakening, :grid_weapon_bullets, { weapon: :weapon_series }],
+      characters: [{ character: :character_series_records }],
+      summons: [{ summon: :summon_series }],
+      job: [],
+      accessory: []
+    }.freeze
+
+    def self.eager_load_party(party_id)
+      Party.includes(*EAGER_LOAD.keys.map { |k| EAGER_LOAD[k].any? ? { k => EAGER_LOAD[k] } : k }).find(party_id)
+    end
+
+    def initialize(party, rules: nil, components: nil, difficulties: nil, ruleset_version: nil)
+      @party = party
+      @rules = rules || DifficultyRule.active.to_a
+      @components = components || DifficultyComponent.all.to_a
+      @difficulties = difficulties || Difficulty.ordered.to_a
+      @ruleset_version = ruleset_version || DifficultyConfig.current_version
+    end
+
+    def call
+      return Result.new(scoreable: false, ruleset_version: @ruleset_version) unless scoreable?
+
+      breakdowns = component_breakdowns
+      composite = composite_score(breakdowns)
+      tier = find_tier(composite)
+
+      Result.new(
+        scoreable: true,
+        score: composite,
+        difficulty: tier,
+        breakdown: { components: breakdowns, score: composite, tier_id: tier&.id },
+        ruleset_version: @ruleset_version
+      )
+    end
+
+    def scoreable?
+      enabled = enabled_components_by_name
+      %w[weapon character summon].all? do |name|
+        comp = enabled[name]
+        comp.nil? || party_count_for(name) >= comp.min_count_to_score
+      end
+    end
+
+    private
+
+    def enabled_components_by_name
+      @enabled_components_by_name ||= @components.select(&:enabled).index_by(&:name)
+    end
+
+    def party_count_for(component_name)
+      case component_name
+      when 'weapon' then @party.weapons_count.to_i
+      when 'character' then @party.characters_count.to_i
+      when 'summon' then @party.summons_count.to_i
+      else 0
+      end
+    end
+
+    def data_for?(component_name)
+      case component_name
+      when 'weapon', 'character', 'summon' then party_count_for(component_name).positive?
+      when 'job' then @party.job_id.present?
+      when 'accessory' then @party.accessory_id.present?
+      else false
+      end
+    end
+
+    def component_breakdowns
+      enabled_components_by_name.map do |name, comp|
+        rules = @rules.select { |r| r.component == name }
+        breakdown_for_component(name, comp, rules)
+      end
+    end
+
+    def breakdown_for_component(name, comp, rules)
+      present = data_for?(name)
+      max_weight = rules.sum { |r| r.weight.to_f }
+
+      if !present || rules.empty? || max_weight.zero?
+        return {
+          name: name,
+          weight: comp.weight.to_f,
+          present: present,
+          raw_score: nil,
+          weighted_score: nil,
+          fired: []
+        }
+      end
+
+      fired = rules.select { |r| safely_apply(r) }
+      contribution = fired.sum { |r| r.weight.to_f }
+      raw_score = contribution / max_weight
+      weighted = raw_score * comp.weight.to_f
+
+      {
+        name: name,
+        weight: comp.weight.to_f,
+        present: true,
+        raw_score: raw_score.round(4),
+        weighted_score: weighted.round(4),
+        fired: fired.map { |r| { id: r.id, name: r.name, rule_type: r.rule_type, weight: r.weight.to_f } }
+      }
+    end
+
+    def safely_apply(rule)
+      rule.applies_to?(@party)
+    rescue StandardError => e
+      Rails.logger.warn("[PartyDifficulty::Calculator] rule #{rule.id} (#{rule.rule_type}) raised: #{e.class}: #{e.message}")
+      false
+    end
+
+    def composite_score(breakdowns)
+      contributing = breakdowns.select { |b| b[:weighted_score] }
+      return 0 if contributing.empty?
+
+      weight_sum = contributing.sum { |b| b[:weight] }
+      return 0 if weight_sum.zero?
+
+      score_sum = contributing.sum { |b| b[:weighted_score] }
+      ((score_sum / weight_sum) * 100).round(2)
+    end
+
+    def find_tier(score)
+      @difficulties.find { |d| score >= d.min_score.to_f && score <= d.max_score.to_f }
+    end
+  end
+end

--- a/app/services/party_difficulty/persister.rb
+++ b/app/services/party_difficulty/persister.rb
@@ -21,11 +21,14 @@ module PartyDifficulty
           difficulty_ruleset_version: result.ruleset_version
         )
       else
+        # Leave difficulty_computed_at nil so the daily sweep picks the party
+        # back up the moment it crosses the scoreability threshold (e.g. via a
+        # counter-cache update that bypassed the Party after_commit callback).
         party.update_columns(
           difficulty_id: nil,
           difficulty_score: nil,
           difficulty_breakdown: nil,
-          difficulty_computed_at: Time.current,
+          difficulty_computed_at: nil,
           difficulty_ruleset_version: result.ruleset_version
         )
       end

--- a/app/services/party_difficulty/persister.rb
+++ b/app/services/party_difficulty/persister.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  ##
+  # Computes a party's difficulty via Calculator and persists the result via
+  # update_columns (so it doesn't trigger after_commit callbacks and recurse).
+  #
+  # When a party is not scoreable (doesn't meet the min_count thresholds), all
+  # five difficulty columns are nulled so the UI hides the badge.
+  class Persister
+    def self.call(party_id)
+      party = Calculator.eager_load_party(party_id)
+      result = Calculator.new(party).call
+
+      if result.scoreable
+        party.update_columns(
+          difficulty_id: result.difficulty&.id,
+          difficulty_score: result.score,
+          difficulty_breakdown: result.breakdown,
+          difficulty_computed_at: Time.current,
+          difficulty_ruleset_version: result.ruleset_version
+        )
+      else
+        party.update_columns(
+          difficulty_id: nil,
+          difficulty_score: nil,
+          difficulty_breakdown: nil,
+          difficulty_computed_at: Time.current,
+          difficulty_ruleset_version: result.ruleset_version
+        )
+      end
+
+      result
+    end
+  end
+end

--- a/app/services/party_difficulty/rules.rb
+++ b/app/services/party_difficulty/rules.rb
@@ -27,7 +27,8 @@ module PartyDifficulty
       'summon_uncap_at_least'           => 'SummonUncapAtLeast',
       'summon_transcendence_at_least'   => 'SummonTranscendenceAtLeast',
       'job_row'                         => 'JobRow',
-      'accessory_match'                 => 'AccessoryMatch'
+      'accessory_match'                 => 'AccessoryMatch',
+      'mainhand_bullet_match'           => 'MainhandBulletMatch'
     }.freeze
 
     def self.registered_types

--- a/app/services/party_difficulty/rules.rb
+++ b/app/services/party_difficulty/rules.rb
@@ -28,6 +28,7 @@ module PartyDifficulty
       'summon_series_match'             => 'SummonSeriesMatch',
       'summon_uncap_at_least'           => 'SummonUncapAtLeast',
       'summon_transcendence_at_least'   => 'SummonTranscendenceAtLeast',
+      'summon_release_within_days'      => 'SummonReleaseWithinDays',
       'job_row'                         => 'JobRow',
       'accessory_match'                 => 'AccessoryMatch',
       'mainhand_bullet_match'           => 'MainhandBulletMatch'

--- a/app/services/party_difficulty/rules.rb
+++ b/app/services/party_difficulty/rules.rb
@@ -8,6 +8,7 @@ module PartyDifficulty
     # Order matters here only for the editor UI's grouping.
     REGISTRY = {
       'weapon_series_match'             => 'WeaponSeriesMatch',
+      'weapon_seasonal_match'           => 'WeaponSeasonalMatch',
       'weapon_specific_match'           => 'WeaponSpecificMatch',
       'weapon_awakening_at_least'       => 'WeaponAwakeningAtLeast',
       'weapon_transcendence_at_least'   => 'WeaponTranscendenceAtLeast',

--- a/app/services/party_difficulty/rules.rb
+++ b/app/services/party_difficulty/rules.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  ##
+  # Registry of all difficulty rule types.
+  # Rule classes live under `app/services/party_difficulty/rules/`.
+  module Rules
+    # Order matters here only for the editor UI's grouping.
+    REGISTRY = {
+      'weapon_series_match'             => 'WeaponSeriesMatch',
+      'weapon_specific_match'           => 'WeaponSpecificMatch',
+      'weapon_awakening_at_least'       => 'WeaponAwakeningAtLeast',
+      'weapon_transcendence_at_least'   => 'WeaponTranscendenceAtLeast',
+      'weapon_uncap_at_least'           => 'WeaponUncapAtLeast',
+      'weapon_promotion_includes'       => 'WeaponPromotionIncludes',
+      'weapon_ax_filled'                => 'WeaponAxFilled',
+      'weapon_befoulment_filled'        => 'WeaponBefoulmentFilled',
+      'weapon_release_within_days'      => 'WeaponReleaseWithinDays',
+      'weapon_bullet_match'             => 'WeaponBulletMatch',
+      'character_seasonal'              => 'CharacterSeasonal',
+      'character_series_match'          => 'CharacterSeriesMatch',
+      'character_perpetuity_ringed'     => 'CharacterPerpetuityRinged',
+      'character_earring_at_least'      => 'CharacterEarringAtLeast',
+      'character_transcendence_at_least' => 'CharacterTranscendenceAtLeast',
+      'character_release_within_days'   => 'CharacterReleaseWithinDays',
+      'summon_series_match'             => 'SummonSeriesMatch',
+      'summon_uncap_at_least'           => 'SummonUncapAtLeast',
+      'summon_transcendence_at_least'   => 'SummonTranscendenceAtLeast',
+      'job_row'                         => 'JobRow',
+      'accessory_match'                 => 'AccessoryMatch'
+    }.freeze
+
+    def self.registered_types
+      REGISTRY.keys
+    end
+
+    def self.lookup(rule_type)
+      class_name = REGISTRY[rule_type.to_s]
+      return nil unless class_name
+
+      "PartyDifficulty::Rules::#{class_name}".constantize
+    end
+
+    def self.build(rule_type, params)
+      klass = lookup(rule_type)
+      raise ArgumentError, "Unknown difficulty rule_type: #{rule_type}" unless klass
+
+      klass.new(params)
+    end
+
+    def self.validate_params(rule_type, params)
+      klass = lookup(rule_type)
+      return ["Unknown rule_type: #{rule_type}"] unless klass
+
+      klass.validate_params(params || {})
+    end
+
+    def self.component_for(rule_type)
+      lookup(rule_type)&.component
+    end
+
+    def self.types_grouped_by_component
+      REGISTRY.keys.group_by { |type| component_for(type) }
+    end
+  end
+end

--- a/app/services/party_difficulty/rules.rb
+++ b/app/services/party_difficulty/rules.rb
@@ -9,6 +9,7 @@ module PartyDifficulty
     REGISTRY = {
       'weapon_series_match'             => 'WeaponSeriesMatch',
       'weapon_seasonal_match'           => 'WeaponSeasonalMatch',
+      'weapon_tier_match'               => 'WeaponTierMatch',
       'weapon_specific_match'           => 'WeaponSpecificMatch',
       'weapon_awakening_at_least'       => 'WeaponAwakeningAtLeast',
       'weapon_transcendence_at_least'   => 'WeaponTranscendenceAtLeast',

--- a/app/services/party_difficulty/rules/accessory_match.rb
+++ b/app/services/party_difficulty/rules/accessory_match.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when the party's accessory matches one of the given ids OR is of
+    # one of the given accessory_types (1=shield, 2=manatura).
+    #
+    # params: { "accessory_ids": ["uuid", ...], "accessory_types": [1, 2] }
+    class AccessoryMatch < Base
+      def self.component
+        'accessory'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        if params[:accessory_ids].blank? && params[:accessory_types].blank?
+          ['accessory_ids or accessory_types must be provided']
+        else
+          []
+        end
+      end
+
+      def applies?(party)
+        return false unless party.accessory
+
+        ids = string_array_param(:accessory_ids)
+        types = Array(params[:accessory_types]).map(&:to_i)
+
+        id_match = ids.any? && ids.include?(party.accessory_id.to_s)
+        type_match = types.any? && types.include?(party.accessory.accessory_type.to_i)
+
+        ids.empty? && types.empty? ? false : (id_match || type_match)
+      end
+
+      def matching_count(party)
+        applies?(party) ? 1 : 0
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/base.rb
+++ b/app/services/party_difficulty/rules/base.rb
@@ -39,6 +39,16 @@ module PartyDifficulty
         raise NotImplementedError
       end
 
+      ##
+      # Per-match contribution multipliers, one per matched item. Default is
+      # 1.0 for every match. Rules that want age-decay or other per-item
+      # scaling (e.g. weapon_seasonal_match) override this. The calculator
+      # multiplies these factors by the rule's weight and sums up to `max_count`
+      # of them to compute the contribution.
+      def match_factors(party)
+        Array.new(matching_count(party), 1.0)
+      end
+
       def min_count
         value = params[:min_count].to_i
         value.positive? ? value : 1
@@ -52,6 +62,19 @@ module PartyDifficulty
 
       def string_array_param(key)
         Array(params[key]).map(&:to_s)
+      end
+
+      ##
+      # Returns a decay multiplier in [floor, 1.0] for an item released
+      # `years_since(release_date)` years ago. Reads `decay_per_year` and
+      # `decay_floor` from the rule's params (defaults: 0 = no decay, floor 0.1).
+      def decay_factor_for(release_date)
+        rate = params[:decay_per_year].to_f
+        return 1.0 if rate <= 0 || release_date.nil?
+
+        years = (Date.current - release_date).to_f / 365.25
+        floor = params[:decay_floor].present? ? params[:decay_floor].to_f : 0.1
+        [1.0 - (rate * years), floor].max
       end
     end
   end

--- a/app/services/party_difficulty/rules/base.rb
+++ b/app/services/party_difficulty/rules/base.rb
@@ -65,6 +65,18 @@ module PartyDifficulty
       end
 
       ##
+      # Resolve a list of series slugs to ids, honoring a thread-local cache when
+      # complete and falling back to the DB on any miss. A partial cache hit
+      # would silently drop unrecognized slugs, so we require every slug to be
+      # present before trusting the cache.
+      def resolve_slugs_via_cache(slugs, cache, model)
+        return [] if slugs.empty?
+        return slugs.filter_map { |s| cache[s] } if cache && slugs.all? { |s| cache.key?(s) }
+
+        model.where(slug: slugs).pluck(:id)
+      end
+
+      ##
       # Returns a decay multiplier in [floor, 1.0] for an item released
       # `years_since(release_date)` years ago. Reads `decay_per_year` and
       # `decay_floor` from the rule's params (defaults: 0 = no decay, floor 0.1).

--- a/app/services/party_difficulty/rules/base.rb
+++ b/app/services/party_difficulty/rules/base.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Base class for all difficulty rules. Rules answer one question:
+    # given a party, does this rule fire? If so, the party gets the rule's
+    # weight added to the relevant component sub-score.
+    #
+    # Most rules implement a count-based pattern: they iterate over the
+    # relevant grid items and return how many match. The rule fires when
+    # `matching_count >= min_count`.
+    class Base
+      def initialize(params = {})
+        @params = (params || {}).with_indifferent_access
+      end
+
+      attr_reader :params
+
+      def applies?(party)
+        matching_count(party) >= min_count
+      end
+
+      ##
+      # Subclasses must declare which component they belong to:
+      # 'weapon', 'character', 'summon', 'job', or 'accessory'.
+      def self.component
+        raise NotImplementedError
+      end
+
+      ##
+      # Return an array of error message strings if params are invalid;
+      # empty array if valid.
+      def self.validate_params(_params)
+        []
+      end
+
+      def matching_count(_party)
+        raise NotImplementedError
+      end
+
+      def min_count
+        value = params[:min_count].to_i
+        value.positive? ? value : 1
+      end
+
+      protected
+
+      def integer_array_param(key)
+        Array(params[key]).map { |v| v.to_s.match?(/\A\d+\z/) ? v.to_i : v.to_s }
+      end
+
+      def string_array_param(key)
+        Array(params[key]).map(&:to_s)
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/character_earring_at_least.rb
+++ b/app/services/party_difficulty/rules/character_earring_at_least.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count grid characters have an earring with
+    # strength >= min_strength.
+    #
+    # params: { "min_strength": 17, "min_count": 1 }
+    class CharacterEarringAtLeast < Base
+      def self.component
+        'character'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:min_strength].to_i.positive? ? [] : ['min_strength must be > 0']
+      end
+
+      def matching_count(party)
+        min_strength = params[:min_strength].to_f
+
+        party.characters.count do |gc|
+          earring = gc.earring.is_a?(Hash) ? gc.earring.with_indifferent_access : {}
+          modifier = earring[:modifier]
+          strength = earring[:strength]
+          next false if modifier.blank? || strength.blank?
+
+          strength.to_f >= min_strength
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/character_perpetuity_ringed.rb
+++ b/app/services/party_difficulty/rules/character_perpetuity_ringed.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count grid characters have the perpetuity ring set.
+    #
+    # params: { "min_count": 1 }
+    class CharacterPerpetuityRinged < Base
+      def self.component
+        'character'
+      end
+
+      def matching_count(party)
+        party.characters.count { |gc| gc.perpetuity == true }
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/character_release_within_days.rb
+++ b/app/services/party_difficulty/rules/character_release_within_days.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count characters were released within the last
+    # `days` days (the time-decay rule for characters).
+    #
+    # params: { "days": 180, "min_count": 1 }
+    class CharacterReleaseWithinDays < Base
+      def self.component
+        'character'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:days].to_i.positive? ? [] : ['days must be > 0']
+      end
+
+      def matching_count(party)
+        cutoff = params[:days].to_i.days.ago.to_date
+        party.characters.count { |gc| gc.character&.release_date && gc.character.release_date >= cutoff }
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/character_seasonal.rb
+++ b/app/services/party_difficulty/rules/character_seasonal.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count characters are seasonal. If the `seasons`
+    # param is empty, any non-Standard season counts; otherwise only the
+    # specified season ints (e.g. summer, valentine).
+    #
+    # params: { "seasons": [9, 11], "min_count": 2 }
+    class CharacterSeasonal < Base
+      def self.component
+        'character'
+      end
+
+      def matching_count(party)
+        seasons = Array(params[:seasons]).map(&:to_i)
+        standard = GranblueEnums::CHARACTER_SEASONS[:Standard]
+
+        party.characters.count do |gc|
+          season = gc.character&.season
+          next false if season.nil? || season == standard
+
+          seasons.empty? || seasons.include?(season)
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/character_seasonal.rb
+++ b/app/services/party_difficulty/rules/character_seasonal.rb
@@ -5,19 +5,37 @@ module PartyDifficulty
     ##
     # Fires when at least min_count characters are seasonal. If the `seasons`
     # param is empty, any non-Standard season counts; otherwise only the
-    # specified season ints (e.g. summer, valentine).
+    # specified season ints (Valentine=1, Formal=2, Summer=3, Halloween=4,
+    # Holiday=5). Supports per-match age decay via decay_per_year so older
+    # seasonals score lower than recent releases.
     #
-    # params: { "seasons": [9, 11], "min_count": 2 }
+    # params: {
+    #   "seasons": [2],
+    #   "min_count": 1,
+    #   "scale_by_count": true,
+    #   "max_count": 3,
+    #   "decay_per_year": 0.1
+    # }
     class CharacterSeasonal < Base
       def self.component
         'character'
       end
 
       def matching_count(party)
+        matching_characters(party).size
+      end
+
+      def match_factors(party)
+        matching_characters(party).map { |gc| decay_factor_for(gc.character&.release_date) }
+      end
+
+      private
+
+      def matching_characters(party)
         seasons = Array(params[:seasons]).map(&:to_i)
         standard = GranblueEnums::CHARACTER_SEASONS[:Standard]
 
-        party.characters.count do |gc|
+        party.characters.select do |gc|
           season = gc.character&.season
           next false if season.nil? || season == standard
 

--- a/app/services/party_difficulty/rules/character_series_match.rb
+++ b/app/services/party_difficulty/rules/character_series_match.rb
@@ -5,8 +5,16 @@ module PartyDifficulty
     ##
     # Fires when at least min_count characters belong to one of the specified
     # character_series (by id or slug — e.g. "grand", "evoker", "eternal").
+    # When `single_series_only` is true, a character is only counted if its
+    # core series is the *only* one it belongs to — this filters out seasonal
+    # variants (e.g. a Summer Eternal won't fire the Eternal rule because the
+    # Summer/Yukata seasonal character rule will instead).
     #
-    # params: { "series_ids": ["uuid", ...], "slugs": ["grand", ...], "min_count": 2 }
+    # params: {
+    #   "slugs": ["eternal", "evoker"],
+    #   "min_count": 1,
+    #   "single_series_only": true
+    # }
     class CharacterSeriesMatch < Base
       def self.component
         'character'
@@ -25,8 +33,12 @@ module PartyDifficulty
         ids = resolved_series_ids
         return 0 if ids.empty?
 
+        single_only = params[:single_series_only] == true
+
         party.characters.count do |gc|
           memberships = gc.character&.character_series_records || []
+          next false if single_only && memberships.size > 1
+
           memberships.any? { |m| ids.include?(m.id) }
         end
       end

--- a/app/services/party_difficulty/rules/character_series_match.rb
+++ b/app/services/party_difficulty/rules/character_series_match.rb
@@ -36,10 +36,19 @@ module PartyDifficulty
       def resolved_series_ids
         @resolved_series_ids ||= begin
           ids = string_array_param(:series_ids)
-          slug_ids = string_array_param(:slugs).then do |slugs|
-            slugs.empty? ? [] : CharacterSeries.where(slug: slugs).pluck(:id)
-          end
+          slug_ids = resolve_slugs(string_array_param(:slugs))
           (ids + slug_ids).uniq
+        end
+      end
+
+      def resolve_slugs(slugs)
+        return [] if slugs.empty?
+
+        cache = Thread.current[:pd_character_series_cache]
+        if cache
+          slugs.filter_map { |s| cache[s] }
+        else
+          CharacterSeries.where(slug: slugs).pluck(:id)
         end
       end
     end

--- a/app/services/party_difficulty/rules/character_series_match.rb
+++ b/app/services/party_difficulty/rules/character_series_match.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count characters belong to one of the specified
+    # character_series (by id or slug — e.g. "grand", "evoker", "eternal").
+    #
+    # params: { "series_ids": ["uuid", ...], "slugs": ["grand", ...], "min_count": 2 }
+    class CharacterSeriesMatch < Base
+      def self.component
+        'character'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        if params[:series_ids].blank? && params[:slugs].blank?
+          ['series_ids or slugs must be provided']
+        else
+          []
+        end
+      end
+
+      def matching_count(party)
+        ids = resolved_series_ids
+        return 0 if ids.empty?
+
+        party.characters.count do |gc|
+          memberships = gc.character&.character_series_records || []
+          memberships.any? { |m| ids.include?(m.id) }
+        end
+      end
+
+      private
+
+      def resolved_series_ids
+        @resolved_series_ids ||= begin
+          ids = string_array_param(:series_ids)
+          slug_ids = string_array_param(:slugs).then do |slugs|
+            slugs.empty? ? [] : CharacterSeries.where(slug: slugs).pluck(:id)
+          end
+          (ids + slug_ids).uniq
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/character_series_match.rb
+++ b/app/services/party_difficulty/rules/character_series_match.rb
@@ -54,14 +54,7 @@ module PartyDifficulty
       end
 
       def resolve_slugs(slugs)
-        return [] if slugs.empty?
-
-        cache = Thread.current[:pd_character_series_cache]
-        if cache
-          slugs.filter_map { |s| cache[s] }
-        else
-          CharacterSeries.where(slug: slugs).pluck(:id)
-        end
+        resolve_slugs_via_cache(slugs, Thread.current[:pd_character_series_cache], CharacterSeries)
       end
     end
   end

--- a/app/services/party_difficulty/rules/character_transcendence_at_least.rb
+++ b/app/services/party_difficulty/rules/character_transcendence_at_least.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count characters have transcendence_step >= min_step.
+    #
+    # params: { "min_step": 4, "min_count": 1 }
+    class CharacterTranscendenceAtLeast < Base
+      def self.component
+        'character'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:min_step].to_i.positive? ? [] : ['min_step must be > 0']
+      end
+
+      def matching_count(party)
+        min_step = params[:min_step].to_i
+        party.characters.count { |gc| gc.transcendence_step.to_i >= min_step }
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/job_row.rb
+++ b/app/services/party_difficulty/rules/job_row.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when the party's job belongs to the specified row, optionally
+    # requiring ultimate_mastery to be enabled on the party.
+    #
+    # params: { "rows": ["IV", "V", "Origin"], "requires_ultimate_mastery": false }
+    class JobRow < Base
+      def self.component
+        'job'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:rows].present? ? [] : ['rows must be provided']
+      end
+
+      def applies?(party)
+        return false unless party.job
+
+        rows = string_array_param(:rows)
+        return false unless rows.include?(party.job.row.to_s)
+
+        params[:requires_ultimate_mastery] == true ? party.ultimate_mastery == true : true
+      end
+
+      def matching_count(party)
+        applies?(party) ? 1 : 0
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/mainhand_bullet_match.rb
+++ b/app/services/party_difficulty/rules/mainhand_bullet_match.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when the party's mainhand weapon has any of the specified bullets
+    # slotted. Scores under the `accessory` component (alongside manaturas /
+    # shields) since rare bullets are gated like accessories rather than like
+    # weapon investment.
+    #
+    # params: { "bullet_ids": ["uuid", ...] }
+    class MainhandBulletMatch < Base
+      def self.component
+        'accessory'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:bullet_ids].present? ? [] : ['bullet_ids must be provided']
+      end
+
+      def applies?(party)
+        matching_count(party).positive?
+      end
+
+      def matching_count(party)
+        ids = string_array_param(:bullet_ids)
+        return 0 if ids.empty?
+
+        mainhand = party.weapons.find(&:mainhand)
+        return 0 unless mainhand
+
+        bullets = mainhand.grid_weapon_bullets.to_a
+        bullets.any? { |b| ids.include?(b.bullet_id.to_s) } ? 1 : 0
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/mainhand_bullet_match.rb
+++ b/app/services/party_difficulty/rules/mainhand_bullet_match.rb
@@ -3,12 +3,14 @@
 module PartyDifficulty
   module Rules
     ##
-    # Fires when the party's mainhand weapon has any of the specified bullets
-    # slotted. Scores under the `accessory` component (alongside manaturas /
-    # shields) since rare bullets are gated like accessories rather than like
-    # weapon investment.
+    # Counts how many slotted bullets on the party's mainhand weapon match
+    # the configured bullet_ids. Scores under the `accessory` component
+    # (alongside manaturas / shields) since rare bullets are gated like
+    # accessories rather than like weapon investment. Combine with
+    # scale_by_count so a mainhand carrying multiple top-tier bullets scores
+    # more than one with a single match.
     #
-    # params: { "bullet_ids": ["uuid", ...] }
+    # params: { "bullet_ids": ["uuid", ...], "min_count": 1, "scale_by_count": true, "max_count": 4 }
     class MainhandBulletMatch < Base
       def self.component
         'accessory'
@@ -19,10 +21,6 @@ module PartyDifficulty
         params[:bullet_ids].present? ? [] : ['bullet_ids must be provided']
       end
 
-      def applies?(party)
-        matching_count(party).positive?
-      end
-
       def matching_count(party)
         ids = string_array_param(:bullet_ids)
         return 0 if ids.empty?
@@ -30,8 +28,7 @@ module PartyDifficulty
         mainhand = party.weapons.find(&:mainhand)
         return 0 unless mainhand
 
-        bullets = mainhand.grid_weapon_bullets.to_a
-        bullets.any? { |b| ids.include?(b.bullet_id.to_s) } ? 1 : 0
+        mainhand.grid_weapon_bullets.count { |b| ids.include?(b.bullet_id.to_s) }
       end
     end
   end

--- a/app/services/party_difficulty/rules/summon_release_within_days.rb
+++ b/app/services/party_difficulty/rules/summon_release_within_days.rb
@@ -3,14 +3,14 @@
 module PartyDifficulty
   module Rules
     ##
-    # Fires when at least min_count characters were released between
-    # `min_days_ago` (inclusive, default 0) and `days` (exclusive) days ago.
-    # The lower bound lets you build mutually exclusive age brackets.
+    # Fires when at least min_count summons (excluding friend summons) were
+    # released between `min_days_ago` (inclusive, default 0) and `days`
+    # (exclusive) days ago. Mirrors the weapon and character variants.
     #
     # params: { "days": 14, "min_days_ago": 0, "min_count": 1 }
-    class CharacterReleaseWithinDays < Base
+    class SummonReleaseWithinDays < Base
       def self.component
-        'character'
+        'summon'
       end
 
       def self.validate_params(params)
@@ -23,8 +23,10 @@ module PartyDifficulty
         lower_days = params[:min_days_ago].to_i
         lower = lower_days.positive? ? lower_days.days.ago.to_date : Date.current
 
-        party.characters.count do |gc|
-          release = gc.character&.release_date
+        party.summons
+             .reject { |gs| gs.friend == true }
+             .count do |gs|
+          release = gs.summon&.release_date
           release && release >= upper && release <= lower
         end
       end

--- a/app/services/party_difficulty/rules/summon_series_match.rb
+++ b/app/services/party_difficulty/rules/summon_series_match.rb
@@ -42,14 +42,7 @@ module PartyDifficulty
       end
 
       def resolve_slugs(slugs)
-        return [] if slugs.empty?
-
-        cache = Thread.current[:pd_summon_series_cache]
-        if cache
-          slugs.filter_map { |s| cache[s] }
-        else
-          SummonSeries.where(slug: slugs).pluck(:id)
-        end
+        resolve_slugs_via_cache(slugs, Thread.current[:pd_summon_series_cache], SummonSeries)
       end
     end
   end

--- a/app/services/party_difficulty/rules/summon_series_match.rb
+++ b/app/services/party_difficulty/rules/summon_series_match.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count summons belong to one of the specified
+    # summon_series (by id or slug — e.g. "providence").
+    #
+    # params: { "series_ids": ["uuid", ...], "slugs": ["providence", ...], "min_count": 1 }
+    class SummonSeriesMatch < Base
+      def self.component
+        'summon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        if params[:series_ids].blank? && params[:slugs].blank?
+          ['series_ids or slugs must be provided']
+        else
+          []
+        end
+      end
+
+      def matching_count(party)
+        ids = resolved_series_ids
+        return 0 if ids.empty?
+
+        party.summons.count { |gs| gs.summon && ids.include?(gs.summon.summon_series_id) }
+      end
+
+      private
+
+      def resolved_series_ids
+        @resolved_series_ids ||= begin
+          ids = string_array_param(:series_ids)
+          slug_ids = string_array_param(:slugs).then do |slugs|
+            slugs.empty? ? [] : SummonSeries.where(slug: slugs).pluck(:id)
+          end
+          (ids + slug_ids).uniq
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/summon_series_match.rb
+++ b/app/services/party_difficulty/rules/summon_series_match.rb
@@ -25,7 +25,9 @@ module PartyDifficulty
         ids = resolved_series_ids
         return 0 if ids.empty?
 
-        party.summons.count { |gs| gs.summon && ids.include?(gs.summon.summon_series_id) }
+        party.summons
+             .reject { |gs| gs.friend == true }
+             .count { |gs| gs.summon && ids.include?(gs.summon.summon_series_id) }
       end
 
       private

--- a/app/services/party_difficulty/rules/summon_series_match.rb
+++ b/app/services/party_difficulty/rules/summon_series_match.rb
@@ -35,10 +35,20 @@ module PartyDifficulty
       def resolved_series_ids
         @resolved_series_ids ||= begin
           ids = string_array_param(:series_ids)
-          slug_ids = string_array_param(:slugs).then do |slugs|
-            slugs.empty? ? [] : SummonSeries.where(slug: slugs).pluck(:id)
-          end
+          slugs = string_array_param(:slugs)
+          slug_ids = resolve_slugs(slugs)
           (ids + slug_ids).uniq
+        end
+      end
+
+      def resolve_slugs(slugs)
+        return [] if slugs.empty?
+
+        cache = Thread.current[:pd_summon_series_cache]
+        if cache
+          slugs.filter_map { |s| cache[s] }
+        else
+          SummonSeries.where(slug: slugs).pluck(:id)
         end
       end
     end

--- a/app/services/party_difficulty/rules/summon_transcendence_at_least.rb
+++ b/app/services/party_difficulty/rules/summon_transcendence_at_least.rb
@@ -18,7 +18,9 @@ module PartyDifficulty
 
       def matching_count(party)
         min_step = params[:min_step].to_i
-        party.summons.count { |gs| gs.transcendence_step.to_i >= min_step }
+        party.summons
+             .reject { |gs| gs.friend == true }
+             .count { |gs| gs.transcendence_step.to_i >= min_step }
       end
     end
   end

--- a/app/services/party_difficulty/rules/summon_transcendence_at_least.rb
+++ b/app/services/party_difficulty/rules/summon_transcendence_at_least.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count summons have transcendence_step >= min_step.
+    #
+    # params: { "min_step": 4, "min_count": 1 }
+    class SummonTranscendenceAtLeast < Base
+      def self.component
+        'summon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:min_step].to_i.positive? ? [] : ['min_step must be > 0']
+      end
+
+      def matching_count(party)
+        min_step = params[:min_step].to_i
+        party.summons.count { |gs| gs.transcendence_step.to_i >= min_step }
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/summon_uncap_at_least.rb
+++ b/app/services/party_difficulty/rules/summon_uncap_at_least.rb
@@ -5,10 +5,16 @@ module PartyDifficulty
     ##
     # Fires when at least min_count summons (main or sub — friend summons are
     # excluded since they belong to the player who joined the raid) have
-    # uncap_level >= min_uncap_level. Optionally filter by whether the summon
-    # is gacha ("gacha") or free ("free") using its promotions array.
+    # uncap_level in the range [min_uncap_level, max_uncap_level]. Optionally
+    # filter by whether the summon is gacha ("gacha") or free ("free") using
+    # its promotions array.
     #
-    # params: { "min_uncap_level": 5, "min_count": 1, "gacha_filter": "gacha"|"free"|"any" }
+    # params: {
+    #   "min_uncap_level": 3,
+    #   "max_uncap_level": 3,
+    #   "min_count": 1,
+    #   "gacha_filter": "gacha"|"free"|"any"
+    # }
     class SummonUncapAtLeast < Base
       def self.component
         'summon'
@@ -21,12 +27,20 @@ module PartyDifficulty
 
       def matching_count(party)
         min_level = params[:min_uncap_level].to_i
+        max_level_present = params[:max_uncap_level].present?
+        max_level = params[:max_uncap_level].to_i
         filter = params[:gacha_filter].to_s
 
         party.summons
              .reject { |gs| gs.friend == true }
              .select { |gs| matches_gacha_filter?(gs.summon, filter) }
-             .count { |gs| gs.uncap_level.to_i >= min_level }
+             .count do |gs|
+               level = gs.uncap_level.to_i
+               next false if level < min_level
+               next false if max_level_present && level > max_level
+
+               true
+             end
       end
 
       private

--- a/app/services/party_difficulty/rules/summon_uncap_at_least.rb
+++ b/app/services/party_difficulty/rules/summon_uncap_at_least.rb
@@ -3,10 +3,12 @@
 module PartyDifficulty
   module Rules
     ##
-    # Fires when at least min_count summons (main, sub, or friend) have
-    # uncap_level >= min_uncap_level.
+    # Fires when at least min_count summons (main or sub — friend summons are
+    # excluded since they belong to the player who joined the raid) have
+    # uncap_level >= min_uncap_level. Optionally filter by whether the summon
+    # is gacha ("gacha") or free ("free") using its promotions array.
     #
-    # params: { "min_uncap_level": 5, "min_count": 1 }
+    # params: { "min_uncap_level": 5, "min_count": 1, "gacha_filter": "gacha"|"free"|"any" }
     class SummonUncapAtLeast < Base
       def self.component
         'summon'
@@ -19,7 +21,25 @@ module PartyDifficulty
 
       def matching_count(party)
         min_level = params[:min_uncap_level].to_i
-        party.summons.count { |gs| gs.uncap_level.to_i >= min_level }
+        filter = params[:gacha_filter].to_s
+
+        party.summons
+             .reject { |gs| gs.friend == true }
+             .select { |gs| matches_gacha_filter?(gs.summon, filter) }
+             .count { |gs| gs.uncap_level.to_i >= min_level }
+      end
+
+      private
+
+      def matches_gacha_filter?(summon, filter)
+        return true if filter.blank? || filter == 'any' || summon.nil?
+
+        promotions = Array(summon.promotions)
+        case filter
+        when 'gacha' then promotions.any?
+        when 'free' then promotions.empty?
+        else true
+        end
       end
     end
   end

--- a/app/services/party_difficulty/rules/summon_uncap_at_least.rb
+++ b/app/services/party_difficulty/rules/summon_uncap_at_least.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count summons (main, sub, or friend) have
+    # uncap_level >= min_uncap_level.
+    #
+    # params: { "min_uncap_level": 5, "min_count": 1 }
+    class SummonUncapAtLeast < Base
+      def self.component
+        'summon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:min_uncap_level].to_i.positive? ? [] : ['min_uncap_level must be > 0']
+      end
+
+      def matching_count(party)
+        min_level = params[:min_uncap_level].to_i
+        party.summons.count { |gs| gs.uncap_level.to_i >= min_level }
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_awakening_at_least.rb
+++ b/app/services/party_difficulty/rules/weapon_awakening_at_least.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count weapons have an awakening at or above
+    # min_level. Optionally restricted to a specific awakening_id.
+    #
+    # params: { "min_level": 5, "awakening_id": "uuid"|null, "min_count": 3 }
+    class WeaponAwakeningAtLeast < Base
+      def self.component
+        'weapon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:min_level].to_i.positive? ? [] : ['min_level must be > 0']
+      end
+
+      def matching_count(party)
+        min_level = params[:min_level].to_i
+        awakening_id = params[:awakening_id].presence&.to_s
+
+        party.weapons.count do |gw|
+          next false unless gw.awakening_id.present?
+          next false if awakening_id && gw.awakening_id.to_s != awakening_id
+
+          gw.awakening_level.to_i >= min_level
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_ax_filled.rb
+++ b/app/services/party_difficulty/rules/weapon_ax_filled.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count weapons have at least min_filled AX modifier
+    # slots filled (proxy for AX RNG investment).
+    #
+    # params: { "min_filled": 1, "min_count": 3 }
+    class WeaponAxFilled < Base
+      def self.component
+        'weapon'
+      end
+
+      def matching_count(party)
+        min_filled = (params[:min_filled].presence || 1).to_i
+        party.weapons.count do |gw|
+          slots = [gw.ax_modifier1_id.present?, gw.ax_modifier2_id.present?].count(true)
+          slots >= min_filled
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_befoulment_filled.rb
+++ b/app/services/party_difficulty/rules/weapon_befoulment_filled.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count weapons have a befoulment modifier set.
+    #
+    # params: { "min_count": 1 }
+    class WeaponBefoulmentFilled < Base
+      def self.component
+        'weapon'
+      end
+
+      def matching_count(party)
+        party.weapons.count { |gw| gw.befoulment_modifier_id.present? }
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_bullet_match.rb
+++ b/app/services/party_difficulty/rules/weapon_bullet_match.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count grid weapons have any of the specified
+    # bullets slotted.
+    #
+    # params: { "bullet_ids": ["uuid", ...], "min_count": 1 }
+    class WeaponBulletMatch < Base
+      def self.component
+        'weapon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:bullet_ids].present? ? [] : ['bullet_ids must be provided']
+      end
+
+      def matching_count(party)
+        ids = string_array_param(:bullet_ids)
+        return 0 if ids.empty?
+
+        party.weapons.count do |gw|
+          bullets = gw.grid_weapon_bullets.to_a
+          bullets.any? { |b| ids.include?(b.bullet_id.to_s) }
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_promotion_includes.rb
+++ b/app/services/party_difficulty/rules/weapon_promotion_includes.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count weapons have one of the specified promotion
+    # values in their `promotions` array (Premium, Classic, Flash, Legend, etc.).
+    #
+    # params: { "promotions": ["Flash", "Legend"], "min_count": 2 }
+    class WeaponPromotionIncludes < Base
+      def self.component
+        'weapon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:promotions].present? ? [] : ['promotions must be provided']
+      end
+
+      def matching_count(party)
+        promotions = string_array_param(:promotions)
+        return 0 if promotions.empty?
+
+        party.weapons.count do |gw|
+          weapon_promotions = Array(gw.weapon&.promotions)
+          weapon_promotions.intersect?(promotions)
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_release_within_days.rb
+++ b/app/services/party_difficulty/rules/weapon_release_within_days.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count weapons were released within the last `days` days.
+    # This is the time-decay rule for weapons — recently released items make a
+    # team harder to assemble.
+    #
+    # params: { "days": 180, "min_count": 1 }
+    class WeaponReleaseWithinDays < Base
+      def self.component
+        'weapon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:days].to_i.positive? ? [] : ['days must be > 0']
+      end
+
+      def matching_count(party)
+        cutoff = params[:days].to_i.days.ago.to_date
+        party.weapons.count { |gw| gw.weapon&.release_date && gw.weapon.release_date >= cutoff }
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_release_within_days.rb
+++ b/app/services/party_difficulty/rules/weapon_release_within_days.rb
@@ -3,11 +3,12 @@
 module PartyDifficulty
   module Rules
     ##
-    # Fires when at least min_count weapons were released within the last `days` days.
-    # This is the time-decay rule for weapons — recently released items make a
-    # team harder to assemble.
+    # Fires when at least min_count weapons were released between
+    # `min_days_ago` (inclusive, default 0) and `days` (exclusive) days ago.
+    # The lower bound lets you build mutually exclusive age brackets — e.g.
+    # `min_days_ago: 14, days: 30` matches weapons that are 14 to 30 days old.
     #
-    # params: { "days": 180, "min_count": 1 }
+    # params: { "days": 14, "min_days_ago": 0, "min_count": 1 }
     class WeaponReleaseWithinDays < Base
       def self.component
         'weapon'
@@ -19,8 +20,14 @@ module PartyDifficulty
       end
 
       def matching_count(party)
-        cutoff = params[:days].to_i.days.ago.to_date
-        party.weapons.count { |gw| gw.weapon&.release_date && gw.weapon.release_date >= cutoff }
+        upper = params[:days].to_i.days.ago.to_date
+        lower_days = params[:min_days_ago].to_i
+        lower = lower_days.positive? ? lower_days.days.ago.to_date : Date.current
+
+        party.weapons.count do |gw|
+          release = gw.weapon&.release_date
+          release && release >= upper && release <= lower
+        end
       end
     end
   end

--- a/app/services/party_difficulty/rules/weapon_seasonal_match.rb
+++ b/app/services/party_difficulty/rules/weapon_seasonal_match.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires for weapons whose recruited character belongs to one of the given
+    # seasons (Valentine=1, Formal=2, Summer=3, Halloween=4, Holiday=5).
+    # Supports per-match age decay so older seasonal weapons score lower than
+    # recent ones — pass `decay_per_year` (e.g. 0.1 = 10% per year, with a
+    # floor at `decay_floor` or 0.1).
+    #
+    # params: {
+    #   "seasons": [2],
+    #   "min_count": 1,
+    #   "scale_by_count": true,
+    #   "max_count": 3,
+    #   "decay_per_year": 0.1
+    # }
+    class WeaponSeasonalMatch < Base
+      def self.component
+        'weapon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:seasons].present? ? [] : ['seasons must be provided']
+      end
+
+      def matching_count(party)
+        matching_weapons(party).size
+      end
+
+      def match_factors(party)
+        matching_weapons(party).map { |gw| decay_factor_for(gw.weapon&.release_date) }
+      end
+
+      private
+
+      def matching_weapons(party)
+        seasons = Array(params[:seasons]).map(&:to_i)
+        return [] if seasons.empty?
+
+        party.weapons.select do |gw|
+          season = gw.weapon&.recruited_character&.season
+          season.present? && seasons.include?(season.to_i)
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_series_match.rb
+++ b/app/services/party_difficulty/rules/weapon_series_match.rb
@@ -48,14 +48,7 @@ module PartyDifficulty
       end
 
       def resolve_slugs(slugs)
-        return [] if slugs.empty?
-
-        cache = Thread.current[:pd_weapon_series_cache]
-        if cache
-          slugs.filter_map { |s| cache[s] }
-        else
-          WeaponSeries.where(slug: slugs).pluck(:id)
-        end
+        resolve_slugs_via_cache(slugs, Thread.current[:pd_weapon_series_cache], WeaponSeries)
       end
     end
   end

--- a/app/services/party_difficulty/rules/weapon_series_match.rb
+++ b/app/services/party_difficulty/rules/weapon_series_match.rb
@@ -23,13 +23,21 @@ module PartyDifficulty
       end
 
       def matching_count(party)
-        ids = resolved_series_ids
-        return 0 if ids.empty?
+        matching_weapons(party).size
+      end
 
-        party.weapons.count { |gw| gw.weapon && ids.include?(gw.weapon.weapon_series_id) }
+      def match_factors(party)
+        matching_weapons(party).map { |gw| decay_factor_for(gw.weapon&.release_date) }
       end
 
       private
+
+      def matching_weapons(party)
+        ids = resolved_series_ids
+        return [] if ids.empty?
+
+        party.weapons.select { |gw| gw.weapon && ids.include?(gw.weapon.weapon_series_id) }
+      end
 
       def resolved_series_ids
         @resolved_series_ids ||= begin

--- a/app/services/party_difficulty/rules/weapon_series_match.rb
+++ b/app/services/party_difficulty/rules/weapon_series_match.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count weapons in the party belong to one of the
+    # specified weapon series. Series may be referenced by id (UUID string) or
+    # by slug (e.g. "grand", "providence").
+    #
+    # params: { "series_ids": ["uuid", ...], "slugs": ["grand", ...], "min_count": 1 }
+    class WeaponSeriesMatch < Base
+      def self.component
+        'weapon'
+      end
+
+      def self.validate_params(params)
+        errors = []
+        params = (params || {}).with_indifferent_access
+        if params[:series_ids].blank? && params[:slugs].blank?
+          errors << 'series_ids or slugs must be provided'
+        end
+        errors
+      end
+
+      def matching_count(party)
+        ids = resolved_series_ids
+        return 0 if ids.empty?
+
+        party.weapons.count { |gw| gw.weapon && ids.include?(gw.weapon.weapon_series_id) }
+      end
+
+      private
+
+      def resolved_series_ids
+        @resolved_series_ids ||= begin
+          ids = string_array_param(:series_ids)
+          slug_ids = string_array_param(:slugs).then do |slugs|
+            slugs.empty? ? [] : WeaponSeries.where(slug: slugs).pluck(:id)
+          end
+          (ids + slug_ids).uniq
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_series_match.rb
+++ b/app/services/party_difficulty/rules/weapon_series_match.rb
@@ -34,10 +34,19 @@ module PartyDifficulty
       def resolved_series_ids
         @resolved_series_ids ||= begin
           ids = string_array_param(:series_ids)
-          slug_ids = string_array_param(:slugs).then do |slugs|
-            slugs.empty? ? [] : WeaponSeries.where(slug: slugs).pluck(:id)
-          end
+          slug_ids = resolve_slugs(string_array_param(:slugs))
           (ids + slug_ids).uniq
+        end
+      end
+
+      def resolve_slugs(slugs)
+        return [] if slugs.empty?
+
+        cache = Thread.current[:pd_weapon_series_cache]
+        if cache
+          slugs.filter_map { |s| cache[s] }
+        else
+          WeaponSeries.where(slug: slugs).pluck(:id)
         end
       end
     end

--- a/app/services/party_difficulty/rules/weapon_specific_match.rb
+++ b/app/services/party_difficulty/rules/weapon_specific_match.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count of the specified weapon ids are present.
+    # Useful for "team requires N copies of weapon X" patterns.
+    #
+    # params: { "weapon_ids": ["uuid", ...], "min_count": 3 }
+    class WeaponSpecificMatch < Base
+      def self.component
+        'weapon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:weapon_ids].present? ? [] : ['weapon_ids must be provided']
+      end
+
+      def matching_count(party)
+        ids = string_array_param(:weapon_ids)
+        return 0 if ids.empty?
+
+        party.weapons.count { |gw| ids.include?(gw.weapon_id.to_s) }
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_tier_match.rb
+++ b/app/services/party_difficulty/rules/weapon_tier_match.rb
@@ -84,6 +84,10 @@ module PartyDifficulty
                   params[:min_transcendence_step], params[:max_transcendence_step])
       end
 
+      # min_awakening_level / max_awakening_level apply to whichever awakening
+      # type the weapon currently has unless awakening_id is set. To require a
+      # specific type (e.g. ATK at level 5+), supply awakening_id alongside the
+      # level range.
       def matches_awakening?(grid_weapon)
         awakening_id = params[:awakening_id].presence&.to_s
         return false if awakening_id && grid_weapon.awakening_id.to_s != awakening_id
@@ -112,14 +116,7 @@ module PartyDifficulty
       end
 
       def resolve_slugs(slugs)
-        return [] if slugs.empty?
-
-        cache = Thread.current[:pd_weapon_series_cache]
-        if cache && slugs.all? { |s| cache.key?(s) }
-          slugs.filter_map { |s| cache[s] }
-        else
-          WeaponSeries.where(slug: slugs).pluck(:id)
-        end
+        resolve_slugs_via_cache(slugs, Thread.current[:pd_weapon_series_cache], WeaponSeries)
       end
     end
   end

--- a/app/services/party_difficulty/rules/weapon_tier_match.rb
+++ b/app/services/party_difficulty/rules/weapon_tier_match.rb
@@ -76,23 +76,31 @@ module PartyDifficulty
       end
 
       def matches_uncap?(grid_weapon)
-        min_level = params[:min_uncap_level].to_i
-        min_level.zero? || grid_weapon.uncap_level.to_i >= min_level
+        in_range?(grid_weapon.uncap_level.to_i, params[:min_uncap_level], params[:max_uncap_level])
       end
 
       def matches_transcendence?(grid_weapon)
-        min_step = params[:min_transcendence_step].to_i
-        min_step.zero? || grid_weapon.transcendence_step.to_i >= min_step
+        in_range?(grid_weapon.transcendence_step.to_i,
+                  params[:min_transcendence_step], params[:max_transcendence_step])
       end
 
       def matches_awakening?(grid_weapon)
-        min_level = params[:min_awakening_level].to_i
-        return true if min_level.zero?
-
         awakening_id = params[:awakening_id].presence&.to_s
         return false if awakening_id && grid_weapon.awakening_id.to_s != awakening_id
 
-        grid_weapon.awakening_level.to_i >= min_level
+        in_range?(grid_weapon.awakening_level.to_i,
+                  params[:min_awakening_level], params[:max_awakening_level])
+      end
+
+      def in_range?(value, min_param, max_param)
+        min = min_param.to_i
+        max_present = max_param.present?
+        max = max_param.to_i
+
+        return false if min.positive? && value < min
+        return false if max_present && value > max
+
+        true
       end
 
       def resolved_series_ids

--- a/app/services/party_difficulty/rules/weapon_tier_match.rb
+++ b/app/services/party_difficulty/rules/weapon_tier_match.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Multi-filter match used to score specific high-end weapon tiers like
+    # "Destroyer at ULB" or "Celestial ULB with awakening 5+". Counts weapons
+    # that satisfy every supplied filter; filters are ANDed together.
+    #
+    # params: {
+    #   "series_slugs": ["destroyer"],
+    #   "min_uncap_level": 5,
+    #   "min_transcendence_step": 3,
+    #   "min_awakening_level": 5,
+    #   "awakening_id": "uuid",
+    #   "gacha_filter": "gacha" | "free" | "any"
+    # }
+    class WeaponTierMatch < Base
+      def self.component
+        'weapon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        has_filter = params[:series_slugs].present? ||
+                     params[:series_ids].present? ||
+                     params[:min_uncap_level].to_i.positive? ||
+                     params[:min_transcendence_step].to_i.positive? ||
+                     params[:min_awakening_level].to_i.positive?
+        has_filter ? [] : ['at least one filter must be provided']
+      end
+
+      def matching_count(party)
+        matching_weapons(party).size
+      end
+
+      def match_factors(party)
+        matching_weapons(party).map { |gw| decay_factor_for(gw.weapon&.release_date) }
+      end
+
+      private
+
+      def matching_weapons(party)
+        party.weapons.select { |gw| matches?(gw) }
+      end
+
+      def matches?(grid_weapon)
+        weapon = grid_weapon.weapon
+        return false unless weapon
+
+        return false unless matches_series?(weapon)
+        return false unless matches_gacha?(weapon)
+        return false unless matches_uncap?(grid_weapon)
+        return false unless matches_transcendence?(grid_weapon)
+
+        matches_awakening?(grid_weapon)
+      end
+
+      def matches_series?(weapon)
+        ids = resolved_series_ids
+        return true if ids.empty?
+
+        ids.include?(weapon.weapon_series_id)
+      end
+
+      def matches_gacha?(weapon)
+        filter = params[:gacha_filter].to_s
+        return true if filter.blank? || filter == 'any'
+
+        promotions = Array(weapon.promotions)
+        case filter
+        when 'gacha' then promotions.any?
+        when 'free' then promotions.empty?
+        else true
+        end
+      end
+
+      def matches_uncap?(grid_weapon)
+        min_level = params[:min_uncap_level].to_i
+        min_level.zero? || grid_weapon.uncap_level.to_i >= min_level
+      end
+
+      def matches_transcendence?(grid_weapon)
+        min_step = params[:min_transcendence_step].to_i
+        min_step.zero? || grid_weapon.transcendence_step.to_i >= min_step
+      end
+
+      def matches_awakening?(grid_weapon)
+        min_level = params[:min_awakening_level].to_i
+        return true if min_level.zero?
+
+        awakening_id = params[:awakening_id].presence&.to_s
+        return false if awakening_id && grid_weapon.awakening_id.to_s != awakening_id
+
+        grid_weapon.awakening_level.to_i >= min_level
+      end
+
+      def resolved_series_ids
+        @resolved_series_ids ||= begin
+          ids = string_array_param(:series_ids)
+          slug_ids = resolve_slugs(string_array_param(:series_slugs))
+          (ids + slug_ids).uniq
+        end
+      end
+
+      def resolve_slugs(slugs)
+        return [] if slugs.empty?
+
+        cache = Thread.current[:pd_weapon_series_cache]
+        if cache && slugs.all? { |s| cache.key?(s) }
+          slugs.filter_map { |s| cache[s] }
+        else
+          WeaponSeries.where(slug: slugs).pluck(:id)
+        end
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_transcendence_at_least.rb
+++ b/app/services/party_difficulty/rules/weapon_transcendence_at_least.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count weapons have transcendence_step >= min_step.
+    #
+    # params: { "min_step": 4, "min_count": 1 }
+    class WeaponTranscendenceAtLeast < Base
+      def self.component
+        'weapon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:min_step].to_i.positive? ? [] : ['min_step must be > 0']
+      end
+
+      def matching_count(party)
+        min_step = params[:min_step].to_i
+        party.weapons.count { |gw| gw.transcendence_step.to_i >= min_step }
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/rules/weapon_uncap_at_least.rb
+++ b/app/services/party_difficulty/rules/weapon_uncap_at_least.rb
@@ -4,8 +4,11 @@ module PartyDifficulty
   module Rules
     ##
     # Fires when at least min_count weapons have uncap_level >= min_uncap_level.
+    # Optionally filter by whether the weapon is gacha ("gacha") or free
+    # ("free") using its promotions array — gacha weapons cost more to obtain
+    # so high uncaps on them typically score higher.
     #
-    # params: { "min_uncap_level": 5, "min_count": 5 }
+    # params: { "min_uncap_level": 5, "min_count": 5, "gacha_filter": "gacha"|"free"|"any" }
     class WeaponUncapAtLeast < Base
       def self.component
         'weapon'
@@ -18,7 +21,24 @@ module PartyDifficulty
 
       def matching_count(party)
         min_level = params[:min_uncap_level].to_i
-        party.weapons.count { |gw| gw.uncap_level.to_i >= min_level }
+        filter = params[:gacha_filter].to_s
+
+        party.weapons
+             .select { |gw| matches_gacha_filter?(gw.weapon, filter) }
+             .count { |gw| gw.uncap_level.to_i >= min_level }
+      end
+
+      private
+
+      def matches_gacha_filter?(weapon, filter)
+        return true if filter.blank? || filter == 'any' || weapon.nil?
+
+        promotions = Array(weapon.promotions)
+        case filter
+        when 'gacha' then promotions.any?
+        when 'free' then promotions.empty?
+        else true
+        end
       end
     end
   end

--- a/app/services/party_difficulty/rules/weapon_uncap_at_least.rb
+++ b/app/services/party_difficulty/rules/weapon_uncap_at_least.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  module Rules
+    ##
+    # Fires when at least min_count weapons have uncap_level >= min_uncap_level.
+    #
+    # params: { "min_uncap_level": 5, "min_count": 5 }
+    class WeaponUncapAtLeast < Base
+      def self.component
+        'weapon'
+      end
+
+      def self.validate_params(params)
+        params = (params || {}).with_indifferent_access
+        params[:min_uncap_level].to_i.positive? ? [] : ['min_uncap_level must be > 0']
+      end
+
+      def matching_count(party)
+        min_level = params[:min_uncap_level].to_i
+        party.weapons.count { |gw| gw.uncap_level.to_i >= min_level }
+      end
+    end
+  end
+end

--- a/app/services/party_query_builder.rb
+++ b/app/services/party_query_builder.rb
@@ -54,8 +54,26 @@ class PartyQueryBuilder
     query = apply_count_filters(query)
     query = apply_has_video_filter(query)
     query = apply_boost_mod_filter(query)
+    query = apply_difficulty_filter(query)
 
     query
+  end
+
+  # Filters by one or more difficulty tiers. Accepts a comma-separated list of
+  # UUIDs or slugs in the `difficulty` param.
+  def apply_difficulty_filter(query)
+    return query unless @params[:difficulty].present?
+
+    raw = @params[:difficulty].to_s.split(',').map(&:strip).reject(&:blank?)
+    return query if raw.empty?
+
+    uuids, slugs = raw.partition { |v| v.match?(UUID_REGEX) }
+    ids = uuids.dup
+    ids.concat(Difficulty.where(slug: slugs).pluck(:id)) if slugs.any?
+
+    return query.none if ids.empty?
+
+    query.where(difficulty_id: ids)
   end
 
   # Example callback method: if no explicit status filter is provided, we may want

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,3 +9,7 @@
     cron: '0 0 * * *'  # Daily at midnight
     class: CleanupPartyPreviewsJob
     queue: maintenance
+  party_difficulty_sweep:
+    cron: '0 4 * * *'  # Daily at 04:00
+    class: PartyDifficulty::SweepJob
+    queue: maintenance

--- a/db/migrate/20260510130000_create_difficulties.rb
+++ b/db/migrate/20260510130000_create_difficulties.rb
@@ -1,0 +1,17 @@
+class CreateDifficulties < ActiveRecord::Migration[8.0]
+  def change
+    create_table :difficulties, id: :uuid do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.text :description
+      t.decimal :min_score, precision: 5, scale: 2, null: false, default: 0
+      t.decimal :max_score, precision: 5, scale: 2, null: false, default: 100
+      t.integer :sort_order, null: false, default: 0
+      t.string :color
+      t.timestamps
+    end
+
+    add_index :difficulties, :slug, unique: true
+    add_index :difficulties, :sort_order
+  end
+end

--- a/db/migrate/20260510130001_create_difficulty_components.rb
+++ b/db/migrate/20260510130001_create_difficulty_components.rb
@@ -1,0 +1,13 @@
+class CreateDifficultyComponents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :difficulty_components, id: :uuid do |t|
+      t.string :name, null: false
+      t.decimal :weight, precision: 6, scale: 2, null: false, default: 1
+      t.boolean :enabled, null: false, default: true
+      t.integer :min_count_to_score, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :difficulty_components, :name, unique: true
+  end
+end

--- a/db/migrate/20260510130002_create_difficulty_rules.rb
+++ b/db/migrate/20260510130002_create_difficulty_rules.rb
@@ -1,0 +1,18 @@
+class CreateDifficultyRules < ActiveRecord::Migration[8.0]
+  def change
+    create_table :difficulty_rules, id: :uuid do |t|
+      t.string :component, null: false
+      t.string :rule_type, null: false
+      t.jsonb :params, null: false, default: {}
+      t.decimal :weight, precision: 6, scale: 2, null: false, default: 1
+      t.boolean :active, null: false, default: true
+      t.string :name, null: false
+      t.text :description
+      t.timestamps
+    end
+
+    add_index :difficulty_rules, :component
+    add_index :difficulty_rules, :rule_type
+    add_index :difficulty_rules, :active
+  end
+end

--- a/db/migrate/20260510130003_create_difficulty_configs.rb
+++ b/db/migrate/20260510130003_create_difficulty_configs.rb
@@ -1,0 +1,8 @@
+class CreateDifficultyConfigs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :difficulty_configs, id: :uuid do |t|
+      t.integer :ruleset_version, null: false, default: 1
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260510130004_add_difficulty_columns_to_parties.rb
+++ b/db/migrate/20260510130004_add_difficulty_columns_to_parties.rb
@@ -1,0 +1,12 @@
+class AddDifficultyColumnsToParties < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :parties, :difficulty, type: :uuid, null: true, foreign_key: true
+    add_column :parties, :difficulty_score, :decimal, precision: 5, scale: 2
+    add_column :parties, :difficulty_breakdown, :jsonb
+    add_column :parties, :difficulty_computed_at, :datetime
+    add_column :parties, :difficulty_ruleset_version, :integer
+
+    add_index :parties, :difficulty_score
+    add_index :parties, :difficulty_computed_at
+  end
+end

--- a/db/migrate/20260510130005_seed_party_difficulty.rb
+++ b/db/migrate/20260510130005_seed_party_difficulty.rb
@@ -1,0 +1,159 @@
+class SeedPartyDifficulty < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    seed_components
+    seed_tiers
+    seed_rules
+    DifficultyConfig.first || DifficultyConfig.create!(ruleset_version: 1)
+  end
+
+  def down
+    DifficultyRule.delete_all
+    Difficulty.delete_all
+    DifficultyComponent.delete_all
+    DifficultyConfig.delete_all
+  end
+
+  private
+
+  def seed_components
+    components = [
+      { name: 'weapon',    weight: 3.0, enabled: true,  min_count_to_score: 5 },
+      { name: 'character', weight: 1.5, enabled: true,  min_count_to_score: 3 },
+      { name: 'summon',    weight: 3.5, enabled: true,  min_count_to_score: 2 },
+      { name: 'job',       weight: 1.0, enabled: true,  min_count_to_score: 0 },
+      { name: 'accessory', weight: 0.5, enabled: true,  min_count_to_score: 0 }
+    ]
+    components.each do |attrs|
+      DifficultyComponent.find_or_create_by!(name: attrs[:name]) do |c|
+        c.assign_attributes(attrs)
+      end
+    end
+  end
+
+  def seed_tiers
+    tiers = [
+      { slug: 'casual',  name: 'Casual',   color: '#86C5A8', min_score: 0,    max_score: 24.99,  sort_order: 0,
+        description: 'Beginner-friendly setups built primarily from accessible characters, weapons, and summons.' },
+      { slug: 'mid',     name: 'Mid',      color: '#7AB8E8', min_score: 25,   max_score: 49.99,  sort_order: 1,
+        description: 'Solid mid-game teams with some investment but no rare endgame items.' },
+      { slug: 'endgame', name: 'Endgame',  color: '#E2B16C', min_score: 50,   max_score: 79.99,  sort_order: 2,
+        description: 'Endgame teams featuring rare or recently released items, deep uncaps, or notable awakenings.' },
+      { slug: 'whale',   name: 'Whale',    color: '#D78EA0', min_score: 80,   max_score: 100.0,  sort_order: 3,
+        description: 'High-investment teams featuring multiple Grand/Providence units, Trans5 weapons, and perpetuity-ringed characters.' }
+    ]
+    tiers.each do |attrs|
+      Difficulty.find_or_create_by!(slug: attrs[:slug]) do |t|
+        t.assign_attributes(attrs)
+      end
+    end
+  end
+
+  def seed_rules
+    rules = [
+      # Weapons -------------------------------------------------------------
+      { name: 'Grand series weapon present',           component: 'weapon',
+        rule_type: 'weapon_series_match', weight: 3.0,
+        params: { 'slugs' => ['grand'], 'min_count' => 1 } },
+      { name: 'Multiple Grand series weapons',         component: 'weapon',
+        rule_type: 'weapon_series_match', weight: 5.0,
+        params: { 'slugs' => ['grand'], 'min_count' => 3 } },
+      { name: 'Providence/Draconic weapon',            component: 'weapon',
+        rule_type: 'weapon_series_match', weight: 4.0,
+        params: { 'slugs' => ['providence'], 'min_count' => 1 } },
+      { name: 'High awakening (level >= 5) on 3+',     component: 'weapon',
+        rule_type: 'weapon_awakening_at_least', weight: 2.0,
+        params: { 'min_level' => 5, 'min_count' => 3 } },
+      { name: 'Max awakening (level 10) on any',       component: 'weapon',
+        rule_type: 'weapon_awakening_at_least', weight: 2.5,
+        params: { 'min_level' => 10, 'min_count' => 1 } },
+      { name: 'Trans5 weapon present',                 component: 'weapon',
+        rule_type: 'weapon_transcendence_at_least', weight: 4.0,
+        params: { 'min_step' => 5, 'min_count' => 1 } },
+      { name: 'Multiple transcended weapons',          component: 'weapon',
+        rule_type: 'weapon_transcendence_at_least', weight: 3.0,
+        params: { 'min_step' => 1, 'min_count' => 3 } },
+      { name: 'AX skills filled on 3+',                component: 'weapon',
+        rule_type: 'weapon_ax_filled', weight: 1.5,
+        params: { 'min_filled' => 1, 'min_count' => 3 } },
+      { name: 'Both AX slots filled on 3+',            component: 'weapon',
+        rule_type: 'weapon_ax_filled', weight: 2.0,
+        params: { 'min_filled' => 2, 'min_count' => 3 } },
+      { name: 'Befoulment present',                    component: 'weapon',
+        rule_type: 'weapon_befoulment_filled', weight: 2.0,
+        params: { 'min_count' => 1 } },
+      { name: 'Recently released weapon (180d)',       component: 'weapon',
+        rule_type: 'weapon_release_within_days', weight: 2.5,
+        params: { 'days' => 180, 'min_count' => 1 } },
+      { name: 'Flash/Legend exclusive weapons',        component: 'weapon',
+        rule_type: 'weapon_promotion_includes', weight: 1.5,
+        params: { 'promotions' => %w[Flash Legend], 'min_count' => 2 } },
+
+      # Characters ----------------------------------------------------------
+      { name: 'Grand character present',               component: 'character',
+        rule_type: 'character_series_match', weight: 2.5,
+        params: { 'slugs' => ['grand'], 'min_count' => 1 } },
+      { name: 'Multiple Grand characters',             component: 'character',
+        rule_type: 'character_series_match', weight: 3.5,
+        params: { 'slugs' => ['grand'], 'min_count' => 2 } },
+      { name: 'Eternal/Evoker character',              component: 'character',
+        rule_type: 'character_series_match', weight: 2.5,
+        params: { 'slugs' => %w[eternal evoker], 'min_count' => 1 } },
+      { name: 'Seasonal character',                    component: 'character',
+        rule_type: 'character_seasonal', weight: 1.0,
+        params: { 'min_count' => 1 } },
+      { name: 'Multiple seasonals',                    component: 'character',
+        rule_type: 'character_seasonal', weight: 2.0,
+        params: { 'min_count' => 3 } },
+      { name: 'Perpetuity ring on any character',      component: 'character',
+        rule_type: 'character_perpetuity_ringed', weight: 3.5,
+        params: { 'min_count' => 1 } },
+      { name: 'Strong earring (>=15)',                 component: 'character',
+        rule_type: 'character_earring_at_least', weight: 1.5,
+        params: { 'min_strength' => 15, 'min_count' => 1 } },
+      { name: 'Trans5 character present',              component: 'character',
+        rule_type: 'character_transcendence_at_least', weight: 3.0,
+        params: { 'min_step' => 5, 'min_count' => 1 } },
+      { name: 'Recently released character (180d)',    component: 'character',
+        rule_type: 'character_release_within_days', weight: 2.0,
+        params: { 'days' => 180, 'min_count' => 1 } },
+
+      # Summons -------------------------------------------------------------
+      { name: 'Providence summon present',             component: 'summon',
+        rule_type: 'summon_series_match', weight: 4.0,
+        params: { 'slugs' => ['providence'], 'min_count' => 1 } },
+      { name: 'Multiple Providence summons',           component: 'summon',
+        rule_type: 'summon_series_match', weight: 5.0,
+        params: { 'slugs' => ['providence'], 'min_count' => 2 } },
+      { name: 'High uncap (5+) on 3+',                 component: 'summon',
+        rule_type: 'summon_uncap_at_least', weight: 2.0,
+        params: { 'min_uncap_level' => 5, 'min_count' => 3 } },
+      { name: 'Trans5 summon present',                 component: 'summon',
+        rule_type: 'summon_transcendence_at_least', weight: 4.0,
+        params: { 'min_step' => 5, 'min_count' => 1 } },
+
+      # Job -----------------------------------------------------------------
+      { name: 'Row V job',                             component: 'job',
+        rule_type: 'job_row', weight: 2.0,
+        params: { 'rows' => ['V'] } },
+      { name: 'Origin job',                            component: 'job',
+        rule_type: 'job_row', weight: 3.0,
+        params: { 'rows' => ['Origin'] } },
+      { name: 'Row IV with Ultimate Mastery',          component: 'job',
+        rule_type: 'job_row', weight: 1.5,
+        params: { 'rows' => ['IV'], 'requires_ultimate_mastery' => true } },
+
+      # Accessory -----------------------------------------------------------
+      { name: 'Accessory equipped',                    component: 'accessory',
+        rule_type: 'accessory_match', weight: 1.0,
+        params: { 'accessory_types' => [1, 2] } }
+    ]
+
+    rules.each do |attrs|
+      DifficultyRule.find_or_create_by!(name: attrs[:name]) do |r|
+        r.assign_attributes(attrs.merge(active: true))
+      end
+    end
+  end
+end

--- a/db/migrate/20260510130005_seed_party_difficulty.rb
+++ b/db/migrate/20260510130005_seed_party_difficulty.rb
@@ -156,13 +156,13 @@ class SeedPartyDifficulty < ActiveRecord::Migration[8.0]
       # Job -----------------------------------------------------------------
       { name: 'Row V job',                             component: 'job',
         rule_type: 'job_row', weight: 2.0,
-        params: { 'rows' => ['V'] } },
+        params: { 'rows' => ['5'] } },
       { name: 'Origin job',                            component: 'job',
         rule_type: 'job_row', weight: 3.0,
-        params: { 'rows' => ['Origin'] } },
+        params: { 'rows' => ['o1'] } },
       { name: 'Row IV with Ultimate Mastery',          component: 'job',
         rule_type: 'job_row', weight: 1.5,
-        params: { 'rows' => ['IV'], 'requires_ultimate_mastery' => true } },
+        params: { 'rows' => ['4'], 'requires_ultimate_mastery' => true } },
 
       # Accessory -----------------------------------------------------------
       { name: 'Accessory equipped',                    component: 'accessory',

--- a/db/migrate/20260510130005_seed_party_difficulty.rb
+++ b/db/migrate/20260510130005_seed_party_difficulty.rb
@@ -43,10 +43,13 @@ class SeedPartyDifficulty < ActiveRecord::Migration[8.0]
       { slug: 'whale',   name: 'Whale',    color: '#D78EA0', min_score: 80,   max_score: 100.0,  sort_order: 3,
         description: 'High-investment teams featuring multiple Grand/Providence units, Trans5 weapons, and perpetuity-ringed characters.' }
     ]
+    # Tiers are seeded with validation disabled because the strict
+    # tier_coverage_complete validation rejects partial coverage; the loop
+    # creates rows one at a time so we can't satisfy it until the last row.
     tiers.each do |attrs|
-      Difficulty.find_or_create_by!(slug: attrs[:slug]) do |t|
-        t.assign_attributes(attrs)
-      end
+      next if Difficulty.exists?(slug: attrs[:slug])
+
+      Difficulty.new(attrs).save(validate: false)
     end
   end
 

--- a/db/migrate/20260510140000_resync_party_difficulty_rules.rb
+++ b/db/migrate/20260510140000_resync_party_difficulty_rules.rb
@@ -1,60 +1,32 @@
-class SeedPartyDifficulty < ActiveRecord::Migration[8.0]
+class ResyncPartyDifficultyRules < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
+  # Replaces the rules seeded in 20260510130005 with a new set that uses
+  # scale_by_count for series/uncap rules and a gacha_filter to distinguish
+  # high-uncap gacha items from high-uncap free items. Safe to run on fresh
+  # installs (it just clears the table the seed migration just populated).
   def up
-    seed_components
-    seed_tiers
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    DifficultyRule.delete_all
     seed_rules
-    DifficultyConfig.first || DifficultyConfig.create!(ruleset_version: 1)
   end
 
   def down
     DifficultyRule.delete_all
-    Difficulty.delete_all
-    DifficultyComponent.delete_all
-    DifficultyConfig.delete_all
   end
 
   private
 
-  def seed_components
-    components = [
-      { name: 'weapon',    weight: 3.0, enabled: true,  min_count_to_score: 5 },
-      { name: 'character', weight: 1.5, enabled: true,  min_count_to_score: 3 },
-      { name: 'summon',    weight: 3.5, enabled: true,  min_count_to_score: 2 },
-      { name: 'job',       weight: 1.0, enabled: true,  min_count_to_score: 0 },
-      { name: 'accessory', weight: 0.5, enabled: true,  min_count_to_score: 0 }
-    ]
-    components.each do |attrs|
-      DifficultyComponent.find_or_create_by!(name: attrs[:name]) do |c|
-        c.assign_attributes(attrs)
-      end
-    end
-  end
-
-  def seed_tiers
-    tiers = [
-      { slug: 'casual',  name: 'Casual',   color: '#86C5A8', min_score: 0,    max_score: 24.99,  sort_order: 0,
-        description: 'Beginner-friendly setups built primarily from accessible characters, weapons, and summons.' },
-      { slug: 'mid',     name: 'Mid',      color: '#7AB8E8', min_score: 25,   max_score: 49.99,  sort_order: 1,
-        description: 'Solid mid-game teams with some investment but no rare endgame items.' },
-      { slug: 'endgame', name: 'Endgame',  color: '#E2B16C', min_score: 50,   max_score: 79.99,  sort_order: 2,
-        description: 'Endgame teams featuring rare or recently released items, deep uncaps, or notable awakenings.' },
-      { slug: 'whale',   name: 'Whale',    color: '#D78EA0', min_score: 80,   max_score: 100.0,  sort_order: 3,
-        description: 'High-investment teams featuring multiple Grand/Providence units, Trans5 weapons, and perpetuity-ringed characters.' }
-    ]
-    tiers.each do |attrs|
-      Difficulty.find_or_create_by!(slug: attrs[:slug]) do |t|
-        t.assign_attributes(attrs)
-      end
-    end
-  end
-
   def seed_rules
-    rules = [
-      # Weapons -------------------------------------------------------------
-      # Series rules use scale_by_count so each additional matching weapon
-      # adds to the score, with a cap so the contribution doesn't run away.
+    rules.each do |attrs|
+      DifficultyRule.create!(attrs.merge(active: true))
+    end
+  end
+
+  def rules
+    [
+      # Weapons -----------------------------------------------------------
       { name: 'Grand series weapons',                  component: 'weapon',
         rule_type: 'weapon_series_match', weight: 2.0,
         params: { 'slugs' => ['grand'], 'min_count' => 1,
@@ -93,8 +65,6 @@ class SeedPartyDifficulty < ActiveRecord::Migration[8.0]
       { name: 'Flash/Legend exclusive weapons',        component: 'weapon',
         rule_type: 'weapon_promotion_includes', weight: 1.5,
         params: { 'promotions' => %w[Flash Legend], 'min_count' => 2 } },
-      # Gacha weapons at high uncap weigh more than free ones at the same
-      # uncap, since they cost more to obtain.
       { name: 'High uncap on gacha weapons',           component: 'weapon',
         rule_type: 'weapon_uncap_at_least', weight: 1.5,
         params: { 'min_uncap_level' => 5, 'min_count' => 1,
@@ -106,7 +76,7 @@ class SeedPartyDifficulty < ActiveRecord::Migration[8.0]
                   'gacha_filter' => 'free',
                   'scale_by_count' => true, 'max_count' => 5 } },
 
-      # Characters ----------------------------------------------------------
+      # Characters --------------------------------------------------------
       { name: 'Grand characters',                      component: 'character',
         rule_type: 'character_series_match', weight: 2.0,
         params: { 'slugs' => ['grand'], 'min_count' => 1,
@@ -132,9 +102,7 @@ class SeedPartyDifficulty < ActiveRecord::Migration[8.0]
         rule_type: 'character_release_within_days', weight: 2.0,
         params: { 'days' => 180, 'min_count' => 1 } },
 
-      # Summons -------------------------------------------------------------
-      # Friend summons are excluded — they belong to the player joining the
-      # raid, not the party owner.
+      # Summons -----------------------------------------------------------
       { name: 'Providence summons',                    component: 'summon',
         rule_type: 'summon_series_match', weight: 3.0,
         params: { 'slugs' => ['providence'], 'min_count' => 1,
@@ -153,7 +121,7 @@ class SeedPartyDifficulty < ActiveRecord::Migration[8.0]
         rule_type: 'summon_transcendence_at_least', weight: 4.0,
         params: { 'min_step' => 5, 'min_count' => 1 } },
 
-      # Job -----------------------------------------------------------------
+      # Job ---------------------------------------------------------------
       { name: 'Row V job',                             component: 'job',
         rule_type: 'job_row', weight: 2.0,
         params: { 'rows' => ['V'] } },
@@ -164,16 +132,10 @@ class SeedPartyDifficulty < ActiveRecord::Migration[8.0]
         rule_type: 'job_row', weight: 1.5,
         params: { 'rows' => ['IV'], 'requires_ultimate_mastery' => true } },
 
-      # Accessory -----------------------------------------------------------
+      # Accessory ---------------------------------------------------------
       { name: 'Accessory equipped',                    component: 'accessory',
         rule_type: 'accessory_match', weight: 1.0,
         params: { 'accessory_types' => [1, 2] } }
     ]
-
-    rules.each do |attrs|
-      DifficultyRule.find_or_create_by!(name: attrs[:name]) do |r|
-        r.assign_attributes(attrs.merge(active: true))
-      end
-    end
   end
 end

--- a/db/migrate/20260510140000_resync_party_difficulty_rules.rb
+++ b/db/migrate/20260510140000_resync_party_difficulty_rules.rb
@@ -91,7 +91,7 @@ class ResyncPartyDifficultyRules < ActiveRecord::Migration[8.0]
                   'scale_by_count' => true, 'max_count' => 4 } },
       { name: 'Perpetuity ring on any character',      component: 'character',
         rule_type: 'character_perpetuity_ringed', weight: 3.5,
-        params: { 'min_count' => 1 } },
+        params: { 'min_count' => 1, 'scale_by_count' => true, 'max_count' => 5 } },
       { name: 'Strong earring (>=15)',                 component: 'character',
         rule_type: 'character_earring_at_least', weight: 1.5,
         params: { 'min_strength' => 15, 'min_count' => 1 } },

--- a/db/migrate/20260510140000_resync_party_difficulty_rules.rb
+++ b/db/migrate/20260510140000_resync_party_difficulty_rules.rb
@@ -124,13 +124,13 @@ class ResyncPartyDifficultyRules < ActiveRecord::Migration[8.0]
       # Job ---------------------------------------------------------------
       { name: 'Row V job',                             component: 'job',
         rule_type: 'job_row', weight: 2.0,
-        params: { 'rows' => ['V'] } },
+        params: { 'rows' => ['5'] } },
       { name: 'Origin job',                            component: 'job',
         rule_type: 'job_row', weight: 3.0,
-        params: { 'rows' => ['Origin'] } },
+        params: { 'rows' => ['o1'] } },
       { name: 'Row IV with Ultimate Mastery',          component: 'job',
         rule_type: 'job_row', weight: 1.5,
-        params: { 'rows' => ['IV'], 'requires_ultimate_mastery' => true } },
+        params: { 'rows' => ['4'], 'requires_ultimate_mastery' => true } },
 
       # Accessory ---------------------------------------------------------
       { name: 'Accessory equipped',                    component: 'accessory',

--- a/db/migrate/20260510150000_seed_rare_accessory_rules.rb
+++ b/db/migrate/20260510150000_seed_rare_accessory_rules.rb
@@ -29,13 +29,13 @@ class SeedRareAccessoryRules < ActiveRecord::Migration[8.0]
           9a063ae4-8aed-427a-b029-08fd0c1b0364
           a73e97e1-3e68-47ec-9c90-7b7fd1c2f29f
           17defece-d8d7-4108-95ca-504533dd0ac9
-        ] } },
+        ], 'min_count' => 1, 'scale_by_count' => true, 'max_count' => 4 } },
       { name: 'Mainhand: high-tier Expert Model bullet', component: 'accessory',
         rule_type: 'mainhand_bullet_match', weight: 3.5,
         params: { 'bullet_ids' => %w[
           9eb5962e-8a90-4734-8da6-49e8d3194212
           ba6e03ac-1eec-4bb6-9282-96d0a834836a
-        ] } },
+        ], 'min_count' => 1, 'scale_by_count' => true, 'max_count' => 4 } },
 
       # Manaturas ----------------------------------------------------------
       { name: 'Top-tier manatura',                       component: 'accessory',

--- a/db/migrate/20260510150000_seed_rare_accessory_rules.rb
+++ b/db/migrate/20260510150000_seed_rare_accessory_rules.rb
@@ -1,0 +1,60 @@
+class SeedRareAccessoryRules < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Seeds rules for very rare mainhand bullets and manaturas. All are scored
+  # under the `accessory` component since they're gated like accessories
+  # (one slot per party) rather than like weapon investment.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    rules.each do |attrs|
+      DifficultyRule.find_or_create_by!(name: attrs[:name]) do |r|
+        r.assign_attributes(attrs.merge(active: true))
+      end
+    end
+  end
+
+  def down
+    DifficultyRule.where(name: rules.map { |r| r[:name] }).delete_all
+  end
+
+  private
+
+  def rules
+    [
+      # Mainhand bullets ---------------------------------------------------
+      { name: 'Mainhand: top-tier Expert Model bullet',  component: 'accessory',
+        rule_type: 'mainhand_bullet_match', weight: 6.0,
+        params: { 'bullet_ids' => %w[
+          9a063ae4-8aed-427a-b029-08fd0c1b0364
+          a73e97e1-3e68-47ec-9c90-7b7fd1c2f29f
+          17defece-d8d7-4108-95ca-504533dd0ac9
+        ] } },
+      { name: 'Mainhand: high-tier Expert Model bullet', component: 'accessory',
+        rule_type: 'mainhand_bullet_match', weight: 3.5,
+        params: { 'bullet_ids' => %w[
+          9eb5962e-8a90-4734-8da6-49e8d3194212
+          ba6e03ac-1eec-4bb6-9282-96d0a834836a
+        ] } },
+
+      # Manaturas ----------------------------------------------------------
+      { name: 'Top-tier manatura',                       component: 'accessory',
+        rule_type: 'accessory_match', weight: 6.0,
+        params: { 'accessory_ids' => %w[
+          a2cf6934-deab-4082-8eb8-6ec3c9c0d53e
+          70db38f8-3761-4c10-815d-17ab02db527b
+        ] } },
+      { name: 'High-tier manatura',                      component: 'accessory',
+        rule_type: 'accessory_match', weight: 3.5,
+        params: { 'accessory_ids' => %w[
+          f4b79884-95e8-4a7a-a559-69de2badd69f
+          0a8e472c-cc48-4284-b4c1-0b72790e3af3
+          c38626f0-a8bf-466b-aa35-d26466576864
+        ] } },
+      { name: 'Unobtainable collab manatura (Chachazero)', component: 'accessory',
+        rule_type: 'accessory_match', weight: 8.0,
+        params: { 'accessory_ids' => %w[fa567a0a-70ea-43e4-8bbc-7fab28fb9dae] } }
+    ]
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/db/migrate/20260510160000_seed_seasonal_weapon_rules.rb
+++ b/db/migrate/20260510160000_seed_seasonal_weapon_rules.rb
@@ -1,0 +1,63 @@
+class SeedSeasonalWeaponRules < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Seeds rules for seasonal weapons (Formal / Halloween / Valentine / Holiday /
+  # Summer-Yukata) tiered by availability window, and adds age-decay to both
+  # the seasonal rules and the existing Grand-series rule so the score reflects
+  # how recently a hard-to-obtain weapon was released.
+  #
+  # Decay model: contribution per match = weight × max(decay_floor, 1 - decay_per_year × years_since_release).
+  # 10% per year with a 10% floor: a freshly-released item contributes its full
+  # weight, drops to 90% after a year, and bottoms out at 10% after 9 years.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    seasonal_rules.each do |attrs|
+      DifficultyRule.find_or_create_by!(name: attrs[:name]) do |r|
+        r.assign_attributes(attrs.merge(active: true))
+      end
+    end
+
+    # Patch the existing Grand-series weapon rule to apply decay so newer
+    # Grands score higher than ancient ones.
+    grand_rule = DifficultyRule.find_by(name: 'Grand series weapons')
+    if grand_rule
+      params = grand_rule.params || {}
+      params['decay_per_year'] = 0.1 unless params.key?('decay_per_year')
+      params['decay_floor'] = 0.2 unless params.key?('decay_floor')
+      grand_rule.update!(params: params)
+    end
+  end
+
+  def down
+    DifficultyRule.where(name: seasonal_rules.map { |r| r[:name] }).delete_all
+  end
+
+  private
+
+  def seasonal_rules
+    [
+      # Formal: ~2-week availability per year, the rarest seasonal.
+      { name: 'Formal seasonal weapons', component: 'weapon',
+        rule_type: 'weapon_seasonal_match', weight: 5.0,
+        params: { 'seasons' => [2], 'min_count' => 1,
+                  'scale_by_count' => true, 'max_count' => 3,
+                  'decay_per_year' => 0.1, 'decay_floor' => 0.2 } },
+
+      # Halloween / Valentine / Holiday: similar mid-tier seasonal windows.
+      { name: 'Halloween/Valentine/Holiday seasonal weapons', component: 'weapon',
+        rule_type: 'weapon_seasonal_match', weight: 3.5,
+        params: { 'seasons' => [1, 4, 5], 'min_count' => 1,
+                  'scale_by_count' => true, 'max_count' => 4,
+                  'decay_per_year' => 0.1, 'decay_floor' => 0.15 } },
+
+      # Summer / Yukata: longest seasonal window — easier to obtain than the
+      # others but still above normal. Roughly on par with Grand series.
+      { name: 'Summer/Yukata seasonal weapons',          component: 'weapon',
+        rule_type: 'weapon_seasonal_match', weight: 2.0,
+        params: { 'seasons' => [3], 'min_count' => 1,
+                  'scale_by_count' => true, 'max_count' => 4,
+                  'decay_per_year' => 0.1, 'decay_floor' => 0.15 } }
+    ]
+  end
+end

--- a/db/migrate/20260510170000_scale_bullet_and_ring_rules.rb
+++ b/db/migrate/20260510170000_scale_bullet_and_ring_rules.rb
@@ -1,0 +1,40 @@
+class ScaleBulletAndRingRules < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Enables count scaling on rules where each additional match represents
+  # real additional investment: top/high-tier mainhand bullets (one weapon
+  # can carry multiple), and perpetuity-ringed characters (a team can have
+  # several).
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    patches.each do |name, extra_params|
+      rule = DifficultyRule.find_by(name: name)
+      next unless rule
+
+      params = (rule.params || {}).deep_dup
+      extra_params.each { |k, v| params[k] = v unless params.key?(k) }
+      rule.update!(params: params)
+    end
+  end
+
+  def down
+    # Best-effort revert: remove the scaling keys we added.
+    DifficultyRule.where(name: patches.keys).each do |rule|
+      params = (rule.params || {}).deep_dup
+      params.delete('scale_by_count')
+      params.delete('max_count')
+      rule.update!(params: params)
+    end
+  end
+
+  private
+
+  def patches
+    {
+      'Mainhand: top-tier Expert Model bullet'  => { 'scale_by_count' => true, 'max_count' => 4 },
+      'Mainhand: high-tier Expert Model bullet' => { 'scale_by_count' => true, 'max_count' => 4 },
+      'Perpetuity ring on any character'        => { 'scale_by_count' => true, 'max_count' => 5 }
+    }
+  end
+end

--- a/db/migrate/20260510180000_seed_endgame_weapon_tier_rules.rb
+++ b/db/migrate/20260510180000_seed_endgame_weapon_tier_rules.rb
@@ -1,0 +1,70 @@
+class SeedEndgameWeaponTierRules < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Endgame weapon tiers based on user-supplied ranking:
+  #   Destroyer ULB > Destroyer FLB > Trans5 Dark Opus ≈ Celestial ULB Awak5
+  #   > Celestial ULB > Trans3 Dark Opus ≈ Celestial FLB ≈ Draconic Providence
+  #
+  # All rules fire on "at least" thresholds so a Destroyer ULB also triggers
+  # the FLB rule — the higher tier just adds more weight.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    rules.each do |attrs|
+      DifficultyRule.find_or_create_by!(name: attrs[:name]) do |r|
+        r.assign_attributes(attrs.merge(active: true))
+      end
+    end
+
+    # Bump the existing Providence/Draconic rule up to weight 3.0 so it
+    # aligns with the new tier ladder (Trans3 Dark Opus / Celestial FLB).
+    providence = DifficultyRule.find_by(name: 'Providence/Draconic weapons')
+    providence&.update!(weight: 3.0)
+  end
+
+  def down
+    DifficultyRule.where(name: rules.map { |r| r[:name] }).delete_all
+  end
+
+  private
+
+  def rules
+    [
+      { name: 'Destroyer weapon FLB',                  component: 'weapon',
+        rule_type: 'weapon_tier_match', weight: 5.0,
+        params: { 'series_slugs' => ['destroyer'], 'min_uncap_level' => 4 } },
+      { name: 'Destroyer weapon ULB',                  component: 'weapon',
+        rule_type: 'weapon_tier_match', weight: 6.0,
+        params: { 'series_slugs' => ['destroyer'], 'min_uncap_level' => 5 } },
+
+      { name: 'Trans3 Dark Opus weapon',               component: 'weapon',
+        rule_type: 'weapon_tier_match', weight: 3.0,
+        params: { 'series_slugs' => ['dark-opus'], 'min_transcendence_step' => 3 } },
+      { name: 'Trans5 Dark Opus weapon',               component: 'weapon',
+        rule_type: 'weapon_tier_match', weight: 4.0,
+        params: { 'series_slugs' => ['dark-opus'], 'min_transcendence_step' => 5 } },
+
+      { name: 'Celestial weapon FLB',                  component: 'weapon',
+        rule_type: 'weapon_tier_match', weight: 3.0,
+        params: { 'series_slugs' => ['celestial'], 'min_uncap_level' => 4 } },
+      { name: 'Celestial weapon ULB',                  component: 'weapon',
+        rule_type: 'weapon_tier_match', weight: 3.5,
+        params: { 'series_slugs' => ['celestial'], 'min_uncap_level' => 5 } },
+      { name: 'Celestial weapon ULB + Awakening 5+',   component: 'weapon',
+        rule_type: 'weapon_tier_match', weight: 4.0,
+        params: { 'series_slugs' => ['celestial'], 'min_uncap_level' => 5,
+                  'min_awakening_level' => 5 } },
+
+      # Sits below Celestial — moderately rare but easier to assemble.
+      { name: 'Superlative weapon',                    component: 'weapon',
+        rule_type: 'weapon_tier_match', weight: 2.5,
+        params: { 'series_slugs' => ['superlative'] } },
+
+      # Tier-equivalent to Trans5 Dark Opus.
+      { name: 'Illustrious weapon',                    component: 'weapon',
+        rule_type: 'weapon_tier_match', weight: 4.0,
+        params: { 'series_slugs' => ['illustrious'] } }
+    ]
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/db/migrate/20260510190000_seed_recency_brackets.rb
+++ b/db/migrate/20260510190000_seed_recency_brackets.rb
@@ -1,0 +1,65 @@
+class SeedRecencyBrackets < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Replaces the single "released within 180 days" rules with four mutually
+  # exclusive brackets per component (weapon / character / summon). Brand-new
+  # items signal active spending; older items get progressively less weight,
+  # and anything past 180 days isn't scored.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    DifficultyRule.where(name: legacy_names).delete_all
+
+    rules.each do |attrs|
+      DifficultyRule.find_or_create_by!(name: attrs[:name]) do |r|
+        r.assign_attributes(attrs.merge(active: true))
+      end
+    end
+  end
+
+  def down
+    DifficultyRule.where(name: rules.map { |r| r[:name] }).delete_all
+  end
+
+  private
+
+  def legacy_names
+    [
+      'Recently released weapon (180d)',
+      'Recently released character (180d)'
+    ]
+  end
+
+  BRACKETS = [
+    { suffix: 'released < 14d',  min_days: 0,   max_days: 14,  weight: 4.0 },
+    { suffix: 'released < 30d',  min_days: 14,  max_days: 30,  weight: 3.0 },
+    { suffix: 'released < 90d',  min_days: 30,  max_days: 90,  weight: 2.0 },
+    { suffix: 'released < 180d', min_days: 90,  max_days: 180, weight: 1.0 }
+  ].freeze
+
+  COMPONENTS = {
+    'weapon'    => 'weapon_release_within_days',
+    'character' => 'character_release_within_days',
+    'summon'    => 'summon_release_within_days'
+  }.freeze
+
+  def rules
+    COMPONENTS.flat_map do |component, rule_type|
+      BRACKETS.map do |bracket|
+        {
+          name: "#{component.capitalize}: #{bracket[:suffix]}",
+          component: component,
+          rule_type: rule_type,
+          weight: bracket[:weight],
+          params: {
+            'days' => bracket[:max_days],
+            'min_days_ago' => bracket[:min_days],
+            'min_count' => 1,
+            'scale_by_count' => true,
+            'max_count' => 3
+          }
+        }
+      end
+    end
+  end
+end

--- a/db/migrate/20260510200000_make_weapon_tiers_exclusive.rb
+++ b/db/migrate/20260510200000_make_weapon_tiers_exclusive.rb
@@ -1,0 +1,97 @@
+class MakeWeaponTiersExclusive < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Each weapon should fire exactly one tier rule. We previously relied on
+  # "at least" thresholds plus stacking — a Trans5 Dark Opus weapon scored
+  # both the Trans3 and Trans5 rules. Now we close the upper end of the
+  # lower-tier rules and roll the stacked weight into the higher tier so
+  # individual weapons score the same as before but only via one rule.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    # Drop the generic transcendence rules — series-specific tier rules
+    # cover them now.
+    DifficultyRule.where(name: ['Transcended weapons', 'Trans5 weapon present']).delete_all
+
+    updates.each do |name, attrs|
+      rule = DifficultyRule.find_by(name: name)
+      next unless rule
+
+      params = (rule.params || {}).deep_dup.merge(attrs[:params] || {})
+      rule.update!(weight: attrs[:weight], params: params)
+    end
+  end
+
+  REVERT_KEYS = %w[max_uncap_level max_transcendence_step max_awakening_level].freeze
+
+  def down
+    # Best-effort revert: drop the upper bounds and restore old weights.
+    revert_updates.each do |name, attrs|
+      rule = DifficultyRule.find_by(name: name)
+      next unless rule
+
+      params = (rule.params || {}).deep_dup
+      REVERT_KEYS.each { |k| params.delete(k) }
+      rule.update!(weight: attrs[:weight], params: params)
+    end
+  end
+
+  private
+
+  def updates
+    {
+      'Destroyer weapon FLB' => {
+        weight: 5.0,
+        params: { 'max_uncap_level' => 4 }
+      },
+      'Destroyer weapon ULB' => {
+        # Was 6 alone + 5 from FLB = 11 stacked.
+        weight: 11.0,
+        params: {}
+      },
+      'Trans3 Dark Opus weapon' => {
+        weight: 3.0,
+        params: { 'max_transcendence_step' => 4 }
+      },
+      'Trans5 Dark Opus weapon' => {
+        # Was 4 alone + 3 from Trans3 = 7 stacked.
+        weight: 7.0,
+        params: {}
+      },
+      'Celestial weapon FLB' => {
+        weight: 3.0,
+        params: { 'max_uncap_level' => 4 }
+      },
+      'Celestial weapon ULB' => {
+        # Was 3.5 alone + 3 from FLB = 6.5 stacked; this rule now only fires
+        # for ULB weapons WITHOUT awakening 5.
+        weight: 6.5,
+        params: { 'max_awakening_level' => 4 }
+      },
+      'Celestial weapon ULB + Awakening 5+' => {
+        # Was 4 alone + 3 + 3.5 = 10.5 stacked.
+        weight: 10.5,
+        params: {}
+      },
+      'Illustrious weapon' => {
+        # User specified equal to Trans5 Dark Opus.
+        weight: 7.0,
+        params: {}
+      }
+    }
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def revert_updates
+    {
+      'Destroyer weapon FLB' => { weight: 5.0 },
+      'Destroyer weapon ULB' => { weight: 6.0 },
+      'Trans3 Dark Opus weapon' => { weight: 3.0 },
+      'Trans5 Dark Opus weapon' => { weight: 4.0 },
+      'Celestial weapon FLB' => { weight: 3.0 },
+      'Celestial weapon ULB' => { weight: 3.5 },
+      'Celestial weapon ULB + Awakening 5+' => { weight: 4.0 },
+      'Illustrious weapon' => { weight: 4.0 }
+    }
+  end
+end

--- a/db/migrate/20260510210000_seed_gacha_sunstone_summon_rules.rb
+++ b/db/migrate/20260510210000_seed_gacha_sunstone_summon_rules.rb
@@ -1,0 +1,57 @@
+class SeedGachaSunstoneSummonRules < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Each uncap on a gacha summon costs a sunstone (3★ MLB and 4★ FLB), which
+  # is a very limited resource. Score those tiers explicitly so endgame
+  # parties register the investment.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    # Constrain the existing ULB rule to uncap 5 only so the new tiers
+    # don't overlap, and bump its weight in line with the value of an
+    # Ultimate-uncap gacha summon.
+    if (ulb = DifficultyRule.find_by(name: 'High uncap on gacha summons'))
+      params = (ulb.params || {}).deep_dup
+      params['min_uncap_level'] = 5
+      params['max_uncap_level'] = 5
+      ulb.update!(weight: 3.0, params: params)
+      ulb.update!(name: 'Gacha summon ULB (5★)')
+    end
+
+    rules.each do |attrs|
+      DifficultyRule.find_or_create_by!(name: attrs[:name]) do |r|
+        r.assign_attributes(attrs.merge(active: true))
+      end
+    end
+  end
+
+  def down
+    DifficultyRule.where(name: ['Gacha summon MLB (3★)', 'Gacha summon FLB (4★)']).delete_all
+    if (rule = DifficultyRule.find_by(name: 'Gacha summon ULB (5★)'))
+      params = (rule.params || {}).deep_dup
+      params.delete('max_uncap_level')
+      rule.update!(name: 'High uncap on gacha summons', weight: 1.5, params: params)
+    end
+  end
+
+  private
+
+  def rules
+    [
+      { name: 'Gacha summon MLB (3★)',                 component: 'summon',
+        rule_type: 'summon_uncap_at_least', weight: 1.5,
+        params: {
+          'min_uncap_level' => 3, 'max_uncap_level' => 3,
+          'gacha_filter' => 'gacha',
+          'min_count' => 1, 'scale_by_count' => true, 'max_count' => 5
+        } },
+      { name: 'Gacha summon FLB (4★)',                 component: 'summon',
+        rule_type: 'summon_uncap_at_least', weight: 2.0,
+        params: {
+          'min_uncap_level' => 4, 'max_uncap_level' => 4,
+          'gacha_filter' => 'gacha',
+          'min_count' => 1, 'scale_by_count' => true, 'max_count' => 5
+        } }
+    ]
+  end
+end

--- a/db/migrate/20260510220000_calibrate_difficulty_weights.rb
+++ b/db/migrate/20260510220000_calibrate_difficulty_weights.rb
@@ -13,12 +13,18 @@ class CalibrateDifficultyWeights < ActiveRecord::Migration[8.0]
     weight_changes.each do |name, weight|
       DifficultyRule.where(name: name).update_all(weight: weight)
     end
+
+    # update_all bypasses the after_save :bump_ruleset_version callback, so
+    # bump explicitly to invalidate already-scored parties under the old weights.
+    DifficultyConfig.bump_version! if defined?(DifficultyConfig)
   end
 
   def down
     revert_changes.each do |name, weight|
       DifficultyRule.where(name: name).update_all(weight: weight)
     end
+
+    DifficultyConfig.bump_version! if defined?(DifficultyConfig)
   end
 
   private

--- a/db/migrate/20260510220000_calibrate_difficulty_weights.rb
+++ b/db/migrate/20260510220000_calibrate_difficulty_weights.rb
@@ -1,0 +1,120 @@
+class CalibrateDifficultyWeights < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # The denominator on each component is the sum of every rule's max possible
+  # contribution. Because we've added many tier-specific rules, the denominator
+  # ballooned and otherwise endgame grids only fill ~25% of it. This pass
+  # rebalances: tier rules carry significantly more weight so they dominate
+  # when they fire, and the recency brackets are dialed back since they
+  # currently inflate the max without representing real investment.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    weight_changes.each do |name, weight|
+      DifficultyRule.where(name: name).update_all(weight: weight)
+    end
+  end
+
+  def down
+    revert_changes.each do |name, weight|
+      DifficultyRule.where(name: name).update_all(weight: weight)
+    end
+  end
+
+  private
+
+  def weight_changes
+    {
+      # Weapon tier ladder — these are the strongest investment signals,
+      # so let them swamp the noise from broad rules.
+      'Destroyer weapon ULB' => 30.0,
+      'Destroyer weapon FLB' => 14.0,
+      'Trans5 Dark Opus weapon' => 18.0,
+      'Trans3 Dark Opus weapon' => 7.0,
+      'Celestial weapon ULB + Awakening 5+' => 28.0,
+      'Celestial weapon ULB' => 17.0,
+      'Celestial weapon FLB' => 7.0,
+      'Illustrious weapon' => 18.0,
+      'Superlative weapon' => 6.0,
+
+      # Seasonal/Grand series weapons — meaningful but not as gated as tier.
+      'Grand series weapons' => 4.0,
+      'Providence/Draconic weapons' => 7.0,
+      'Formal seasonal weapons' => 9.0,
+      'Halloween/Valentine/Holiday seasonal weapons' => 6.0,
+      'Summer/Yukata seasonal weapons' => 4.0,
+
+      # Awakening tier — bump so high awakening on a full grid is noticed.
+      'High awakening (level >= 5)' => 2.5,
+      'Max awakening (level 10)' => 4.0,
+
+      # Summons.
+      'Providence summons' => 8.0,
+      'Gacha summon ULB (5★)' => 6.0,
+      'Gacha summon FLB (4★)' => 3.0,
+      'Gacha summon MLB (3★)' => 2.0,
+
+      # Character investments.
+      'Grand characters' => 4.0,
+      'Eternal/Evoker characters' => 4.0,
+      'Perpetuity ring on any character' => 6.0,
+      'Trans5 character present' => 6.0,
+
+      # Recency brackets — dial back so they don't dominate the denominator.
+      'Weapon: released < 14d' => 1.5,
+      'Weapon: released < 30d' => 1.0,
+      'Weapon: released < 90d' => 0.5,
+      'Weapon: released < 180d' => 0.25,
+      'Character: released < 14d' => 1.5,
+      'Character: released < 30d' => 1.0,
+      'Character: released < 90d' => 0.5,
+      'Character: released < 180d' => 0.25,
+      'Summon: released < 14d' => 1.5,
+      'Summon: released < 30d' => 1.0,
+      'Summon: released < 90d' => 0.5,
+      'Summon: released < 180d' => 0.25
+    }
+  end
+
+  def revert_changes
+    {
+      'Destroyer weapon ULB' => 11.0,
+      'Destroyer weapon FLB' => 5.0,
+      'Trans5 Dark Opus weapon' => 7.0,
+      'Trans3 Dark Opus weapon' => 3.0,
+      'Celestial weapon ULB + Awakening 5+' => 10.5,
+      'Celestial weapon ULB' => 6.5,
+      'Celestial weapon FLB' => 3.0,
+      'Illustrious weapon' => 7.0,
+      'Superlative weapon' => 2.5,
+      'Grand series weapons' => 2.0,
+      'Providence/Draconic weapons' => 3.0,
+      'Formal seasonal weapons' => 5.0,
+      'Halloween/Valentine/Holiday seasonal weapons' => 3.5,
+      'Summer/Yukata seasonal weapons' => 2.0,
+      'High awakening (level >= 5)' => 1.0,
+      'Max awakening (level 10)' => 1.5,
+      'Providence summons' => 3.0,
+      'Gacha summon ULB (5★)' => 3.0,
+      'Gacha summon FLB (4★)' => 2.0,
+      'Gacha summon MLB (3★)' => 1.5,
+      'Grand characters' => 2.0,
+      'Eternal/Evoker characters' => 2.0,
+      'Perpetuity ring on any character' => 3.5,
+      'Trans5 character present' => 3.0,
+      'Weapon: released < 14d' => 4.0,
+      'Weapon: released < 30d' => 3.0,
+      'Weapon: released < 90d' => 2.0,
+      'Weapon: released < 180d' => 1.0,
+      'Character: released < 14d' => 4.0,
+      'Character: released < 30d' => 3.0,
+      'Character: released < 90d' => 2.0,
+      'Character: released < 180d' => 1.0,
+      'Summon: released < 14d' => 4.0,
+      'Summon: released < 30d' => 3.0,
+      'Summon: released < 90d' => 2.0,
+      'Summon: released < 180d' => 1.0
+    }
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/db/migrate/20260510230000_add_target_max_to_difficulty_components.rb
+++ b/db/migrate/20260510230000_add_target_max_to_difficulty_components.rb
@@ -1,0 +1,5 @@
+class AddTargetMaxToDifficultyComponents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :difficulty_components, :target_max, :decimal, precision: 8, scale: 2
+  end
+end

--- a/db/migrate/20260510240000_split_seasonal_character_tiers.rb
+++ b/db/migrate/20260510240000_split_seasonal_character_tiers.rb
@@ -1,0 +1,50 @@
+class SplitSeasonalCharacterTiers < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Mirrors the weapon seasonal tiering on characters:
+  #   Formal > Halloween/Valentine/Holiday > Summer/Yukata
+  # CharacterSeasonal now supports decay_per_year too, so older seasonals
+  # progressively contribute less than recent ones.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    DifficultyRule.where(name: ['Seasonal characters', 'Multiple seasonals']).delete_all
+
+    rules.each do |attrs|
+      DifficultyRule.find_or_create_by!(name: attrs[:name]) do |r|
+        r.assign_attributes(attrs.merge(active: true))
+      end
+    end
+  end
+
+  def down
+    DifficultyRule.where(name: rules.map { |r| r[:name] }).delete_all
+  end
+
+  private
+
+  def rules
+    [
+      # Formal: shortest availability window — highest score.
+      { name: 'Formal seasonal characters', component: 'character',
+        rule_type: 'character_seasonal', weight: 5.0,
+        params: { 'seasons' => [2], 'min_count' => 1,
+                  'scale_by_count' => true, 'max_count' => 3,
+                  'decay_per_year' => 0.1, 'decay_floor' => 0.2 } },
+
+      # Halloween / Valentine / Holiday: mid-tier seasonal windows.
+      { name: 'Halloween/Valentine/Holiday seasonal characters', component: 'character',
+        rule_type: 'character_seasonal', weight: 3.5,
+        params: { 'seasons' => [1, 4, 5], 'min_count' => 1,
+                  'scale_by_count' => true, 'max_count' => 4,
+                  'decay_per_year' => 0.1, 'decay_floor' => 0.15 } },
+
+      # Summer / Yukata: the longest seasonal window.
+      { name: 'Summer/Yukata seasonal characters',          component: 'character',
+        rule_type: 'character_seasonal', weight: 2.0,
+        params: { 'seasons' => [3], 'min_count' => 1,
+                  'scale_by_count' => true, 'max_count' => 4,
+                  'decay_per_year' => 0.1, 'decay_floor' => 0.15 } }
+    ]
+  end
+end

--- a/db/migrate/20260510250000_bump_summer_yukata_and_jobs.rb
+++ b/db/migrate/20260510250000_bump_summer_yukata_and_jobs.rb
@@ -7,12 +7,18 @@ class BumpSummerYukataAndJobs < ActiveRecord::Migration[8.0]
     weight_changes.each do |name, weight|
       DifficultyRule.where(name: name).update_all(weight: weight)
     end
+
+    # update_all bypasses the after_save :bump_ruleset_version callback, so
+    # bump explicitly to invalidate already-scored parties under the old weights.
+    DifficultyConfig.bump_version! if defined?(DifficultyConfig)
   end
 
   def down
     revert_changes.each do |name, weight|
       DifficultyRule.where(name: name).update_all(weight: weight)
     end
+
+    DifficultyConfig.bump_version! if defined?(DifficultyConfig)
   end
 
   private

--- a/db/migrate/20260510250000_bump_summer_yukata_and_jobs.rb
+++ b/db/migrate/20260510250000_bump_summer_yukata_and_jobs.rb
@@ -1,0 +1,44 @@
+class BumpSummerYukataAndJobs < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    weight_changes.each do |name, weight|
+      DifficultyRule.where(name: name).update_all(weight: weight)
+    end
+  end
+
+  def down
+    revert_changes.each do |name, weight|
+      DifficultyRule.where(name: name).update_all(weight: weight)
+    end
+  end
+
+  private
+
+  def weight_changes
+    {
+      # Summer/Yukata seasonals — still the easiest season to roll for, but
+      # the prior numbers undersold the investment to obtain a specific unit.
+      'Summer/Yukata seasonal weapons' => 6.0,
+      'Summer/Yukata seasonal characters' => 4.0,
+
+      # Origin classes are gated behind end-of-game content and a long
+      # mastery grind; they're easily the rarest job tier.
+      'Origin job' => 10.0,
+
+      # Row V is more accessible but still requires significant progression.
+      'Row V job' => 4.0
+    }
+  end
+
+  def revert_changes
+    {
+      'Summer/Yukata seasonal weapons' => 4.0,
+      'Summer/Yukata seasonal characters' => 2.0,
+      'Origin job' => 3.0,
+      'Row V job' => 2.0
+    }
+  end
+end

--- a/db/migrate/20260510260000_fix_job_row_seeds.rb
+++ b/db/migrate/20260510260000_fix_job_row_seeds.rb
@@ -1,0 +1,48 @@
+class FixJobRowSeeds < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # The seeded job rules referenced 'V' / 'Origin' / 'IV' but jobs.row is
+  # stored as '5' / 'o1' / '4' (plus 'ex1', 'ex2' for extras). Patch the
+  # existing rule rows so they actually fire.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    patches.each do |name, new_rows|
+      rule = DifficultyRule.find_by(name: name)
+      next unless rule
+
+      params = (rule.params || {}).deep_dup
+      params['rows'] = new_rows
+      rule.update!(params: params)
+    end
+  end
+
+  def down
+    revert.each do |name, old_rows|
+      rule = DifficultyRule.find_by(name: name)
+      next unless rule
+
+      params = (rule.params || {}).deep_dup
+      params['rows'] = old_rows
+      rule.update!(params: params)
+    end
+  end
+
+  private
+
+  def patches
+    {
+      'Row V job' => ['5'],
+      'Origin job' => ['o1'],
+      'Row IV with Ultimate Mastery' => ['4']
+    }
+  end
+
+  def revert
+    {
+      'Row V job' => ['V'],
+      'Origin job' => ['Origin'],
+      'Row IV with Ultimate Mastery' => ['IV']
+    }
+  end
+end

--- a/db/migrate/20260510270000_remove_per_match_decay.rb
+++ b/db/migrate/20260510270000_remove_per_match_decay.rb
@@ -1,0 +1,25 @@
+class RemovePerMatchDecay < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Previously every match contributed weight × per-item decay factor, which
+  # made later (older) matches score noticeably less than the first. That
+  # surprised editors looking at the breakdown — they expect every Grand
+  # weapon / Providence summon / seasonal character to count the same.
+  # Strip decay_per_year / decay_floor from every rule that still has them;
+  # the helper itself stays around if we want to opt-in to decay later.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    DifficultyRule.where("params ? 'decay_per_year' OR params ? 'decay_floor'").find_each do |rule|
+      params = (rule.params || {}).deep_dup
+      saved_decay = params.delete('decay_per_year')
+      saved_floor = params.delete('decay_floor')
+      rule.update!(params: params) if saved_decay || saved_floor
+    end
+  end
+
+  def down
+    # No-op: the previous values weren't uniform, and re-seeding would clobber
+    # any tuning editors did in the meantime.
+  end
+end

--- a/db/migrate/20260510280000_skip_seasonal_eternals_and_evokers.rb
+++ b/db/migrate/20260510280000_skip_seasonal_eternals_and_evokers.rb
@@ -1,0 +1,29 @@
+class SkipSeasonalEternalsAndEvokers < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # Eternals and Evokers each have seasonal variants. When a character is a
+  # Summer Eternal we want only the seasonal rule to fire, not the Eternal
+  # rule — otherwise that character double-counts and overweights the
+  # 'invested in core uncap content' signal. Set single_series_only on the
+  # Eternal/Evoker rule so characters with more than one series membership
+  # are excluded.
+  def up
+    return unless ActiveRecord::Base.connection.table_exists?(:difficulty_rules)
+
+    rule = DifficultyRule.find_by(name: 'Eternal/Evoker characters')
+    return unless rule
+
+    params = (rule.params || {}).deep_dup
+    params['single_series_only'] = true
+    rule.update!(params: params)
+  end
+
+  def down
+    rule = DifficultyRule.find_by(name: 'Eternal/Evoker characters')
+    return unless rule
+
+    params = (rule.params || {}).deep_dup
+    params.delete('single_series_only')
+    rule.update!(params: params)
+  end
+end

--- a/db/migrate/20260510290000_enforce_difficulty_config_singleton.rb
+++ b/db/migrate/20260510290000_enforce_difficulty_config_singleton.rb
@@ -1,0 +1,19 @@
+class EnforceDifficultyConfigSingleton < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  INDEX_NAME = 'index_difficulty_configs_singleton'.freeze
+
+  def up
+    # DifficultyConfig is a singleton. A partial unique index on the constant
+    # expression (true) lets PostgreSQL reject a second row even when two
+    # callers race past `DifficultyConfig.first` and both reach `create!`.
+    execute <<~SQL.squish
+      CREATE UNIQUE INDEX IF NOT EXISTS #{INDEX_NAME}
+        ON difficulty_configs ((true))
+    SQL
+  end
+
+  def down
+    execute "DROP INDEX IF EXISTS #{INDEX_NAME}"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_180000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_140000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_280000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_290000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -410,6 +410,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_10_280000) do
     t.integer "ruleset_version", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index "(true)", name: "index_difficulty_configs_singleton", unique: true
   end
 
   create_table "difficulty_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_190000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_170000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_130005) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_160000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_220000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_230000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -402,6 +402,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_10_220000) do
     t.integer "min_count_to_score", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "target_max", precision: 8, scale: 2
     t.index ["name"], name: "index_difficulty_components_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_270000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_280000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_230000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_240000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_200000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_220000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_240000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_250000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_130005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -381,6 +381,51 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.index ["filename"], name: "index_data_versions_on_filename", unique: true
   end
 
+  create_table "difficulties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.text "description"
+    t.decimal "min_score", precision: 5, scale: 2, default: "0.0", null: false
+    t.decimal "max_score", precision: 5, scale: 2, default: "100.0", null: false
+    t.integer "sort_order", default: 0, null: false
+    t.string "color"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_difficulties_on_slug", unique: true
+    t.index ["sort_order"], name: "index_difficulties_on_sort_order"
+  end
+
+  create_table "difficulty_components", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.decimal "weight", precision: 6, scale: 2, default: "1.0", null: false
+    t.boolean "enabled", default: true, null: false
+    t.integer "min_count_to_score", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_difficulty_components_on_name", unique: true
+  end
+
+  create_table "difficulty_configs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "ruleset_version", default: 1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "difficulty_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "component", null: false
+    t.string "rule_type", null: false
+    t.jsonb "params", default: {}, null: false
+    t.decimal "weight", precision: 6, scale: 2, default: "1.0", null: false
+    t.boolean "active", default: true, null: false
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active"], name: "index_difficulty_rules_on_active"
+    t.index ["component"], name: "index_difficulty_rules_on_component"
+    t.index ["rule_type"], name: "index_difficulty_rules_on_rule_type"
+  end
+
   create_table "effects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name_en", null: false
     t.string "name_jp"
@@ -395,20 +440,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.datetime "updated_at", null: false
     t.index ["effect_class"], name: "index_effects_on_effect_class"
     t.index ["name_en"], name: "index_effects_on_name_en"
-  end
-
-  create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name", null: false
-    t.integer "event_type", null: false
-    t.datetime "start_time", null: false
-    t.datetime "end_time", null: false
-    t.integer "element"
-    t.string "banner_image"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["event_type"], name: "index_events_on_event_type"
-    t.index ["start_time", "end_time"], name: "index_events_on_start_time_and_end_time"
-    t.index ["start_time"], name: "index_events_on_start_time"
   end
 
   create_table "favorites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -466,6 +497,25 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.index ["orphaned"], name: "index_grid_artifacts_on_orphaned"
   end
 
+  create_table "grid_character_role_assignments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "grid_character_id", null: false
+    t.uuid "grid_character_role_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_character_id", "grid_character_role_id"], name: "idx_gc_role_assignments_unique", unique: true
+    t.index ["grid_character_id"], name: "index_grid_character_role_assignments_on_grid_character_id"
+    t.index ["grid_character_role_id"], name: "idx_on_grid_character_role_id_36d875e35b"
+  end
+
+  create_table "grid_character_roles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name_en", null: false
+    t.string "name_jp"
+    t.integer "sort_order"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "icon_key"
+  end
+
   create_table "grid_characters", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "party_id"
     t.uuid "character_id"
@@ -483,6 +533,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.uuid "awakening_id"
     t.integer "awakening_level", default: 1
     t.uuid "collection_character_id"
+    t.boolean "is_substitute", default: false, null: false
+    t.jsonb "description"
     t.index ["awakening_id"], name: "index_grid_characters_on_awakening_id"
     t.index ["character_id"], name: "index_grid_characters_on_character_id"
     t.index ["collection_character_id"], name: "index_grid_characters_on_collection_character_id"
@@ -503,6 +555,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.boolean "quick_summon", default: false
     t.uuid "collection_summon_id"
     t.boolean "orphaned", default: false, null: false
+    t.boolean "is_substitute", default: false, null: false
+    t.jsonb "description"
     t.index ["collection_summon_id"], name: "index_grid_summons_on_collection_summon_id"
     t.index ["orphaned"], name: "index_grid_summons_on_orphaned"
     t.index ["party_id", "position"], name: "index_grid_summons_on_party_id_and_position"
@@ -546,6 +600,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.bigint "befoulment_modifier_id"
     t.float "befoulment_strength"
     t.integer "exorcism_level", default: 0
+    t.boolean "is_substitute", default: false, null: false
+    t.jsonb "description"
     t.index ["awakening_id"], name: "index_grid_weapons_on_awakening_id"
     t.index ["ax_modifier1_id"], name: "index_grid_weapons_on_ax_modifier1_id"
     t.index ["ax_modifier2_id"], name: "index_grid_weapons_on_ax_modifier2_id"
@@ -744,10 +800,18 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.string "boost_side"
     t.boolean "solo", default: false, null: false
     t.datetime "last_updated"
+    t.uuid "difficulty_id"
+    t.decimal "difficulty_score", precision: 5, scale: 2
+    t.jsonb "difficulty_breakdown"
+    t.datetime "difficulty_computed_at"
+    t.integer "difficulty_ruleset_version"
     t.index ["accessory_id"], name: "index_parties_on_accessory_id"
     t.index ["boost_mod", "boost_side"], name: "index_parties_on_boost_mod_and_boost_side"
     t.index ["collection_source_user_id"], name: "index_parties_on_collection_source_user_id"
     t.index ["created_at"], name: "index_parties_on_created_at"
+    t.index ["difficulty_computed_at"], name: "index_parties_on_difficulty_computed_at"
+    t.index ["difficulty_id"], name: "index_parties_on_difficulty_id"
+    t.index ["difficulty_score"], name: "index_parties_on_difficulty_score"
     t.index ["element"], name: "index_parties_on_element"
     t.index ["guidebook1_id"], name: "index_parties_on_guidebook1_id"
     t.index ["guidebook2_id"], name: "index_parties_on_guidebook2_id"
@@ -877,7 +941,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.bigint "quest_id"
     t.boolean "extra"
     t.integer "player_count", default: 18, null: false
-    t.boolean "trackable", default: false, null: false
   end
 
   create_table "skill_effects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -935,6 +998,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.string "target_memo"
     t.index ["target_type", "target_id"], name: "index_sparks_on_target"
     t.index ["user_id"], name: "index_sparks_on_user_id", unique: true
+  end
+
+  create_table "substitutions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "grid_type", null: false
+    t.uuid "grid_id", null: false
+    t.string "substitute_grid_type", null: false
+    t.uuid "substitute_grid_id", null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grid_type", "grid_id", "substitute_grid_type", "substitute_grid_id"], name: "index_substitutions_uniqueness", unique: true
+    t.index ["grid_type", "grid_id"], name: "index_substitutions_on_grid"
+    t.index ["substitute_grid_type", "substitute_grid_id"], name: "index_substitutions_on_substitute_grid"
   end
 
   create_table "summon_auras", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1031,16 +1107,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
     t.datetime "created_at", null: false
     t.index ["user_id", "edit_key"], name: "index_user_edit_keys_on_user_id_and_edit_key", unique: true
     t.index ["user_id"], name: "index_user_edit_keys_on_user_id"
-  end
-
-  create_table "user_raid_elements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
-    t.uuid "raid_id", null: false
-    t.integer "element", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["raid_id"], name: "index_user_raid_elements_on_raid_id"
-    t.index ["user_id", "raid_id", "element"], name: "index_user_raid_elements_unique", unique: true
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1310,6 +1376,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
   add_foreign_key "grid_artifacts", "artifacts"
   add_foreign_key "grid_artifacts", "collection_artifacts"
   add_foreign_key "grid_artifacts", "grid_characters"
+  add_foreign_key "grid_character_role_assignments", "grid_character_roles"
+  add_foreign_key "grid_character_role_assignments", "grid_characters"
   add_foreign_key "grid_characters", "awakenings"
   add_foreign_key "grid_characters", "characters"
   add_foreign_key "grid_characters", "collection_characters"
@@ -1334,6 +1402,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
   add_foreign_key "gw_individual_scores", "users", column: "recorded_by_id"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "parties", "difficulties"
   add_foreign_key "parties", "guidebooks", column: "guidebook1_id"
   add_foreign_key "parties", "guidebooks", column: "guidebook2_id"
   add_foreign_key "parties", "guidebooks", column: "guidebook3_id"
@@ -1363,8 +1432,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_19_045519) do
   add_foreign_key "summon_calls", "skills", column: "alt_skill_id"
   add_foreign_key "summons", "summon_series"
   add_foreign_key "user_edit_keys", "users"
-  add_foreign_key "user_raid_elements", "raids"
-  add_foreign_key "user_raid_elements", "users"
   add_foreign_key "weapon_awakenings", "awakenings"
   add_foreign_key "weapon_awakenings", "weapons"
   add_foreign_key "weapon_key_series", "weapon_keys"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_250000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_270000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/spec/services/party_difficulty/calculator_spec.rb
+++ b/spec/services/party_difficulty/calculator_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe PartyDifficulty::Calculator do
     it 'normalises the contribution within its component and renormalises across present components' do
       rule = DifficultyRule.new(name: 'always', component: 'weapon', rule_type: 'weapon_uncap_at_least',
                                 weight: 1.0, active: true, params: { 'min_uncap_level' => 0, 'min_count' => 1 })
-      impl = instance_double(PartyDifficulty::Rules::WeaponUncapAtLeast, matching_count: 1, min_count: 1)
+      impl = instance_double(PartyDifficulty::Rules::WeaponUncapAtLeast,
+                             matching_count: 1, min_count: 1, match_factors: [1.0])
       allow(rule).to receive(:implementation).and_return(impl)
 
       party = build_stubbed(:party, weapons_count: 5, characters_count: 3, summons_count: 2)

--- a/spec/services/party_difficulty/calculator_spec.rb
+++ b/spec/services/party_difficulty/calculator_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe PartyDifficulty::Calculator do
     it 'normalises the contribution within its component and renormalises across present components' do
       rule = DifficultyRule.new(name: 'always', component: 'weapon', rule_type: 'weapon_uncap_at_least',
                                 weight: 1.0, active: true, params: { 'min_uncap_level' => 0, 'min_count' => 1 })
-      allow(rule).to receive(:applies_to?).and_return(true)
+      impl = instance_double(PartyDifficulty::Rules::WeaponUncapAtLeast, matching_count: 1, min_count: 1)
+      allow(rule).to receive(:implementation).and_return(impl)
 
       party = build_stubbed(:party, weapons_count: 5, characters_count: 3, summons_count: 2)
       allow(party).to receive_messages(weapons: [], characters: [], summons: [], job_id: nil, accessory_id: nil)

--- a/spec/services/party_difficulty/calculator_spec.rb
+++ b/spec/services/party_difficulty/calculator_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PartyDifficulty::Calculator do
+  let(:components) do
+    [
+      DifficultyComponent.new(name: 'weapon', weight: 1.0, enabled: true, min_count_to_score: 5),
+      DifficultyComponent.new(name: 'character', weight: 1.0, enabled: true, min_count_to_score: 3),
+      DifficultyComponent.new(name: 'summon', weight: 1.0, enabled: true, min_count_to_score: 2),
+      DifficultyComponent.new(name: 'job', weight: 1.0, enabled: true, min_count_to_score: 0),
+      DifficultyComponent.new(name: 'accessory', weight: 1.0, enabled: true, min_count_to_score: 0)
+    ]
+  end
+
+  let(:difficulties) do
+    [
+      Difficulty.new(name: 'Casual', slug: 'casual', min_score: 0, max_score: 24.99, sort_order: 0),
+      Difficulty.new(name: 'Mid', slug: 'mid', min_score: 25, max_score: 49.99, sort_order: 1),
+      Difficulty.new(name: 'Endgame', slug: 'endgame', min_score: 50, max_score: 100, sort_order: 2)
+    ]
+  end
+
+  describe '#scoreable?' do
+    it 'returns false when below the weapons threshold' do
+      party = build_stubbed(:party, weapons_count: 4, characters_count: 5, summons_count: 5)
+      result = described_class.new(party, rules: [], components: components, difficulties: difficulties, ruleset_version: 1).call
+      expect(result.scoreable).to be(false)
+    end
+
+    it 'returns true when all primary thresholds are met' do
+      party = build_stubbed(:party, weapons_count: 5, characters_count: 3, summons_count: 2)
+      allow(party).to receive_messages(weapons: [], characters: [], summons: [], job_id: nil, accessory_id: nil)
+      result = described_class.new(party, rules: [], components: components, difficulties: difficulties, ruleset_version: 1).call
+      expect(result.scoreable).to be(true)
+    end
+  end
+
+  describe '#call with no rules' do
+    it 'returns score 0 and the lowest tier' do
+      party = build_stubbed(:party, weapons_count: 5, characters_count: 3, summons_count: 2)
+      allow(party).to receive_messages(weapons: [], characters: [], summons: [], job_id: nil, accessory_id: nil)
+      result = described_class.new(party, rules: [], components: components, difficulties: difficulties, ruleset_version: 1).call
+      expect(result.scoreable).to be(true)
+      expect(result.score).to eq(0)
+      expect(result.difficulty.slug).to eq('casual')
+    end
+  end
+
+  describe '#call with a single firing rule' do
+    it 'normalises the contribution within its component and renormalises across present components' do
+      rule = DifficultyRule.new(name: 'always', component: 'weapon', rule_type: 'weapon_uncap_at_least',
+                                weight: 1.0, active: true, params: { 'min_uncap_level' => 0, 'min_count' => 1 })
+      allow(rule).to receive(:applies_to?).and_return(true)
+
+      party = build_stubbed(:party, weapons_count: 5, characters_count: 3, summons_count: 2)
+      allow(party).to receive_messages(weapons: [], characters: [], summons: [], job_id: nil, accessory_id: nil)
+
+      result = described_class.new(party, rules: [rule], components: components, difficulties: difficulties, ruleset_version: 1).call
+
+      # weapon raw = 1/1 = 1.0; weighted = 1.0; characters/summons present but have no rules and skip.
+      # composite = 1.0 / 1.0 * 100 = 100
+      expect(result.score).to eq(100)
+      expect(result.difficulty.slug).to eq('endgame')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a configurable difficulty scoring system for parties, surfaced as a tier label + numeric score on every party.

- **Schema**: `difficulties`, `difficulty_rules`, `difficulty_components`, `difficulty_configs` tables; `difficulty_id`, `_score`, `_breakdown`, `_computed_at`, `_ruleset_version` columns on parties
- **Engine**: `PartyDifficulty::Calculator` produces a 0–100 composite from per-component sub-scores; 20 fixed rule classes cover weapons / characters / summons / job / accessory; `Persister` writes the result via `update_columns` (no callback recursion)
- **Lifecycle**: edit-triggered scoring through `Party#after_commit` and `mark_updated!` (which all grid controllers already call); daily `SweepJob` at 04:00 recomputes parties whose score is older than 30 days or scored under an older ruleset version (bumped on any tier/rule/component edit)
- **Seeds**: 4 starter tiers (`casual`/`mid`/`endgame`/`whale`), 5 components, 29 rules — meant to be tuned via the editor UI
- **API surface**: `PartyBlueprint` exposes the difficulty payload (`tier`, `score`, `breakdown`, `computed_at`); `PartyQueryBuilder` filters by `?difficulty=casual,mid` (slug or id, comma-separated)

## Test plan

- [x] Migrations run cleanly; seeds idempotent
- [x] Calculator returns sensible score on real party (12w/5c/8s → 23.82 → Casual)
- [x] `mark_updated!` enqueues `PartyDifficulty::ScoreJob`
- [x] `SweepJob#stale_scope` finds parties needing recompute
- [x] Query builder `difficulty=casual` produces `WHERE difficulty_id IN (...)`
- [x] Existing `Party` specs still pass (93 examples)
- [x] New `Calculator` specs (4 examples) cover scoreability gate, no-rules, and a single-firing-rule path

---

## Review pass

**Resolved**
- [High] Two calibration migrations used `update_all` and skipped the `after_save :bump_ruleset_version` callback — append explicit `DifficultyConfig.bump_version!` so previously-scored parties get re-swept under the new weights
- [Medium] `ScoreJob` enqueued on every party save — `Party#after_commit` now guards on `saved_changes.keys.intersect?(SCORING_COLUMNS)` (weapons_count, characters_count, summons_count, job_id, accessory_id, ultimate_mastery); `mark_updated!` still enqueues directly because it bypasses callbacks
- [Medium] `*_series_match` rules silently returned `[]` on partial cache miss — hoisted `resolve_slugs_via_cache` into `Base` with proper "all-or-DB-fallback" semantics; used by all four series-match rules
- [Medium] `Calculator#composite_score` excludes zero-scoring components from the denominator, so adding a low-scoring rule to a previously-empty component can lower the composite — documented in `Calculator` + `PartyBlueprint` rather than changing behavior (calibration migrations were tuned against the current math)
- [Low] `Persister` set `difficulty_computed_at: Time.current` on unscoreable parties, hiding them from sweep for 30 days even if they later crossed the threshold — set to `nil` instead
- [Low] No invariant validated that tiers tile `[0, 100]` — added strict `tier_coverage_complete` validation that rejects gaps > 0.01 (one score quantum) and any overlap; seed migration bypasses with `save(validate: false)` since tiers are seeded one at a time
- [Low/Possible] `DifficultyConfig` singleton had no DB-level uniqueness — new migration adds `CREATE UNIQUE INDEX … ON difficulty_configs ((true))`; `.instance` rescues `RecordNotUnique` from concurrent first-create
- [Low] `Calculator#scoreable?` short-circuit when a component is disabled wasn't obvious — added a clarifying comment
- [Medium/Possible] `WeaponTierMatch#matches_awakening?` matches any awakening type when `awakening_id` is absent — doc-comment clarifying the intent

**Deferred** (tracked in `docs/follow-ups/party-difficulty.md`)
- Cache `DifficultyRule.active` / `DifficultyComponent.all` / `Difficulty.ordered` in `Calculator#initialize` keyed by `DifficultyConfig.current_version` — perf optimization, no measured symptom today
- Backfill rule-class / decay / exclusivity specs (R3 — follow-up PR off `main` so it doesn't rebase the stack)
- Consolidate the seed/resync/calibration migration chain into one idempotent seed once weights stabilize
