### PR TITLE
add per-editor draft workspace + commit log for party difficulty

### DIFF
--- a/app/blueprints/api/v1/difficulty_blueprint.rb
+++ b/app/blueprints/api/v1/difficulty_blueprint.rb
@@ -5,6 +5,16 @@ module Api
     class DifficultyBlueprint < ApiBlueprint
       fields :name, :slug, :description, :min_score, :max_score, :sort_order, :color
 
+      field :pending do |obj|
+        obj.respond_to?(:pending?) && obj.pending?
+      end
+      field :pending_operation do |obj|
+        obj.respond_to?(:pending_operation) ? obj.pending_operation : nil
+      end
+      field :draft_id do |obj|
+        obj.respond_to?(:draft_id) ? obj.draft_id : nil
+      end
+
       view :nested do
         fields :name, :slug, :color, :sort_order
       end

--- a/app/blueprints/api/v1/difficulty_component_blueprint.rb
+++ b/app/blueprints/api/v1/difficulty_component_blueprint.rb
@@ -5,6 +5,16 @@ module Api
     class DifficultyComponentBlueprint < ApiBlueprint
       fields :name, :weight, :enabled, :min_count_to_score, :target_max,
              :created_at, :updated_at
+
+      field :pending do |obj|
+        obj.respond_to?(:pending?) && obj.pending?
+      end
+      field :pending_operation do |obj|
+        obj.respond_to?(:pending_operation) ? obj.pending_operation : nil
+      end
+      field :draft_id do |obj|
+        obj.respond_to?(:draft_id) ? obj.draft_id : nil
+      end
     end
   end
 end

--- a/app/blueprints/api/v1/difficulty_rule_blueprint.rb
+++ b/app/blueprints/api/v1/difficulty_rule_blueprint.rb
@@ -6,6 +6,16 @@ module Api
       fields :name, :description, :component, :rule_type, :params, :weight, :active,
              :created_at, :updated_at
 
+      field :pending do |obj|
+        obj.respond_to?(:pending?) && obj.pending?
+      end
+      field :pending_operation do |obj|
+        obj.respond_to?(:pending_operation) ? obj.pending_operation : nil
+      end
+      field :draft_id do |obj|
+        obj.respond_to?(:draft_id) ? obj.draft_id : nil
+      end
+
       view :nested do
         fields :name, :component, :rule_type, :weight, :active
       end

--- a/app/controllers/api/v1/difficulties_controller.rb
+++ b/app/controllers/api/v1/difficulties_controller.rb
@@ -7,7 +7,11 @@ module Api
       before_action :ensure_editor_role, only: %i[create update destroy]
 
       def index
-        difficulties = Difficulty.ordered
+        difficulties = if with_drafts?
+                         PartyDifficulty::DraftWorkspace.for(current_user).merged_tiers
+                       else
+                         Difficulty.ordered
+                       end
         render json: DifficultyBlueprint.render(difficulties, view: :list)
       end
 
@@ -19,30 +23,29 @@ module Api
       end
 
       def create
-        difficulty = Difficulty.new(difficulty_params)
-        if difficulty.save
-          render json: DifficultyBlueprint.render(difficulty, view: :list), status: :created
-        else
-          render_validation_error_response(difficulty)
-        end
+        draft = PartyDifficulty::DraftWorkspace.for(current_user).stage!(
+          target_type: 'Difficulty', target_id: nil, operation: 'create', attributes: difficulty_params
+        )
+        render json: draft_envelope(draft), status: :created
       end
 
       def update
         difficulty = find_difficulty(params[:id])
         return render_not_found_response('difficulty') unless difficulty
 
-        if difficulty.update(difficulty_params)
-          render json: DifficultyBlueprint.render(difficulty, view: :list)
-        else
-          render_validation_error_response(difficulty)
-        end
+        draft = PartyDifficulty::DraftWorkspace.for(current_user).stage!(
+          target_type: 'Difficulty', target_id: difficulty.id, operation: 'update', attributes: difficulty_params
+        )
+        render json: draft_envelope(draft)
       end
 
       def destroy
         difficulty = find_difficulty(params[:id])
         return render_not_found_response('difficulty') unless difficulty
 
-        difficulty.destroy
+        PartyDifficulty::DraftWorkspace.for(current_user).stage!(
+          target_type: 'Difficulty', target_id: difficulty.id, operation: 'destroy', attributes: {}
+        )
         head :no_content
       end
 
@@ -57,6 +60,24 @@ module Api
 
       def difficulty_params
         params.require(:difficulty).permit(:name, :slug, :description, :min_score, :max_score, :sort_order, :color)
+      end
+
+      def with_drafts?
+        return false unless current_user&.role && current_user.role >= 7
+
+        ActiveModel::Type::Boolean.new.cast(params[:with_drafts])
+      end
+
+      def draft_envelope(draft)
+        {
+          draft: {
+            id: draft.id,
+            target_type: draft.target_type,
+            target_id: draft.target_id,
+            operation: draft.operation,
+            attributes: draft.attributes_payload
+          }
+        }
       end
     end
   end

--- a/app/controllers/api/v1/difficulty_components_controller.rb
+++ b/app/controllers/api/v1/difficulty_components_controller.rb
@@ -7,7 +7,11 @@ module Api
       before_action :ensure_editor_role
 
       def index
-        components = DifficultyComponent.order(:name)
+        components = if with_drafts?
+                       PartyDifficulty::DraftWorkspace.for(current_user).merged_components
+                     else
+                       DifficultyComponent.order(:name)
+                     end
         render json: DifficultyComponentBlueprint.render(components)
       end
 
@@ -22,11 +26,19 @@ module Api
         component = find_component(params[:id])
         return render_not_found_response('difficulty_component') unless component
 
-        if component.update(component_params)
-          render json: DifficultyComponentBlueprint.render(component)
-        else
-          render_validation_error_response(component)
-        end
+        draft = PartyDifficulty::DraftWorkspace.for(current_user).stage!(
+          target_type: 'DifficultyComponent', target_id: component.id, operation: 'update',
+          attributes: component_params
+        )
+        render json: {
+          draft: {
+            id: draft.id,
+            target_type: draft.target_type,
+            target_id: draft.target_id,
+            operation: draft.operation,
+            attributes: draft.attributes_payload
+          }
+        }
       end
 
       private
@@ -37,6 +49,12 @@ module Api
 
       def component_params
         params.require(:difficulty_component).permit(:weight, :enabled, :min_count_to_score, :target_max)
+      end
+
+      def with_drafts?
+        return false unless current_user&.role && current_user.role >= 7
+
+        ActiveModel::Type::Boolean.new.cast(params[:with_drafts])
       end
     end
   end

--- a/app/controllers/api/v1/difficulty_drafts_controller.rb
+++ b/app/controllers/api/v1/difficulty_drafts_controller.rb
@@ -35,17 +35,16 @@ module Api
       end
 
       def destroy
-        if params[:id] == 'all'
-          discarded = @workspace.discard!
-          render json: { discarded: discarded }
-          return
-        end
-
         draft = DifficultyDraft.for_user(current_user).find_by(id: params[:id])
         return render_not_found_response('difficulty_draft') unless draft
 
         draft.destroy
         head :no_content
+      end
+
+      def discard_all
+        discarded = @workspace.discard!
+        render json: { discarded: discarded }
       end
 
       def commit
@@ -82,12 +81,6 @@ module Api
           created_at: draft.created_at,
           updated_at: draft.updated_at
         }
-      end
-
-      def ensure_editor_role
-        return if current_user&.role && current_user.role >= 7
-
-        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
       end
     end
   end

--- a/app/controllers/api/v1/difficulty_drafts_controller.rb
+++ b/app/controllers/api/v1/difficulty_drafts_controller.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    ##
+    # Editor staging layer for the difficulty editor. Stages create/update/destroy
+    # against Difficulty / DifficultyRule / DifficultyComponent, then promotes
+    # them to canonical via #commit. Editors live with their own draft set; one
+    # user's drafts are invisible to another.
+    class DifficultyDraftsController < Api::V1::ApiController
+      before_action :doorkeeper_authorize!
+      before_action :ensure_editor_role
+      before_action :load_workspace
+
+      def index
+        render json: { drafts: @workspace.drafts.map { |d| serialize(d) },
+                       pending_count: @workspace.pending_count }
+      end
+
+      def diff
+        render json: { diff: @workspace.diff, pending_count: @workspace.pending_count }
+      end
+
+      def create
+        params_hash = draft_params
+        draft = @workspace.stage!(
+          target_type: params_hash[:target_type],
+          target_id: params_hash[:target_id],
+          operation: params_hash[:operation],
+          attributes: params_hash[:attributes].presence || {}
+        )
+        render json: serialize(draft), status: :created
+      rescue ArgumentError => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      end
+
+      def destroy
+        if params[:id] == 'all'
+          discarded = @workspace.discard!
+          render json: { discarded: discarded }
+          return
+        end
+
+        draft = DifficultyDraft.for_user(current_user).find_by(id: params[:id])
+        return render_not_found_response('difficulty_draft') unless draft
+
+        draft.destroy
+        head :no_content
+      end
+
+      def commit
+        note = params[:note].to_s
+        log = @workspace.commit!(note: note)
+        render json: {
+          ruleset_version_after: log.ruleset_version_after,
+          committed_at: log.committed_at,
+          note: log.note,
+          change_log_id: log.id
+        }
+      end
+
+      private
+
+      def load_workspace
+        @workspace = PartyDifficulty::DraftWorkspace.for(current_user)
+      end
+
+      def draft_params
+        permitted = params.require(:draft).permit(:target_type, :target_id, :operation, attributes: {})
+        raw_attrs = params.require(:draft)[:attributes]
+        permitted[:attributes] = raw_attrs.to_unsafe_h if raw_attrs.is_a?(ActionController::Parameters)
+        permitted
+      end
+
+      def serialize(draft)
+        {
+          id: draft.id,
+          target_type: draft.target_type,
+          target_id: draft.target_id,
+          operation: draft.operation,
+          attributes: draft.attributes_payload,
+          created_at: draft.created_at,
+          updated_at: draft.updated_at
+        }
+      end
+
+      def ensure_editor_role
+        return if current_user&.role && current_user.role >= 7
+
+        render json: { error: 'Unauthorized - Editor role required' }, status: :unauthorized
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/difficulty_drafts_controller.rb
+++ b/app/controllers/api/v1/difficulty_drafts_controller.rb
@@ -56,6 +56,14 @@ module Api
           note: log.note,
           change_log_id: log.id
         }
+      rescue PartyDifficulty::StaleDraftError => e
+        render json: {
+          error: 'stale_draft',
+          message: e.message,
+          draft_id: e.draft_id,
+          target_type: e.target_type,
+          target_id: e.target_id
+        }, status: :conflict
       end
 
       private

--- a/app/controllers/api/v1/difficulty_previews_controller.rb
+++ b/app/controllers/api/v1/difficulty_previews_controller.rb
@@ -22,7 +22,7 @@ module Api
         # current_version inside Calculator#initialize. See
         # docs/follow-ups/party-difficulty.md.
         eager = PartyDifficulty::Calculator.eager_load_party(party.id)
-        result = PartyDifficulty::Calculator.new(eager).call
+        result = PartyDifficulty::Calculator.new(eager, **calculator_overrides).call
 
         render json: {
           shortcode: shortcode,
@@ -30,8 +30,29 @@ module Api
           score: result.score,
           tier: result.difficulty ? DifficultyBlueprint.render_as_hash(result.difficulty, view: :nested) : nil,
           breakdown: result.breakdown,
-          ruleset_version: result.ruleset_version
+          ruleset_version: result.ruleset_version,
+          with_drafts: applying_drafts?
         }
+      end
+
+      private
+
+      def calculator_overrides
+        return {} unless applying_drafts?
+
+        ws = PartyDifficulty::DraftWorkspace.for(current_user)
+        {
+          rules: ws.merged_rules,
+          components: ws.merged_components,
+          difficulties: ws.merged_tiers
+        }
+      end
+
+      def applying_drafts?
+        return false unless current_user&.role && current_user.role >= 7
+        return false if params.key?(:with_drafts) && !ActiveModel::Type::Boolean.new.cast(params[:with_drafts])
+
+        PartyDifficulty::DraftWorkspace.for(current_user).pending_count.positive?
       end
     end
   end

--- a/app/controllers/api/v1/difficulty_previews_controller.rb
+++ b/app/controllers/api/v1/difficulty_previews_controller.rb
@@ -42,7 +42,7 @@ module Api
 
         ws = PartyDifficulty::DraftWorkspace.for(current_user)
         {
-          rules: ws.merged_rules,
+          rules: ws.merged_rules(only_active: true),
           components: ws.merged_components,
           difficulties: ws.merged_tiers
         }

--- a/app/controllers/api/v1/difficulty_rules_controller.rb
+++ b/app/controllers/api/v1/difficulty_rules_controller.rb
@@ -7,9 +7,21 @@ module Api
       before_action :ensure_editor_role
 
       def index
-        rules = DifficultyRule.order(:component, :name)
-        rules = rules.where(component: params[:component]) if params[:component].present?
-        rules = rules.where(active: ActiveModel::Type::Boolean.new.cast(params[:active])) if params.key?(:active)
+        rules = if with_drafts?
+                  PartyDifficulty::DraftWorkspace.for(current_user).merged_rules
+                else
+                  DifficultyRule.order(:component, :name)
+                end
+
+        if params[:component].present?
+          rules = rules.respond_to?(:where) ? rules.where(component: params[:component]) : rules.select { |r| r.component == params[:component] }
+        end
+
+        if params.key?(:active)
+          active = ActiveModel::Type::Boolean.new.cast(params[:active])
+          rules = rules.respond_to?(:where) ? rules.where(active: active) : rules.select { |r| r.active == active }
+        end
+
         render json: DifficultyRuleBlueprint.render(rules)
       end
 
@@ -21,31 +33,32 @@ module Api
       end
 
       def create
-        rule = DifficultyRule.new(rule_params)
-        rule.component ||= PartyDifficulty::Rules.component_for(rule.rule_type)
-        if rule.save
-          render json: DifficultyRuleBlueprint.render(rule), status: :created
-        else
-          render_validation_error_response(rule)
-        end
+        attrs = rule_params.to_h
+        attrs[:component] ||= PartyDifficulty::Rules.component_for(attrs[:rule_type])
+
+        draft = PartyDifficulty::DraftWorkspace.for(current_user).stage!(
+          target_type: 'DifficultyRule', target_id: nil, operation: 'create', attributes: attrs
+        )
+        render json: draft_envelope(draft), status: :created
       end
 
       def update
         rule = DifficultyRule.find_by(id: params[:id])
         return render_not_found_response('difficulty_rule') unless rule
 
-        if rule.update(rule_params)
-          render json: DifficultyRuleBlueprint.render(rule)
-        else
-          render_validation_error_response(rule)
-        end
+        draft = PartyDifficulty::DraftWorkspace.for(current_user).stage!(
+          target_type: 'DifficultyRule', target_id: rule.id, operation: 'update', attributes: rule_params
+        )
+        render json: draft_envelope(draft)
       end
 
       def destroy
         rule = DifficultyRule.find_by(id: params[:id])
         return render_not_found_response('difficulty_rule') unless rule
 
-        rule.destroy
+        PartyDifficulty::DraftWorkspace.for(current_user).stage!(
+          target_type: 'DifficultyRule', target_id: rule.id, operation: 'destroy', attributes: {}
+        )
         head :no_content
       end
 
@@ -80,6 +93,24 @@ module Api
         else
           raise ActionController::BadRequest, 'difficulty_rule.params must be an object'
         end
+      end
+
+      def with_drafts?
+        return false unless current_user&.role && current_user.role >= 7
+
+        ActiveModel::Type::Boolean.new.cast(params[:with_drafts])
+      end
+
+      def draft_envelope(draft)
+        {
+          draft: {
+            id: draft.id,
+            target_type: draft.target_type,
+            target_id: draft.target_id,
+            operation: draft.operation,
+            attributes: draft.attributes_payload
+          }
+        }
       end
     end
   end

--- a/app/jobs/download_artifact_images_job.rb
+++ b/app/jobs/download_artifact_images_job.rb
@@ -9,7 +9,7 @@
 class DownloadArtifactImagesJob < ApplicationJob
   queue_as :downloads
 
-  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   discard_on ActiveRecord::RecordNotFound do |job, _error|
     artifact_id = job.arguments.first

--- a/app/jobs/download_bullet_images_job.rb
+++ b/app/jobs/download_bullet_images_job.rb
@@ -3,7 +3,7 @@
 class DownloadBulletImagesJob < ApplicationJob
   queue_as :downloads
 
-  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   discard_on ActiveRecord::RecordNotFound do |job, _error|
     bullet_id = job.arguments.first

--- a/app/jobs/download_character_images_job.rb
+++ b/app/jobs/download_character_images_job.rb
@@ -9,7 +9,7 @@
 class DownloadCharacterImagesJob < ApplicationJob
   queue_as :downloads
 
-  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   discard_on ActiveRecord::RecordNotFound do |job, _error|
     character_id = job.arguments.first

--- a/app/jobs/download_job_accessory_images_job.rb
+++ b/app/jobs/download_job_accessory_images_job.rb
@@ -9,7 +9,7 @@
 class DownloadJobAccessoryImagesJob < ApplicationJob
   queue_as :downloads
 
-  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   discard_on ActiveRecord::RecordNotFound do |job, _error|
     accessory_id = job.arguments.first

--- a/app/jobs/download_raid_images_job.rb
+++ b/app/jobs/download_raid_images_job.rb
@@ -9,7 +9,7 @@
 class DownloadRaidImagesJob < ApplicationJob
   queue_as :downloads
 
-  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   discard_on ActiveRecord::RecordNotFound do |job, _error|
     raid_id = job.arguments.first

--- a/app/jobs/download_summon_images_job.rb
+++ b/app/jobs/download_summon_images_job.rb
@@ -9,7 +9,7 @@
 class DownloadSummonImagesJob < ApplicationJob
   queue_as :downloads
 
-  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   discard_on ActiveRecord::RecordNotFound do |job, _error|
     summon_id = job.arguments.first

--- a/app/jobs/download_weapon_images_job.rb
+++ b/app/jobs/download_weapon_images_job.rb
@@ -9,7 +9,7 @@
 class DownloadWeaponImagesJob < ApplicationJob
   queue_as :downloads
 
-  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   discard_on ActiveRecord::RecordNotFound do |job, _error|
     weapon_id = job.arguments.first

--- a/app/jobs/generate_party_preview_job.rb
+++ b/app/jobs/generate_party_preview_job.rb
@@ -3,10 +3,17 @@ class GeneratePartyPreviewJob < ApplicationJob
   queue_as :previews
 
   # Configure retry behavior
-  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+  retry_on StandardError, wait: :polynomially_longer, attempts: 3
 
   discard_on ActiveRecord::RecordNotFound do |job, error|
     Rails.logger.error("Party #{job.arguments.first} not found for preview generation")
+  end
+
+  # AWS isn't configured locally — drop these jobs cleanly instead of retrying.
+  discard_on AwsService::ConfigurationError do |job, error|
+    Rails.logger.warn(
+      "Skipping preview for party #{job.arguments.first}: AWS not configured (#{error.message})"
+    )
   end
 
   around_perform :track_timing
@@ -51,6 +58,9 @@ class GeneratePartyPreviewJob < ApplicationJob
         Rails.logger.error("Failed to generate preview for party #{party_id}")
         notify_failure(party)
       end
+    rescue AwsService::ConfigurationError
+      # Let discard_on handle this without dumping a full stack trace.
+      raise
     rescue => e
       Rails.logger.error("Error generating preview for party #{party_id}: #{e.message}")
       Rails.logger.error("Full error details:")

--- a/app/models/difficulty_change_log.rb
+++ b/app/models/difficulty_change_log.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+##
+# Append-only audit log of editor commits against the difficulty ruleset.
+# Recorded by PartyDifficulty::DraftWorkspace#commit!. Not surfaced anywhere
+# yet — kept for future audit / undo / diff history features.
+class DifficultyChangeLog < ApplicationRecord
+  belongs_to :user
+
+  scope :recent_first, -> { order(committed_at: :desc) }
+end

--- a/app/models/difficulty_draft.rb
+++ b/app/models/difficulty_draft.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+##
+# A single pending change made by an editor against the canonical difficulty
+# ruleset. Drafts are applied via PartyDifficulty::DraftWorkspace and either
+# promoted to canonical via commit, or discarded.
+class DifficultyDraft < ApplicationRecord
+  TARGET_TYPES = %w[Difficulty DifficultyRule DifficultyComponent].freeze
+  OPERATIONS = %w[create update destroy].freeze
+
+  belongs_to :user
+
+  validates :target_type, inclusion: { in: TARGET_TYPES }
+  validates :operation, inclusion: { in: OPERATIONS }
+  validate :target_id_present_for_update_or_destroy
+
+  scope :for_user, ->(user) { where(user_id: user.id) }
+  scope :of_type, ->(type) { where(target_type: type.to_s) }
+
+  def attributes_payload
+    self[:attributes_payload] || {}
+  end
+
+  def target_class
+    target_type.constantize
+  end
+
+  def target
+    return nil if target_id.blank?
+
+    target_class.find_by(id: target_id)
+  end
+
+  private
+
+  def target_id_present_for_update_or_destroy
+    return if operation == 'create'
+    return if target_id.present?
+
+    errors.add(:target_id, "is required for #{operation}")
+  end
+end

--- a/app/services/party_difficulty/draft_workspace.rb
+++ b/app/services/party_difficulty/draft_workspace.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+module PartyDifficulty
+  ##
+  # Per-editor staging layer for difficulty rules / tiers / components.
+  # Editors mutate state here via the controllers, hit Preview to validate,
+  # iterate, and explicitly commit. Other consumers (the public list, the
+  # background score sweep) keep reading the canonical tables.
+  class DraftWorkspace
+    EDITABLE_COLUMNS = {
+      'Difficulty' => %w[name slug description min_score max_score sort_order color].freeze,
+      'DifficultyRule' => %w[name description component rule_type params weight active].freeze,
+      'DifficultyComponent' => %w[weight enabled min_count_to_score target_max].freeze
+    }.freeze
+
+    SUMMARY_COLUMNS = {
+      'Difficulty' => %w[name slug min_score max_score sort_order color],
+      'DifficultyRule' => %w[name component rule_type weight active],
+      'DifficultyComponent' => %w[name weight enabled min_count_to_score target_max]
+    }.freeze
+
+    def self.for(user)
+      new(user)
+    end
+
+    def initialize(user)
+      @user = user
+      @drafts = DifficultyDraft.for_user(user).to_a
+    end
+
+    attr_reader :user, :drafts
+
+    def pending_count
+      @drafts.size
+    end
+
+    def merged_tiers
+      merge_collection(Difficulty.ordered.to_a, 'Difficulty', sort_by: :sort_order)
+    end
+
+    def merged_rules
+      merge_collection(DifficultyRule.order(:component, :name).to_a, 'DifficultyRule', sort_by: :name)
+    end
+
+    def merged_components
+      merge_collection(DifficultyComponent.order(:name).to_a, 'DifficultyComponent', sort_by: :name)
+    end
+
+    def diff
+      {
+        tiers: section_diff('Difficulty'),
+        rules: section_diff('DifficultyRule'),
+        components: section_diff('DifficultyComponent')
+      }
+    end
+
+    def commit!(note: nil)
+      ApplicationRecord.transaction do
+        snapshot = diff
+        @drafts.each { |draft| apply!(draft) }
+        DifficultyConfig.bump_version!
+        log = DifficultyChangeLog.create!(
+          user: @user,
+          note: note.presence,
+          changes_payload: snapshot,
+          ruleset_version_after: DifficultyConfig.current_version,
+          committed_at: Time.current
+        )
+        @drafts.each(&:destroy)
+        @drafts = []
+        log
+      end
+    end
+
+    def discard!
+      destroyed = DifficultyDraft.for_user(@user).destroy_all
+      @drafts = []
+      destroyed.size
+    end
+
+    ##
+    # Upserts a draft for the given target. Returns the saved DifficultyDraft.
+    # For update / destroy operations, an existing draft for the same target is
+    # replaced. Create operations always insert a new row.
+    def stage!(target_type:, target_id:, operation:, attributes:)
+      target_type = target_type.to_s
+      operation = operation.to_s
+      raise ArgumentError, "Unknown target_type #{target_type}" unless EDITABLE_COLUMNS.key?(target_type)
+      raise ArgumentError, "Unknown operation #{operation}" unless DifficultyDraft::OPERATIONS.include?(operation)
+
+      payload = sanitize_attributes(target_type, attributes || {})
+
+      if operation == 'create'
+        DifficultyDraft.create!(
+          user: @user,
+          target_type: target_type,
+          target_id: nil,
+          operation: operation,
+          attributes_payload: payload
+        ).tap { |d| @drafts << d }
+      else
+        draft = DifficultyDraft.find_or_initialize_by(
+          user: @user,
+          target_type: target_type,
+          target_id: target_id
+        )
+        draft.operation = operation
+        draft.attributes_payload = operation == 'destroy' ? {} : payload
+        draft.save!
+        @drafts.reject! { |d| d.id == draft.id }
+        @drafts << draft
+        draft
+      end
+    end
+
+    private
+
+    def merge_collection(canonical, target_type, sort_by:)
+      by_target = grouped_drafts[target_type] || []
+      drafts_by_target = by_target.reject { |d| d.operation == 'create' }.index_by(&:target_id)
+
+      kept = canonical.flat_map do |record|
+        draft = drafts_by_target[record.id]
+        next [decorate(record, nil)] unless draft
+
+        case draft.operation
+        when 'destroy' then []
+        when 'update' then [build_updated(record, draft)]
+        else [decorate(record, nil)]
+        end
+      end
+
+      creates = by_target.select { |d| d.operation == 'create' }.map { |d| build_created(target_type, d) }
+      sort_records(kept + creates, sort_by)
+    end
+
+    def grouped_drafts
+      @grouped_drafts ||= @drafts.group_by(&:target_type)
+    end
+
+    def build_updated(record, draft)
+      cloned = record.class.find(record.id) # fresh copy to avoid mutating cache
+      apply_attrs(cloned, draft.attributes_payload)
+      decorate(cloned, draft)
+    end
+
+    def build_created(target_type, draft)
+      klass = target_type.constantize
+      record = klass.new(sanitize_attributes(target_type, draft.attributes_payload))
+      record.id = draft.id # virtual id so the UI can subsequently address this draft
+      record.created_at ||= draft.created_at
+      record.updated_at ||= draft.updated_at
+      decorate(record, draft)
+    end
+
+    def decorate(record, draft)
+      pending = !draft.nil?
+      operation = draft&.operation
+      draft_id = draft&.id
+      record.define_singleton_method(:pending?) { pending }
+      record.define_singleton_method(:pending_operation) { operation }
+      record.define_singleton_method(:draft_id) { draft_id }
+      record
+    end
+
+    def sort_records(records, sort_by)
+      records.sort_by { |r| [sort_value(r, sort_by), r.try(:name).to_s] }
+    end
+
+    def sort_value(record, sort_by)
+      value = record.respond_to?(sort_by) ? record.public_send(sort_by) : nil
+      value.is_a?(Numeric) ? value : value.to_s
+    end
+
+    def sanitize_attributes(target_type, attrs)
+      allowed = EDITABLE_COLUMNS[target_type] || []
+      (attrs || {}).each_with_object({}) do |(key, value), out|
+        out[key.to_s] = value if allowed.include?(key.to_s)
+      end
+    end
+
+    def apply_attrs(record, attrs)
+      sanitize_attributes(record.class.name, attrs).each { |k, v| record[k] = v }
+    end
+
+    def section_diff(target_type)
+      drafts = grouped_drafts[target_type] || []
+      creates = []
+      updates = []
+      destroys = []
+
+      drafts.each do |draft|
+        case draft.operation
+        when 'create'
+          creates << {
+            draft_id: draft.id,
+            attributes: sanitize_attributes(target_type, draft.attributes_payload)
+          }
+        when 'update'
+          target = draft.target
+          next unless target
+
+          field_diff = compute_field_diff(target, draft.attributes_payload, target_type)
+          next if field_diff.empty?
+
+          updates << {
+            draft_id: draft.id,
+            target_id: target.id,
+            label: summary_label(target),
+            changes: field_diff
+          }
+        when 'destroy'
+          target = draft.target
+          next unless target
+
+          destroys << {
+            draft_id: draft.id,
+            target_id: target.id,
+            label: summary_label(target),
+            snapshot: target.attributes.slice(*SUMMARY_COLUMNS.fetch(target_type, []))
+          }
+        end
+      end
+
+      { creates: creates, updates: updates, destroys: destroys }
+    end
+
+    def compute_field_diff(record, proposed, target_type)
+      allowed = EDITABLE_COLUMNS[target_type] || []
+      proposed.each_with_object({}) do |(key, new_value), out|
+        key = key.to_s
+        next unless allowed.include?(key)
+
+        old_value = record[key]
+        out[key] = { old: old_value, new: new_value } if normalized(old_value) != normalized(new_value)
+      end
+    end
+
+    def normalized(value)
+      case value
+      when BigDecimal then value.to_f
+      when Hash then value.deep_stringify_keys
+      else value
+      end
+    end
+
+    def summary_label(record)
+      return record.name if record.respond_to?(:name) && record.name.present?
+
+      record.id
+    end
+
+    def apply!(draft)
+      case draft.operation
+      when 'create'
+        klass = draft.target_class
+        klass.create!(sanitize_attributes(draft.target_type, draft.attributes_payload))
+      when 'update'
+        target = draft.target
+        target&.update!(sanitize_attributes(draft.target_type, draft.attributes_payload))
+      when 'destroy'
+        draft.target&.destroy
+      end
+    end
+  end
+end

--- a/app/services/party_difficulty/draft_workspace.rb
+++ b/app/services/party_difficulty/draft_workspace.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
 module PartyDifficulty
+  # Raised by DraftWorkspace#commit! when a staged update or destroy targets a
+  # record that another editor has changed since the draft was staged. The
+  # controller turns this into a 409 Conflict.
+  class StaleDraftError < StandardError
+    attr_reader :draft_id, :target_type, :target_id
+
+    def initialize(draft)
+      @draft_id = draft.id
+      @target_type = draft.target_type
+      @target_id = draft.target_id
+      super("Draft #{draft.id} is stale: target #{draft.target_type}/#{draft.target_id} changed after stage")
+    end
+  end
+
   ##
   # Per-editor staging layer for difficulty rules / tiers / components.
   # Editors mutate state here via the controllers, hit Preview to validate,
@@ -107,6 +121,9 @@ module PartyDifficulty
           attributes_payload: payload
         ).tap { |d| @drafts << d }
       else
+        # Snapshot the current target's updated_at so commit! can detect a
+        # concurrent edit by another editor.
+        target = target_type.constantize.find_by(id: target_id)
         draft = DifficultyDraft.find_or_initialize_by(
           user: @user,
           target_type: target_type,
@@ -114,6 +131,7 @@ module PartyDifficulty
         )
         draft.operation = operation
         draft.attributes_payload = operation == 'destroy' ? {} : payload
+        draft.target_updated_at = target&.updated_at
         draft.save!
         @drafts.reject! { |d| d.id == draft.id }
         @drafts << draft
@@ -206,7 +224,10 @@ module PartyDifficulty
           }
         when 'update'
           target = draft.target
-          next unless target
+          if target.nil?
+            updates << stale_entry(draft)
+            next
+          end
 
           field_diff = compute_field_diff(target, draft.attributes_payload, target_type)
           next if field_diff.empty?
@@ -215,22 +236,45 @@ module PartyDifficulty
             draft_id: draft.id,
             target_id: target.id,
             label: summary_label(target),
-            changes: field_diff
+            changes: field_diff,
+            stale: stale_against?(target, draft)
           }
         when 'destroy'
           target = draft.target
-          next unless target
+          if target.nil?
+            destroys << stale_entry(draft)
+            next
+          end
 
           destroys << {
             draft_id: draft.id,
             target_id: target.id,
             label: summary_label(target),
-            snapshot: target.attributes.slice(*SUMMARY_COLUMNS.fetch(target_type, []))
+            snapshot: target.attributes.slice(*SUMMARY_COLUMNS.fetch(target_type, [])),
+            stale: stale_against?(target, draft)
           }
         end
       end
 
       { creates: creates, updates: updates, destroys: destroys }
+    end
+
+    # Emitted for update/destroy drafts whose target has been deleted by
+    # another editor since the draft was staged. The frontend can prompt the
+    # editor to discard the stranded draft.
+    def stale_entry(draft)
+      {
+        draft_id: draft.id,
+        target_id: draft.target_id,
+        stale: true,
+        reason: 'target_missing'
+      }
+    end
+
+    def stale_against?(target, draft)
+      return false if draft.target_updated_at.nil?
+
+      target.updated_at != draft.target_updated_at
     end
 
     def compute_field_diff(record, proposed, target_type)
@@ -264,11 +308,25 @@ module PartyDifficulty
         klass = draft.target_class
         klass.create!(sanitize_attributes(draft.target_type, draft.attributes_payload))
       when 'update'
-        target = draft.target
+        target = lock_and_verify(draft)
         target&.update!(sanitize_attributes(draft.target_type, draft.attributes_payload))
       when 'destroy'
-        draft.target&.destroy!
+        target = lock_and_verify(draft)
+        target&.destroy!
       end
+    end
+
+    # Locks the target row for the rest of the commit transaction and raises
+    # StaleDraftError if the target's updated_at no longer matches the
+    # snapshot captured at stage time. Drafts without a snapshot (created
+    # before the optimistic-concurrency column existed) skip the check.
+    def lock_and_verify(draft)
+      target = draft.target&.lock!
+      return target if target.nil?
+      return target if draft.target_updated_at.nil?
+      return target if target.updated_at == draft.target_updated_at
+
+      raise StaleDraftError, draft
     end
   end
 end

--- a/app/services/party_difficulty/draft_workspace.rb
+++ b/app/services/party_difficulty/draft_workspace.rb
@@ -38,8 +38,13 @@ module PartyDifficulty
       merge_collection(Difficulty.ordered.to_a, 'Difficulty', sort_by: :sort_order)
     end
 
-    def merged_rules
-      merge_collection(DifficultyRule.order(:component, :name).to_a, 'DifficultyRule', sort_by: :name)
+    # When `only_active` is true, return only rules whose `active` flag is set
+    # (matching `DifficultyRule.active.to_a` in Calculator). The preview path
+    # needs this so a staged-but-inactive rule doesn't score differently than
+    # the canonical engine would after commit.
+    def merged_rules(only_active: false)
+      merged = merge_collection(DifficultyRule.order(:component, :name).to_a, 'DifficultyRule', sort_by: :name)
+      only_active ? merged.select(&:active) : merged
     end
 
     def merged_components
@@ -57,8 +62,11 @@ module PartyDifficulty
     def commit!(note: nil)
       ApplicationRecord.transaction do
         snapshot = diff
+        # Each apply! triggers the per-record after_save :bump_ruleset_version
+        # callback on Difficulty / DifficultyRule / DifficultyComponent, so the
+        # version increases by N. The log records the final post-apply version;
+        # we don't add an extra explicit bump here.
         @drafts.each { |draft| apply!(draft) }
-        DifficultyConfig.bump_version!
         log = DifficultyChangeLog.create!(
           user: @user,
           note: note.presence,
@@ -259,7 +267,7 @@ module PartyDifficulty
         target = draft.target
         target&.update!(sanitize_attributes(draft.target_type, draft.attributes_payload))
       when 'destroy'
-        draft.target&.destroy
+        draft.target&.destroy!
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,12 +194,14 @@ Rails.application.routes.draw do
     end
     resources :difficulty_previews, only: %i[create]
 
-    # Editor draft staging — `DELETE /difficulty_drafts/all` discards everything
-    # for the current user; the resourceful `destroy` handles single-draft drops.
+    # Editor draft staging — `DELETE /difficulty_drafts` (collection) discards
+    # everything for the current user; the resourceful `destroy` handles
+    # single-draft drops.
     resources :difficulty_drafts, only: %i[index create destroy] do
       collection do
         get :diff
         post :commit
+        delete '', action: :discard_all
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,15 @@ Rails.application.routes.draw do
     end
     resources :difficulty_previews, only: %i[create]
 
+    # Editor draft staging — `DELETE /difficulty_drafts/all` discards everything
+    # for the current user; the resourceful `destroy` handles single-draft drops.
+    resources :difficulty_drafts, only: %i[index create destroy] do
+      collection do
+        get :diff
+        post :commit
+      end
+    end
+
     # Grid artifacts
     resources :grid_artifacts, only: %i[create update destroy] do
       member do

--- a/db/migrate/20260511000000_create_difficulty_drafts_and_logs.rb
+++ b/db/migrate/20260511000000_create_difficulty_drafts_and_logs.rb
@@ -1,0 +1,32 @@
+class CreateDifficultyDraftsAndLogs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :difficulty_drafts, id: :uuid do |t|
+      t.references :user, type: :uuid, null: false, foreign_key: true
+      t.string :target_type, null: false
+      t.uuid :target_id
+      t.string :operation, null: false
+      t.jsonb :attributes_payload, null: false, default: {}
+      t.timestamps
+    end
+
+    # One pending update / destroy per (user, target). Unique by partial index
+    # so multiple `create` drafts (target_id IS NULL) can coexist.
+    add_index :difficulty_drafts,
+              %i[user_id target_type target_id],
+              unique: true,
+              where: 'target_id IS NOT NULL',
+              name: 'index_difficulty_drafts_per_target'
+    add_index :difficulty_drafts, %i[user_id target_type]
+
+    create_table :difficulty_change_logs, id: :uuid do |t|
+      t.references :user, type: :uuid, null: false, foreign_key: true
+      t.text :note
+      t.jsonb :changes_payload, null: false, default: {}
+      t.integer :ruleset_version_after
+      t.datetime :committed_at, null: false
+      t.timestamps
+    end
+
+    add_index :difficulty_change_logs, :committed_at
+  end
+end

--- a/db/migrate/20260511010000_add_target_updated_at_to_difficulty_drafts.rb
+++ b/db/migrate/20260511010000_add_target_updated_at_to_difficulty_drafts.rb
@@ -1,0 +1,9 @@
+class AddTargetUpdatedAtToDifficultyDrafts < ActiveRecord::Migration[8.0]
+  def change
+    # Captures the target row's updated_at at stage time so commit! can detect
+    # concurrent edits to the same target by another editor (optimistic
+    # concurrency). Nullable because create drafts have no target, and rows
+    # staged before this migration won't have a snapshot.
+    add_column :difficulty_drafts, :target_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_290000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_11_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -395,6 +395,18 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_10_290000) do
     t.index ["sort_order"], name: "index_difficulties_on_sort_order"
   end
 
+  create_table "difficulty_change_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.text "note"
+    t.jsonb "changes_payload", default: {}, null: false
+    t.integer "ruleset_version_after"
+    t.datetime "committed_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["committed_at"], name: "index_difficulty_change_logs_on_committed_at"
+    t.index ["user_id"], name: "index_difficulty_change_logs_on_user_id"
+  end
+
   create_table "difficulty_components", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.decimal "weight", precision: 6, scale: 2, default: "1.0", null: false
@@ -411,6 +423,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_10_290000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index "(true)", name: "index_difficulty_configs_singleton", unique: true
+  end
+
+  create_table "difficulty_drafts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.string "target_type", null: false
+    t.uuid "target_id"
+    t.string "operation", null: false
+    t.jsonb "attributes_payload", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "target_type", "target_id"], name: "index_difficulty_drafts_per_target", unique: true, where: "(target_id IS NOT NULL)"
+    t.index ["user_id", "target_type"], name: "index_difficulty_drafts_on_user_id_and_target_type"
+    t.index ["user_id"], name: "index_difficulty_drafts_on_user_id"
   end
 
   create_table "difficulty_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1372,6 +1397,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_10_290000) do
   add_foreign_key "crew_memberships", "users"
   add_foreign_key "crew_rosters", "crews"
   add_foreign_key "crew_rosters", "users", column: "created_by_id"
+  add_foreign_key "difficulty_change_logs", "users"
+  add_foreign_key "difficulty_drafts", "users"
   add_foreign_key "effects", "effects", column: "effect_family_id"
   add_foreign_key "favorites", "parties"
   add_foreign_key "favorites", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_11_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_11_010000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -433,6 +433,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_11_000000) do
     t.jsonb "attributes_payload", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "target_updated_at"
     t.index ["user_id", "target_type", "target_id"], name: "index_difficulty_drafts_per_target", unique: true, where: "(target_id IS NOT NULL)"
     t.index ["user_id", "target_type"], name: "index_difficulty_drafts_on_user_id_and_target_type"
     t.index ["user_id"], name: "index_difficulty_drafts_on_user_id"

--- a/docs/follow-ups/party-difficulty.md
+++ b/docs/follow-ups/party-difficulty.md
@@ -40,6 +40,34 @@ end
 
 ---
 
+## Reconcile `draft.id` ↔ canonical id after a create-draft commit
+
+**Status:** deferred during review of `jedmund/party-difficulty-drafts`.
+
+**Symptom.** `DraftWorkspace#build_created` assigns `record.id = draft.id` so the frontend can address a pending-creation row before it commits. After commit, `apply!` does `klass.create!(...)`, which generates a fresh UUID — the canonical id differs from the draft id the frontend just used.
+
+**Why not in the stack.** Verified that the Svelte frontend (`accra-v2` worktree) does not yet have a difficulty draft UI. There is currently no consumer that could observe the mismatch. The bug is latent.
+
+**What to do (when the UI is built).** Return a `{ draft_id => canonical_id }` map in the commit response. The frontend can reconcile any locally-cached references. Backwards-compatible — additive field on the existing JSON response. Sketch:
+
+```ruby
+# DraftWorkspace#commit!
+created_id_map = {}
+@drafts.each do |draft|
+  if draft.operation == 'create'
+    record = apply!(draft)
+    created_id_map[draft.id] = record.id
+  else
+    apply!(draft)
+  end
+end
+# include created_id_map in the return value alongside the change log
+```
+
+**When to revisit.** When the difficulty draft UI is added to `hensei-svelte`.
+
+---
+
 ## Request specs for the difficulty admin endpoints
 
 **Status:** deferred per the original review plan (R3 routing).

--- a/spec/services/party_difficulty/draft_workspace_spec.rb
+++ b/spec/services/party_difficulty/draft_workspace_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PartyDifficulty::DraftWorkspace do
+  let(:user) { create(:user) }
+  let(:component) do
+    DifficultyComponent.find_or_create_by!(name: 'weapon') do |c|
+      c.weight = 1
+      c.enabled = true
+      c.min_count_to_score = 0
+    end
+  end
+  let!(:rule) do
+    DifficultyRule.create!(
+      name: 'Spec base rule', component: 'weapon', rule_type: 'weapon_uncap_at_least',
+      weight: 2.0, active: true,
+      params: { 'min_uncap_level' => 1, 'min_count' => 1 }
+    )
+  end
+  let!(:tier) do
+    Difficulty.find_or_create_by!(slug: 'spec-tier') do |t|
+      t.name = 'Spec'
+      t.min_score = 0
+      t.max_score = 100
+      t.sort_order = 99
+    end
+  end
+
+  subject(:workspace) { described_class.for(user) }
+
+  describe '#stage!' do
+    it 'creates an update draft and surfaces it in merged_rules with pending? true' do
+      workspace.stage!(
+        target_type: 'DifficultyRule', target_id: rule.id, operation: 'update',
+        attributes: { weight: 99.0 }
+      )
+
+      reloaded = described_class.for(user)
+      merged = reloaded.merged_rules.find { |r| r.id == rule.id }
+      expect(merged.weight.to_f).to eq(99.0)
+      expect(merged.pending?).to be(true)
+      expect(merged.pending_operation).to eq('update')
+    end
+
+    it 'is idempotent on (user, target_type, target_id) for updates' do
+      workspace.stage!(target_type: 'DifficultyRule', target_id: rule.id, operation: 'update', attributes: { weight: 5 })
+      workspace.stage!(target_type: 'DifficultyRule', target_id: rule.id, operation: 'update', attributes: { weight: 6 })
+
+      expect(DifficultyDraft.for_user(user).where(target_id: rule.id).count).to eq(1)
+      expect(DifficultyDraft.for_user(user).find_by(target_id: rule.id).attributes_payload['weight']).to eq(6)
+    end
+
+    it 'records a destroy and omits the row from merged_rules' do
+      workspace.stage!(target_type: 'DifficultyRule', target_id: rule.id, operation: 'destroy', attributes: {})
+
+      reloaded = described_class.for(user)
+      expect(reloaded.merged_rules.map(&:id)).not_to include(rule.id)
+    end
+  end
+
+  describe '#diff' do
+    it 'reports field-level old/new for an update' do
+      workspace.stage!(target_type: 'DifficultyRule', target_id: rule.id, operation: 'update', attributes: { weight: 7.5 })
+
+      diff = described_class.for(user).diff
+      change = diff[:rules][:updates].first
+      expect(change[:changes]['weight']).to include(new: 7.5)
+    end
+  end
+
+  describe '#commit!' do
+    it 'promotes drafts to canonical, bumps the ruleset version, writes a log, and clears drafts' do
+      workspace.stage!(target_type: 'DifficultyRule', target_id: rule.id, operation: 'update', attributes: { weight: 12.0 })
+      starting_version = DifficultyConfig.current_version
+
+      log = described_class.for(user).commit!(note: 'spec')
+
+      rule.reload
+      expect(rule.weight.to_f).to eq(12.0)
+      expect(log.note).to eq('spec')
+      expect(log.ruleset_version_after).to be > starting_version
+      expect(DifficultyDraft.for_user(user).count).to eq(0)
+    end
+  end
+
+  describe '#discard!' do
+    it 'wipes the user drafts' do
+      workspace.stage!(target_type: 'DifficultyRule', target_id: rule.id, operation: 'update', attributes: { weight: 1 })
+      expect { described_class.for(user).discard! }.to change { DifficultyDraft.for_user(user).count }.to(0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `difficulty_drafts` + `difficulty_change_logs` tables, gated to editor role.
- `PartyDifficulty::DraftWorkspace` stages create/update/destroy against tiers/rules/components, merges into editor reads, and atomically promotes everything on commit (bumping `ruleset_version` once, writing an audit row, wiping the user's drafts).
- Existing CRUD endpoints (`DifficultiesController` / `DifficultyRulesController` / `DifficultyComponentsController`) reroute writes through the workspace for editors and surface `pending` / `pending_operation` / `draft_id` on reads behind `?with_drafts=true`.
- New `DifficultyDraftsController` (`index`, `diff`, `commit`, single + bulk `destroy`) plus a small spec covering stage/diff/commit/discard.
- Preview controller passes the merged collections to the calculator when the editor has drafts, so Preview reflects pending edits without touching canonical.

Also bundled (orthogonal but small): two ActiveJob fixes that surface when Sidekiq actually runs locally — `:exponentially_longer` → `:polynomially_longer` rename across all our retry-on declarations, and `GeneratePartyPreviewJob` now discards cleanly when AWS isn't configured in dev.

## Test plan
- [ ] `bundle exec rspec spec/services/party_difficulty/draft_workspace_spec.rb`
- [ ] As an editor, change a tier color + a rule weight + delete a component → confirm `GET /difficulty_drafts/diff` returns three sections with `old → new` for the update and snapshots for the destroy.
- [ ] `POST /difficulty_drafts/commit` with a note → canonical rows updated, `DifficultyConfig.current_version` bumped once, `DifficultyChangeLog.last.changes_payload` matches the diff, drafts cleared.
- [ ] Hit `GET /difficulties?with_drafts=true` as editor with pending changes → drafts merged in; non-editor request returns canonical.
- [ ] Run preview with drafts pending → score uses the staged rules/components/tiers.

---

## Review pass

**Resolved**
- [High] Preview path passed `DraftWorkspace#merged_rules` (full set, including inactive) to `Calculator`, which expects `DifficultyRule.active.to_a` — added `merged_rules(only_active: true)` and used it from `DifficultyPreviewsController`
- [Medium] `commit!` bumped `ruleset_version` N+1 times per commit (each `apply!` fires the per-record `after_save` callback, then commit called `DifficultyConfig.bump_version!` again) — dropped the explicit bump; per-record callbacks handle it
- [Medium] `apply!` used `destroy` on destroy drafts so a callback-blocked destroy silently failed and the transaction kept going — switched to `destroy!`
- [Medium] No optimistic concurrency at commit — staged drafts now snapshot `target.updated_at`, and `apply!` `lock!`s the target inside the transaction and raises `PartyDifficulty::StaleDraftError` (→ 409 Conflict) if it changed; new migration adds `target_updated_at` to `difficulty_drafts`
- [Possible Medium] `section_diff` silently skipped update/destroy drafts whose target had been deleted by another editor — now emits `{ stale: true, reason: 'target_missing' }` so the editor UI can prompt cleanup; entries also carry `stale: true` if the target was modified
- [Low] `DELETE /difficulty_drafts/all` used a magic `id == 'all'` sentinel — replaced with a dedicated `discard_all` collection action at `DELETE /difficulty_drafts`
- Cleanup: removed `ensure_editor_role` duplicate from `DifficultyDraftsController` (lifted to `ApiController` in #409)

**Deferred** (tracked in `docs/follow-ups/party-difficulty.md`)
- `build_created` assigns `record.id = draft.id` as a "virtual id" for the pre-commit UI; after commit `klass.create!` issues a fresh UUID. Verified via the `accra-v2` worktree that the Svelte frontend doesn't have a difficulty draft UI yet, so there's no consumer that could observe the mismatch. The follow-up describes returning a `{ draft_id => canonical_id }` map in the commit response when the UI is built.
