### PR TITLE
add admin endpoints + preview for party difficulty

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -185,6 +185,16 @@ module Api
                status: :unauthorized
       end
 
+      # Shared editor-role gate. Use as a before_action in any controller that
+      # exposes editor-only actions; logs the controller name and user id on
+      # rejection so unauthorized attempts are auditable.
+      def ensure_editor_role
+        return if current_user&.role && current_user.role >= 7
+
+        Rails.logger.warn "[#{controller_name.upcase}] Unauthorized access attempt by user #{current_user&.id}"
+        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
+      end
+
       def render_forbidden_response(message = 'Forbidden')
         render json: ErrorBlueprint.render(nil, error: {
           message: message,

--- a/app/controllers/api/v1/artifact_skills_controller.rb
+++ b/app/controllers/api/v1/artifact_skills_controller.rb
@@ -49,12 +49,6 @@ module Api
         @skill = ArtifactSkill.find(params[:id])
       end
 
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
-
       def artifact_skill_params
         params.permit(
           :skill_group, :modifier,

--- a/app/controllers/api/v1/awakenings_controller.rb
+++ b/app/controllers/api/v1/awakenings_controller.rb
@@ -78,13 +78,6 @@ module Api
       def awakening_params
         params.require(:awakening).permit(:name_en, :name_jp, :slug, :object_type, :order)
       end
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[AWAKENINGS] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
     end
   end
 end

--- a/app/controllers/api/v1/bullets_controller.rb
+++ b/app/controllers/api/v1/bullets_controller.rb
@@ -110,12 +110,6 @@ module Api
         params.permit(:name_en, :name_jp, :effect_en, :effect_jp, :granblue_id,
                       :slug, :bullet_type, :atk, :hits_all, :order)
       end
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
     end
   end
 end

--- a/app/controllers/api/v1/character_series_controller.rb
+++ b/app/controllers/api/v1/character_series_controller.rb
@@ -57,13 +57,6 @@ module Api
         @character_series = CharacterSeries.find_by(slug: params[:id]) || CharacterSeries.find(params[:id])
       end
 
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[CHARACTER_SERIES] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
-
       def character_series_params
         params.require(:character_series).permit(:name_en, :name_jp, :slug, :order)
       end

--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -245,14 +245,6 @@ module Api
         render_not_found_response('character') unless @character
       end
 
-      # Ensures the current user has editor role (role >= 7)
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[CHARACTERS] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
-
       def character_params
         params.require(:character).permit(
           :granblue_id, :name_en, :name_jp, :rarity, :element,

--- a/app/controllers/api/v1/difficulties_controller.rb
+++ b/app/controllers/api/v1/difficulties_controller.rb
@@ -12,7 +12,7 @@ module Api
       end
 
       def show
-        difficulty = Difficulty.find_by(id: params[:id]) || Difficulty.find_by(slug: params[:id])
+        difficulty = find_difficulty(params[:id])
         return render_not_found_response('difficulty') unless difficulty
 
         render json: DifficultyBlueprint.render(difficulty, view: :list)
@@ -28,7 +28,7 @@ module Api
       end
 
       def update
-        difficulty = Difficulty.find_by(id: params[:id])
+        difficulty = find_difficulty(params[:id])
         return render_not_found_response('difficulty') unless difficulty
 
         if difficulty.update(difficulty_params)
@@ -39,7 +39,7 @@ module Api
       end
 
       def destroy
-        difficulty = Difficulty.find_by(id: params[:id])
+        difficulty = find_difficulty(params[:id])
         return render_not_found_response('difficulty') unless difficulty
 
         difficulty.destroy
@@ -47,6 +47,13 @@ module Api
       end
 
       private
+
+      # Looks up a Difficulty by UUID first and falls back to slug. Slug strings
+      # cast to nil for the UUID column, so find_by(id:) safely returns nil for
+      # slug-shaped identifiers rather than raising.
+      def find_difficulty(identifier)
+        Difficulty.find_by(id: identifier) || Difficulty.find_by(slug: identifier)
+      end
 
       def difficulty_params
         params.require(:difficulty).permit(:name, :slug, :description, :min_score, :max_score, :sort_order, :color)

--- a/app/controllers/api/v1/difficulties_controller.rb
+++ b/app/controllers/api/v1/difficulties_controller.rb
@@ -58,12 +58,6 @@ module Api
       def difficulty_params
         params.require(:difficulty).permit(:name, :slug, :description, :min_score, :max_score, :sort_order, :color)
       end
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
     end
   end
 end

--- a/app/controllers/api/v1/difficulties_controller.rb
+++ b/app/controllers/api/v1/difficulties_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class DifficultiesController < Api::V1::ApiController
+      before_action :doorkeeper_authorize!, only: %i[create update destroy]
+      before_action :ensure_editor_role, only: %i[create update destroy]
+
+      def index
+        difficulties = Difficulty.ordered
+        render json: DifficultyBlueprint.render(difficulties, view: :list)
+      end
+
+      def show
+        difficulty = Difficulty.find_by(id: params[:id]) || Difficulty.find_by(slug: params[:id])
+        return render_not_found_response('difficulty') unless difficulty
+
+        render json: DifficultyBlueprint.render(difficulty, view: :list)
+      end
+
+      def create
+        difficulty = Difficulty.new(difficulty_params)
+        if difficulty.save
+          render json: DifficultyBlueprint.render(difficulty, view: :list), status: :created
+        else
+          render_validation_error_response(difficulty)
+        end
+      end
+
+      def update
+        difficulty = Difficulty.find_by(id: params[:id])
+        return render_not_found_response('difficulty') unless difficulty
+
+        if difficulty.update(difficulty_params)
+          render json: DifficultyBlueprint.render(difficulty, view: :list)
+        else
+          render_validation_error_response(difficulty)
+        end
+      end
+
+      def destroy
+        difficulty = Difficulty.find_by(id: params[:id])
+        return render_not_found_response('difficulty') unless difficulty
+
+        difficulty.destroy
+        head :no_content
+      end
+
+      private
+
+      def difficulty_params
+        params.require(:difficulty).permit(:name, :slug, :description, :min_score, :max_score, :sort_order, :color)
+      end
+
+      def ensure_editor_role
+        return if current_user&.role && current_user.role >= 7
+
+        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/difficulty_components_controller.rb
+++ b/app/controllers/api/v1/difficulty_components_controller.rb
@@ -12,14 +12,14 @@ module Api
       end
 
       def show
-        component = DifficultyComponent.find_by(id: params[:id]) || DifficultyComponent.find_by(name: params[:id])
+        component = find_component(params[:id])
         return render_not_found_response('difficulty_component') unless component
 
         render json: DifficultyComponentBlueprint.render(component)
       end
 
       def update
-        component = DifficultyComponent.find_by(id: params[:id]) || DifficultyComponent.find_by(name: params[:id])
+        component = find_component(params[:id])
         return render_not_found_response('difficulty_component') unless component
 
         if component.update(component_params)
@@ -30,6 +30,10 @@ module Api
       end
 
       private
+
+      def find_component(identifier)
+        DifficultyComponent.find_by(id: identifier) || DifficultyComponent.find_by(name: identifier)
+      end
 
       def component_params
         params.require(:difficulty_component).permit(:weight, :enabled, :min_count_to_score, :target_max)

--- a/app/controllers/api/v1/difficulty_components_controller.rb
+++ b/app/controllers/api/v1/difficulty_components_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class DifficultyComponentsController < Api::V1::ApiController
+      before_action :doorkeeper_authorize!
+      before_action :ensure_editor_role
+
+      def index
+        components = DifficultyComponent.order(:name)
+        render json: DifficultyComponentBlueprint.render(components)
+      end
+
+      def show
+        component = DifficultyComponent.find_by(id: params[:id]) || DifficultyComponent.find_by(name: params[:id])
+        return render_not_found_response('difficulty_component') unless component
+
+        render json: DifficultyComponentBlueprint.render(component)
+      end
+
+      def update
+        component = DifficultyComponent.find_by(id: params[:id]) || DifficultyComponent.find_by(name: params[:id])
+        return render_not_found_response('difficulty_component') unless component
+
+        if component.update(component_params)
+          render json: DifficultyComponentBlueprint.render(component)
+        else
+          render_validation_error_response(component)
+        end
+      end
+
+      private
+
+      def component_params
+        params.require(:difficulty_component).permit(:weight, :enabled, :min_count_to_score, :target_max)
+      end
+
+      def ensure_editor_role
+        return if current_user&.role && current_user.role >= 7
+
+        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/difficulty_components_controller.rb
+++ b/app/controllers/api/v1/difficulty_components_controller.rb
@@ -38,12 +38,6 @@ module Api
       def component_params
         params.require(:difficulty_component).permit(:weight, :enabled, :min_count_to_score, :target_max)
       end
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
     end
   end
 end

--- a/app/controllers/api/v1/difficulty_previews_controller.rb
+++ b/app/controllers/api/v1/difficulty_previews_controller.rb
@@ -17,6 +17,10 @@ module Api
         party = Party.find_by(shortcode: shortcode)
         return render_not_found_response('party') unless party
 
+        # TODO(party-difficulty-perf): cache DifficultyRule.active /
+        # DifficultyComponent.all / Difficulty.ordered by DifficultyConfig
+        # current_version inside Calculator#initialize. See
+        # docs/follow-ups/party-difficulty.md.
         eager = PartyDifficulty::Calculator.eager_load_party(party.id)
         result = PartyDifficulty::Calculator.new(eager).call
 
@@ -28,14 +32,6 @@ module Api
           breakdown: result.breakdown,
           ruleset_version: result.ruleset_version
         }
-      end
-
-      private
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
       end
     end
   end

--- a/app/controllers/api/v1/difficulty_previews_controller.rb
+++ b/app/controllers/api/v1/difficulty_previews_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    ##
+    # Editor-only endpoint that runs the difficulty calculator against a party
+    # without persisting the result. Used in the Database editor UI to test
+    # rule changes against real parties.
+    class DifficultyPreviewsController < Api::V1::ApiController
+      before_action :doorkeeper_authorize!
+      before_action :ensure_editor_role
+
+      def create
+        shortcode = params[:shortcode] || params.dig(:preview, :shortcode)
+        return render json: { error: 'shortcode is required' }, status: :unprocessable_entity if shortcode.blank?
+
+        party = Party.find_by(shortcode: shortcode)
+        return render_not_found_response('party') unless party
+
+        eager = PartyDifficulty::Calculator.eager_load_party(party.id)
+        result = PartyDifficulty::Calculator.new(eager).call
+
+        render json: {
+          shortcode: shortcode,
+          scoreable: result.scoreable,
+          score: result.score,
+          tier: result.difficulty ? DifficultyBlueprint.render_as_hash(result.difficulty, view: :nested) : nil,
+          breakdown: result.breakdown,
+          ruleset_version: result.ruleset_version
+        }
+      end
+
+      private
+
+      def ensure_editor_role
+        return if current_user&.role && current_user.role >= 7
+
+        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/difficulty_rules_controller.rb
+++ b/app/controllers/api/v1/difficulty_rules_controller.rb
@@ -81,12 +81,6 @@ module Api
           raise ActionController::BadRequest, 'difficulty_rule.params must be an object'
         end
       end
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
     end
   end
 end

--- a/app/controllers/api/v1/difficulty_rules_controller.rb
+++ b/app/controllers/api/v1/difficulty_rules_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class DifficultyRulesController < Api::V1::ApiController
+      before_action :doorkeeper_authorize!
+      before_action :ensure_editor_role
+
+      def index
+        rules = DifficultyRule.order(:component, :name)
+        rules = rules.where(component: params[:component]) if params[:component].present?
+        rules = rules.where(active: ActiveModel::Type::Boolean.new.cast(params[:active])) if params.key?(:active)
+        render json: DifficultyRuleBlueprint.render(rules)
+      end
+
+      def show
+        rule = DifficultyRule.find_by(id: params[:id])
+        return render_not_found_response('difficulty_rule') unless rule
+
+        render json: DifficultyRuleBlueprint.render(rule)
+      end
+
+      def create
+        rule = DifficultyRule.new(rule_params)
+        rule.component ||= PartyDifficulty::Rules.component_for(rule.rule_type)
+        if rule.save
+          render json: DifficultyRuleBlueprint.render(rule), status: :created
+        else
+          render_validation_error_response(rule)
+        end
+      end
+
+      def update
+        rule = DifficultyRule.find_by(id: params[:id])
+        return render_not_found_response('difficulty_rule') unless rule
+
+        if rule.update(rule_params)
+          render json: DifficultyRuleBlueprint.render(rule)
+        else
+          render_validation_error_response(rule)
+        end
+      end
+
+      def destroy
+        rule = DifficultyRule.find_by(id: params[:id])
+        return render_not_found_response('difficulty_rule') unless rule
+
+        rule.destroy
+        head :no_content
+      end
+
+      def types
+        render json: {
+          types: PartyDifficulty::Rules.registered_types,
+          grouped: PartyDifficulty::Rules.types_grouped_by_component
+        }
+      end
+
+      private
+
+      def rule_params
+        permitted = params.require(:difficulty_rule).permit(:name, :description, :component, :rule_type,
+                                                            :weight, :active, params: {})
+        raw_params = params.require(:difficulty_rule)[:params]
+        permitted[:params] = raw_params.to_unsafe_h if raw_params.is_a?(ActionController::Parameters)
+        permitted
+      end
+
+      def ensure_editor_role
+        return if current_user&.role && current_user.role >= 7
+
+        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/difficulty_rules_controller.rb
+++ b/app/controllers/api/v1/difficulty_rules_controller.rb
@@ -58,12 +58,28 @@ module Api
 
       private
 
+      # Rule `params` is an unstructured jsonb whose shape varies per rule_type,
+      # so strong-params can't enumerate keys generically — DifficultyRule's
+      # params_valid_for_rule_type validator constrains the payload after assignment.
+      # Reject non-hash params explicitly so callers get a 422 instead of having
+      # the field silently dropped.
       def rule_params
-        permitted = params.require(:difficulty_rule).permit(:name, :description, :component, :rule_type,
-                                                            :weight, :active, params: {})
-        raw_params = params.require(:difficulty_rule)[:params]
-        permitted[:params] = raw_params.to_unsafe_h if raw_params.is_a?(ActionController::Parameters)
-        permitted
+        permitted = params.require(:difficulty_rule).permit(:name, :description, :component,
+                                                            :rule_type, :weight, :active)
+        raw = params.require(:difficulty_rule)[:params]
+
+        case raw
+        when nil
+          permitted
+        when ActionController::Parameters
+          permitted[:params] = raw.to_unsafe_h
+          permitted
+        when Hash
+          permitted[:params] = raw
+          permitted
+        else
+          raise ActionController::BadRequest, 'difficulty_rule.params must be an object'
+        end
       end
 
       def ensure_editor_role

--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -318,18 +318,6 @@ module Api
       end
 
       ##
-      # Ensures the current user has editor role (role >= 7).
-      # Renders an error if the user is not an editor.
-      #
-      # @return [void]
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[IMPORT] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
-
-      ##
       # Reads and parses the raw JSON request body.
       #
       # @return [Hash] Parsed JSON data.

--- a/app/controllers/api/v1/job_accessories_controller.rb
+++ b/app/controllers/api/v1/job_accessories_controller.rb
@@ -125,13 +125,6 @@ module Api
       def job_accessory_params
         params.permit(:name_en, :name_jp, :granblue_id, :rarity, :release_date, :accessory_type, :job_id)
       end
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[JOB_ACCESSORIES] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
     end
   end
 end

--- a/app/controllers/api/v1/job_skills_controller.rb
+++ b/app/controllers/api/v1/job_skills_controller.rb
@@ -95,13 +95,6 @@ module Api
         params.permit(:name_en, :name_jp, :slug, :color, :main, :base, :sub, :emp, :order,
                       :image_id, :action_id)
       end
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[JOB_SKILLS] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
     end
   end
 end

--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -232,14 +232,6 @@ module Api
         render_not_found_response('job') unless @job
       end
 
-      # Ensures the current user has editor role (role >= 7)
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[JOBS] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
-
       def job_update_params
         params.permit(
           :name_en, :name_jp, :granblue_id,

--- a/app/controllers/api/v1/raid_groups_controller.rb
+++ b/app/controllers/api/v1/raid_groups_controller.rb
@@ -65,13 +65,6 @@ module Api
           :name_en, :name_jp, :difficulty, :order, :section, :extra, :hl, :guidebooks, :unlimited
         )
       end
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[RAID_GROUPS] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
     end
   end
 end

--- a/app/controllers/api/v1/raids_controller.rb
+++ b/app/controllers/api/v1/raids_controller.rb
@@ -170,13 +170,6 @@ module Api
       def filter_params
         params.except(:controller, :action, :format, :raid).permit(:element, :group_id, :difficulty, :hl, :extra, :guidebooks)
       end
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[RAIDS] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
     end
   end
 end

--- a/app/controllers/api/v1/summon_series_controller.rb
+++ b/app/controllers/api/v1/summon_series_controller.rb
@@ -57,13 +57,6 @@ module Api
         @summon_series = SummonSeries.find_by(slug: params[:id]) || SummonSeries.find(params[:id])
       end
 
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[SUMMON_SERIES] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
-
       def summon_series_params
         params.require(:summon_series).permit(:name_en, :name_jp, :slug, :order)
       end

--- a/app/controllers/api/v1/summons_controller.rb
+++ b/app/controllers/api/v1/summons_controller.rb
@@ -205,14 +205,6 @@ module Api
         render_not_found_response('summon') unless @summon
       end
 
-      # Ensures the current user has editor role (role >= 7)
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[SUMMONS] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
-
       def summon_params
         params.require(:summon).permit(
           :granblue_id, :name_en, :name_jp, :summon_id, :rarity, :element, :series,

--- a/app/controllers/api/v1/weapon_series_controller.rb
+++ b/app/controllers/api/v1/weapon_series_controller.rb
@@ -57,13 +57,6 @@ module Api
         @weapon_series = WeaponSeries.find_by(slug: params[:id]) || WeaponSeries.find(params[:id])
       end
 
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[WEAPON_SERIES] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
-
       def weapon_series_params
         params.require(:weapon_series).permit(
           :name_en, :name_jp, :slug, :order,

--- a/app/controllers/api/v1/weapon_series_variants_controller.rb
+++ b/app/controllers/api/v1/weapon_series_variants_controller.rb
@@ -44,13 +44,6 @@ module Api
         @variant = @weapon_series.weapon_series_variants.find(params[:id])
       end
 
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[WEAPON_SERIES_VARIANTS] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
-
       def variant_params
         params.require(:weapon_series_variant).permit(
           :name, :has_weapon_keys, :has_awakening, :num_weapon_keys,

--- a/app/controllers/api/v1/weapons_controller.rb
+++ b/app/controllers/api/v1/weapons_controller.rb
@@ -229,14 +229,6 @@ module Api
         render_not_found_response('weapon') unless @weapon
       end
 
-      # Ensures the current user has editor role (role >= 7)
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        Rails.logger.warn "[WEAPONS] Unauthorized access attempt by user #{current_user&.id}"
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
-      end
-
       def weapon_params
         params.require(:weapon).permit(
           :granblue_id, :name_en, :name_jp, :rarity, :element, :proficiency, :series, :new_series, :weapon_series_variant_id,

--- a/app/services/party_difficulty/calculator.rb
+++ b/app/services/party_difficulty/calculator.rb
@@ -27,6 +27,11 @@ module PartyDifficulty
       Party.includes(*EAGER_LOAD.keys.map { |k| EAGER_LOAD[k].any? ? { k => EAGER_LOAD[k] } : k }).find(party_id)
     end
 
+    # TODO(party-difficulty-perf): the four default reads below run on every
+    # ScoreJob, SweepJob, and preview-controller invocation. Wrap them in
+    # Rails.cache.fetch keyed by DifficultyConfig.current_version so the
+    # ruleset cache invalidates automatically on edits. See
+    # docs/follow-ups/party-difficulty.md.
     def initialize(party, rules: nil, components: nil, difficulties: nil, ruleset_version: nil)
       @party = party
       @rules = rules || DifficultyRule.active.to_a

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,16 @@ Rails.application.routes.draw do
     resources :weapon_skill_data, only: %i[index show]
     resources :weapon_skill_boost_types, only: %i[index show]
 
+    # Party difficulty
+    resources :difficulties, only: %i[index show create update destroy]
+    resources :difficulty_components, only: %i[index show update]
+    resources :difficulty_rules, only: %i[index show create update destroy] do
+      collection do
+        get :types
+      end
+    end
+    post 'difficulty_previews', to: 'difficulty_previews#create'
+
     # Grid artifacts
     resources :grid_artifacts, only: %i[create update destroy] do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,7 +192,7 @@ Rails.application.routes.draw do
         get :types
       end
     end
-    post 'difficulty_previews', to: 'difficulty_previews#create'
+    resources :difficulty_previews, only: %i[create]
 
     # Grid artifacts
     resources :grid_artifacts, only: %i[create update destroy] do

--- a/docs/follow-ups/party-difficulty.md
+++ b/docs/follow-ups/party-difficulty.md
@@ -1,0 +1,77 @@
+# Party Difficulty — Deferred Follow-Ups
+
+Items surfaced during code review of the stacked `party-difficulty-*` PRs that were intentionally deferred. Each entry includes where the deferral was decided and what a future change should do.
+
+---
+
+## Cache ruleset reads in `Calculator`
+
+**Status:** deferred during review of `jedmund/party-difficulty-admin`.
+
+**Symptom.** `Calculator#initialize` reads four tables on every invocation:
+- `DifficultyRule.active.to_a`
+- `DifficultyComponent.all.to_a`
+- `Difficulty.ordered.to_a`
+- `DifficultyConfig.current_version`
+
+These reads fire from `ScoreJob`, `SweepJob`, and `DifficultyPreviewsController#create`. They produce identical results across every call within a ruleset version, but are re-fetched each time.
+
+**What to do.** Wrap the four defaults in `Rails.cache.fetch` keyed by `DifficultyConfig.current_version`. The version bumps on every relevant save (`after_save :bump_ruleset_version` on `Difficulty`, `DifficultyRule`, `DifficultyComponent`) plus explicitly in the two `update_all` calibration migrations, so the cache key changes automatically when the ruleset changes — no manual invalidation needed.
+
+Sketch:
+
+```ruby
+def initialize(party, rules: nil, components: nil, difficulties: nil, ruleset_version: nil)
+  @party = party
+  @ruleset_version = ruleset_version || DifficultyConfig.current_version
+  @rules = rules || Rails.cache.fetch(["pd_rules", @ruleset_version]) { DifficultyRule.active.to_a }
+  @components = components || Rails.cache.fetch(["pd_components", @ruleset_version]) { DifficultyComponent.all.to_a }
+  @difficulties = difficulties || Rails.cache.fetch(["pd_difficulties", @ruleset_version]) { Difficulty.ordered.to_a }
+end
+```
+
+**Why not in the original stack.** The win is real but small at ~30 rules. Editor-only access mitigates abuse on the preview endpoint, so this is not a merge blocker. Cache code is also a new failure mode (Marshal serialization of ActiveRecord, `:null_store` vs `:memory_store` test-env nuance) that should be motivated by a measured symptom, not a code smell.
+
+**Files to touch.**
+- `app/services/party_difficulty/calculator.rb:30` — has a `TODO(party-difficulty-perf)` pointer.
+- `app/controllers/api/v1/difficulty_previews_controller.rb:20` — has a matching pointer.
+
+**When to revisit.** When rule count grows past ~100, or when editor preview latency becomes a noticeable complaint.
+
+---
+
+## Request specs for the difficulty admin endpoints
+
+**Status:** deferred per the original review plan (R3 routing).
+
+**What.** No request specs exist for any of the four new controllers added in `-admin`, nor for `DifficultyDraftsController` added in `-drafts`.
+
+**What to do.** Add request specs covering: auth branch (non-editor → 401), happy path for each CRUD action, slug/UUID dispatch on `Difficulty#show/update/destroy` and `DifficultyComponent#show/update`, preview happy path, missing-party preview, malformed `difficulty_rule.params` (now returns 400).
+
+**Why not in the stack.** Adding specs to any branch in the stack rebases all branches above it. Specs aren't behavior-changing so they don't need to ship in the same PRs as the engine. One follow-up PR off `main` after the stack merges costs zero rebases.
+
+**Files to touch (new).** `spec/requests/api/v1/difficulties_spec.rb`, `spec/requests/api/v1/difficulty_components_spec.rb`, `spec/requests/api/v1/difficulty_rules_spec.rb`, `spec/requests/api/v1/difficulty_previews_spec.rb`, `spec/requests/api/v1/difficulty_drafts_spec.rb`.
+
+---
+
+## Rule-class specs and calibration coverage
+
+**Status:** deferred per the original review plan (R3 routing).
+
+**What.** `spec/services/party_difficulty/calculator_spec.rb` covers the calculator but stubs every rule via `instance_double`. None of the 25+ rule classes has its own spec.
+
+**What to do.** Cover `Base#decay_factor_for`, `scale_by_count` accounting, the "max_count caps denominator but not numerator" branch in `rule_contribution`, and `min_count` gating. Add regression tests for the weapon-tier exclusivity that the calibration migrations enforce (e.g. a Trans5 Dark Opus should fire `Trans5 Dark Opus weapon` but not the lower-tier `Trans3 Dark Opus weapon`).
+
+**Why not in the stack.** Same rebase argument as above.
+
+---
+
+## Consolidate the difficulty seed/calibration migration chain
+
+**Status:** deferred per the original review plan (R3 routing).
+
+**What.** `20260510130005_seed_party_difficulty.rb` seeds rules; `20260510140000_resync_party_difficulty_rules.rb` immediately `delete_all`s and re-seeds; `20260510200000_make_weapon_tiers_exclusive.rb` deletes specific rules; downstream calibration migrations reference rules by name via `update_all`.
+
+**What to do.** Once calibration stabilizes, consolidate into a single idempotent seed migration. Greenfield setup is fine today, but a re-run or hand-edited seed mid-chain produces the wrong set of active rules. Calibration `update_all`s also no-op silently when a rule name doesn't exist at that timestamp.
+
+**Why not in the stack.** Consolidation requires the calibration work to be finished. Weights are still being tuned (see commits `9eea4c66`, `af64ef41`, `1c6e3217`, `7d845471` in the `-score` history).


### PR DESCRIPTION
## Summary

Stacked on #408. Adds the editor-only API surface that backs the new Database editor UI.

- `GET /difficulties` (public read) + `POST/PUT/DELETE` (editor)
- `GET/PUT /difficulty_components/:id` — components are seeded; weights, enabled, and min_count_to_score are editable
- `GET/POST/PUT/DELETE /difficulty_rules` plus `GET /difficulty_rules/types` for the editor type picker
- `POST /difficulty_previews` — accepts a shortcode, runs the calculator, returns the score + breakdown without persisting

All editor endpoints require role >= 7 (matches existing taxonomy editors like `AwakeningsController`).

## Test plan

- [x] Routes registered (`bin/rails routes | grep difficulty` shows expected entries)
- [x] Controllers boot without errors
- [ ] Manual test: hit each endpoint with editor account
- [ ] Confirm preview matches scoreboard for a persisted party

---

## Review pass

**Resolved**
- [Critical] `db/schema.rb` was rewound past `target_max` on the parent branch, which would have broken `DifficultyComponentBlueprint` and `PartyDifficulty::Calculator` after `db:schema:load` — resolved by rebasing on post-fix `-score` (schema is now at `2026_05_10_290000` with `target_max` intact and the new singleton index)
- [Medium] `Difficulty#show` accepted UUID or slug but `#update`/`#destroy` only accepted UUID, so editors who resolved a record by slug got 404 on save — extracted `find_difficulty(identifier)` helper, used in all three member actions; same treatment for `DifficultyComponent` (UUID or name)
- [Medium] `DifficultyRule#rule_params` had a misleading `params: {}` permit followed by `to_unsafe_h`, which silently dropped non-`ActionController::Parameters` payloads (e.g. arrays) instead of 422'ing — replaced with an explicit `case raw` that returns 400 on shapes other than hash/Parameters/nil
- [Low/R4] `ensure_editor_role` was duplicated across the 4 new controllers and ~16 existing ones — lifted to `Api::V1::ApiController` with `controller_name.upcase` for the log tag (6 controllers that didn't log before now do, matching the rest); net diff −145/+14
- [Low/R4] `post 'difficulty_previews'` was inconsistent with the resourceful style used elsewhere — switched to `resources :difficulty_previews, only: %i[create]`

**Deferred** (tracked in `docs/follow-ups/party-difficulty.md`)
- Cache the four reference reads in `Calculator#initialize` keyed by `DifficultyConfig.current_version` — would benefit `ScoreJob`, `SweepJob`, and this preview endpoint; deferred until there's a measured symptom
- Request specs for all four new controllers (R3 — follow-up PR off `main`)
