### PR TITLE
fix nil-awakening crash when rendering grid characters

### DIFF
--- a/app/blueprints/api/v1/grid_character_blueprint.rb
+++ b/app/blueprints/api/v1/grid_character_blueprint.rb
@@ -46,7 +46,7 @@ module Api
       end
 
       view :mastery_bonuses do
-        field :awakening, if: ->(_field_name, gc, _options) { gc.association(:awakening).loaded? } do |gc|
+        field :awakening, if: ->(_field_name, gc, _options) { gc.awakening.present? } do |gc|
           {
             type: AwakeningBlueprint.render_as_hash(gc.awakening),
             level: gc.awakening_level.to_i


### PR DESCRIPTION
## Summary

`PartiesController#show` eager-loads `:awakening` on grid_characters via `set_from_slug`. For grid_characters with `awakening_id = NULL` (7 such rows in dev), Rails marks the association as *loaded* (to nil). `GridCharacterBlueprint#awakening` only gated on `association(:awakening).loaded?`, so it tried to render the nil association and crashed with `NoMethodError: undefined method 'id' for nil` from inside `AwakeningBlueprint`.

Switched the gate to `gc.awakening.present?` — same pattern `GridWeaponBlueprint` already uses for its awakening field.

## Test plan

- [x] Identified failing party (shortcode `kbBI5g`) — has one grid_character with `awakening_id = NULL`
- [x] `spec/models/party_spec.rb` still green (93 examples)
- [ ] Hit `GET /api/v1/parties/kbBI5g` against the fix and confirm 200