### PR TITLE
add optional icon to difficulty tiers via staged S3 upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ config/application.yml
 codebase.md
 mise.toml
 public/assets
+
+# Dev-only uploaded icons (live in S3 in production)
+public/images/difficulties/

--- a/app/blueprints/api/v1/difficulty_blueprint.rb
+++ b/app/blueprints/api/v1/difficulty_blueprint.rb
@@ -5,6 +5,18 @@ module Api
     class DifficultyBlueprint < ApiBlueprint
       fields :name, :slug, :description, :min_score, :max_score, :sort_order, :color
 
+      # Versioned with updated_at so the URL changes on every upload, busting
+      # any browser / CDN cache while the S3 object stays at a stable path.
+      field :image_key do |difficulty|
+        next nil if difficulty.image_key.blank?
+
+        if difficulty.respond_to?(:updated_at) && difficulty.updated_at
+          "#{difficulty.image_key}?v=#{difficulty.updated_at.to_i}"
+        else
+          difficulty.image_key
+        end
+      end
+
       field :pending do |obj|
         obj.respond_to?(:pending?) && obj.pending?
       end

--- a/app/blueprints/api/v1/difficulty_blueprint.rb
+++ b/app/blueprints/api/v1/difficulty_blueprint.rb
@@ -5,9 +5,11 @@ module Api
     class DifficultyBlueprint < ApiBlueprint
       fields :name, :slug, :description, :min_score, :max_score, :sort_order, :color
 
-      # Versioned with updated_at so the URL changes on every upload, busting
-      # any browser / CDN cache while the S3 object stays at a stable path.
-      field :image_key do |difficulty|
+      # Host-relative URL (i.e. <prefix>/<key>?v=<timestamp>), not a literal S3
+      # key. Versioned with updated_at so the URL changes on every upload,
+      # busting any browser / CDN cache while the S3 object stays at a stable
+      # path. Frontend prepends the configured S3/CDN host.
+      field :image_url do |difficulty|
         next nil if difficulty.image_key.blank?
 
         if difficulty.respond_to?(:updated_at) && difficulty.updated_at

--- a/app/controllers/api/v1/difficulty_drafts_controller.rb
+++ b/app/controllers/api/v1/difficulty_drafts_controller.rb
@@ -38,13 +38,27 @@ module Api
         draft = DifficultyDraft.for_user(current_user).find_by(id: params[:id])
         return render_not_found_response('difficulty_draft') unless draft
 
-        draft.destroy
+        @workspace.delete_draft!(draft)
         head :no_content
       end
 
       def discard_all
         discarded = @workspace.discard!
         render json: { discarded: discarded }
+      end
+
+      # POST /difficulty_drafts/:id/upload_image
+      # Body: { image: <base64-png>, filename: <string?> }
+      def upload_image
+        draft = DifficultyDraft.for_user(current_user).find_by(id: params[:id])
+        return render_not_found_response('difficulty_draft') unless draft
+
+        @workspace.attach_image!(draft, image_data: params[:image], filename: params[:filename])
+        render json: serialize(draft.reload)
+      rescue ArgumentError => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      rescue PartyDifficulty::DraftWorkspace::ImageValidationError => e
+        render json: { error: e.message }, status: :unprocessable_entity
       end
 
       def commit

--- a/app/controllers/api/v1/difficulty_drafts_controller.rb
+++ b/app/controllers/api/v1/difficulty_drafts_controller.rb
@@ -49,15 +49,24 @@ module Api
 
       # POST /difficulty_drafts/:id/upload_image
       # Body: { image: <base64-png>, filename: <string?> }
+      #
+      # IconUploadValidator caps decoded bytes at 256KB; base64 expansion adds
+      # ~33%, so reject requests above 512KB on Content-Length before reading
+      # the body so a misbehaving client can't pin a worker on a huge payload.
+      UPLOAD_REQUEST_MAX_BYTES = 512 * 1024
+
       def upload_image
+        if request.content_length.to_i > UPLOAD_REQUEST_MAX_BYTES
+          return render json: { error: "Request body exceeds #{UPLOAD_REQUEST_MAX_BYTES / 1024}KB" },
+                        status: :payload_too_large
+        end
+
         draft = DifficultyDraft.for_user(current_user).find_by(id: params[:id])
         return render_not_found_response('difficulty_draft') unless draft
 
         @workspace.attach_image!(draft, image_data: params[:image], filename: params[:filename])
         render json: serialize(draft.reload)
-      rescue ArgumentError => e
-        render json: { error: e.message }, status: :unprocessable_entity
-      rescue PartyDifficulty::DraftWorkspace::ImageValidationError => e
+      rescue ArgumentError, PartyDifficulty::DraftWorkspace::ImageValidationError => e
         render json: { error: e.message }, status: :unprocessable_entity
       end
 

--- a/app/services/icon_storage.rb
+++ b/app/services/icon_storage.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Editor-uploaded icon storage. In production this writes to S3 via
+# AwsService; in development/test it writes to public/<key> so files
+# are served by Rails' public_file_server at /<key>.
+#
+# Keys are stable, slash-separated paths starting with `images/`
+# (e.g. `images/difficulties/abc.png`). Read paths on the web side
+# strip the leading `images/` and prepend the configured image host.
+class IconStorage
+  CONTENT_TYPE = 'image/png'
+
+  def self.put(key, bytes)
+    new.put(key, bytes)
+  end
+
+  def self.copy(source_key, dest_key)
+    new.copy(source_key, dest_key)
+  end
+
+  def self.delete(key)
+    new.delete(key)
+  end
+
+  def initialize
+    @backend = Rails.env.production? ? :s3 : :local
+  end
+
+  def put(key, bytes)
+    if @backend == :s3
+      aws.s3_client.put_object(
+        bucket: aws.bucket,
+        key: key,
+        body: StringIO.new(bytes),
+        content_type: CONTENT_TYPE,
+        acl: 'public-read'
+      )
+    else
+      path = local_path(key)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.binwrite(path, bytes)
+    end
+  end
+
+  def copy(source_key, dest_key)
+    if @backend == :s3
+      aws.s3_client.copy_object(
+        bucket: aws.bucket,
+        copy_source: "#{aws.bucket}/#{source_key}",
+        key: dest_key,
+        acl: 'public-read',
+        metadata_directive: 'COPY'
+      )
+    else
+      src = local_path(source_key)
+      dest = local_path(dest_key)
+      FileUtils.mkdir_p(File.dirname(dest))
+      FileUtils.cp(src, dest)
+    end
+  end
+
+  def delete(key)
+    if @backend == :s3
+      aws.s3_client.delete_object(bucket: aws.bucket, key: key)
+    else
+      path = local_path(key)
+      File.delete(path) if File.exist?(path)
+    end
+  end
+
+  private
+
+  def aws
+    @aws ||= AwsService.new
+  end
+
+  def local_path(key)
+    Rails.root.join('public', key)
+  end
+end

--- a/app/services/icon_storage.rb
+++ b/app/services/icon_storage.rb
@@ -63,8 +63,7 @@ class IconStorage
     if @backend == :s3
       aws.s3_client.delete_object(bucket: aws.bucket, key: key)
     else
-      path = local_path(key)
-      File.delete(path) if File.exist?(path)
+      FileUtils.rm_f(local_path(key))
     end
   end
 

--- a/app/services/icon_upload_validator.rb
+++ b/app/services/icon_upload_validator.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Validates a raw (binary-decoded) PNG icon for editor-uploaded assets.
+#
+# Used by Difficulty tier icon uploads; intended to be the shared validator
+# for any other editor-uploadable icon (e.g. Roles when they grow drafts).
+class IconUploadValidator
+  PNG_SIGNATURE = "\x89PNG\r\n\x1A\n".b
+  DEFAULT_MAX_DIMENSION = 128
+  DEFAULT_MAX_BYTES = 256 * 1024
+
+  Result = Struct.new(:valid?, :error, keyword_init: true)
+
+  def self.call(decoded_bytes, max_dimension: DEFAULT_MAX_DIMENSION, max_bytes: DEFAULT_MAX_BYTES)
+    new(decoded_bytes, max_dimension: max_dimension, max_bytes: max_bytes).call
+  end
+
+  def initialize(decoded_bytes, max_dimension:, max_bytes:)
+    @bytes = decoded_bytes
+    @max_dimension = max_dimension
+    @max_bytes = max_bytes
+  end
+
+  def call
+    return invalid('No image data provided') if @bytes.blank?
+    return invalid("Icon must be #{@max_bytes / 1024}KB or smaller") if @bytes.bytesize > @max_bytes
+    return invalid('Icon must be a PNG') unless @bytes.start_with?(PNG_SIGNATURE)
+
+    Tempfile.create(['icon', '.png']) do |tmp|
+      tmp.binmode
+      tmp.write(@bytes)
+      tmp.flush
+
+      image = MiniMagick::Image.open(tmp.path)
+      return invalid('Icon must be a PNG') unless image.type == 'PNG'
+
+      if image.width > @max_dimension || image.height > @max_dimension
+        return invalid("Icon must be #{@max_dimension}x#{@max_dimension} or smaller")
+      end
+    end
+
+    Result.new(valid?: true, error: nil)
+  rescue MiniMagick::Invalid
+    invalid('Icon could not be read as an image')
+  end
+
+  private
+
+  def invalid(message)
+    Result.new(valid?: false, error: message)
+  end
+end

--- a/app/services/party_difficulty/draft_workspace.rb
+++ b/app/services/party_difficulty/draft_workspace.rb
@@ -33,6 +33,11 @@ module PartyDifficulty
       'DifficultyComponent' => %w[name weight enabled min_count_to_score target_max]
     }.freeze
 
+    # Stable canonical prefix; the editor writes drafts under the `_drafts/`
+    # subkey so a per-draft temp file never collides with a live tier icon.
+    IMAGE_FINAL_PREFIX = 'images/difficulties'
+    IMAGE_DRAFT_PREFIX = 'images/difficulties/_drafts'
+
     def self.for(user)
       new(user)
     end
@@ -95,10 +100,45 @@ module PartyDifficulty
     end
 
     def discard!
+      remove_temp_images(@drafts)
       destroyed = DifficultyDraft.for_user(@user).destroy_all
       @drafts = []
       destroyed.size
     end
+
+    ##
+    # Drops a single draft, cleaning up any temp S3 object that was staged
+    # against it. Returns true if the draft was destroyed.
+    def delete_draft!(draft)
+      remove_temp_images([draft])
+      destroyed = draft.destroy
+      @drafts.reject! { |d| d.id == draft.id }
+      destroyed
+    end
+
+    ##
+    # Stages an icon image for a Difficulty draft. Uploads the bytes to a
+    # draft-scoped S3 key and records that key on the draft's attributes so
+    # commit! can promote it to the canonical key once the tier's id is known.
+    def attach_image!(draft, image_data:, filename: nil)
+      raise ArgumentError, 'attach_image! only supports Difficulty drafts' unless draft.target_type == 'Difficulty'
+
+      decoded = decode_image(image_data)
+      result = IconUploadValidator.call(decoded)
+      raise ImageValidationError, result.error unless result.valid?
+
+      key = "#{IMAGE_DRAFT_PREFIX}/#{draft.id}.png"
+      IconStorage.put(key, decoded)
+
+      payload = (draft.attributes_payload || {}).merge('image_key' => key)
+      payload['image_filename'] = filename if filename.present?
+      draft.update!(attributes_payload: payload)
+      draft
+    end
+
+    # Raised by attach_image! when the uploaded bytes fail validation. The
+    # controller maps this to a 422 with the validator's message.
+    class ImageValidationError < StandardError; end
 
     ##
     # Upserts a draft for the given target. Returns the saved DifficultyDraft.
@@ -306,12 +346,15 @@ module PartyDifficulty
       case draft.operation
       when 'create'
         klass = draft.target_class
-        klass.create!(sanitize_attributes(draft.target_type, draft.attributes_payload))
+        record = klass.create!(sanitize_attributes(draft.target_type, draft.attributes_payload))
+        promote_image_if_present(draft, record)
       when 'update'
         target = lock_and_verify(draft)
         target&.update!(sanitize_attributes(draft.target_type, draft.attributes_payload))
+        promote_image_if_present(draft, target) if target
       when 'destroy'
         target = lock_and_verify(draft)
+        cleanup_canonical_image(target) if target.is_a?(Difficulty)
         target&.destroy!
       end
     end
@@ -327,6 +370,64 @@ module PartyDifficulty
       return target if target.updated_at == draft.target_updated_at
 
       raise StaleDraftError, draft
+    end
+
+    # When a draft has a `_drafts/`-prefixed image_key in its attributes, copy
+    # the staged S3 object to the canonical key and write that key to the row.
+    #
+    # Ordering matters for retry safety: copy → update_column → best-effort
+    # delete. If the DB write fails, the canonical key exists but the row
+    # doesn't reference it (orphan, recoverable). If the delete fails, the
+    # staged copy lingers — that's intentionally non-fatal, the S3 lifecycle
+    # rule on the `_drafts/` prefix sweeps it.
+    def promote_image_if_present(draft, record)
+      return unless draft.target_type == 'Difficulty'
+
+      staged_key = draft.attributes_payload&.dig('image_key')
+      return unless staged_key.is_a?(String) && staged_key.start_with?("#{IMAGE_DRAFT_PREFIX}/")
+
+      final_key = "#{IMAGE_FINAL_PREFIX}/#{record.id}.png"
+      IconStorage.copy(staged_key, final_key)
+      record.update!(image_key: final_key)
+      begin
+        IconStorage.delete(staged_key)
+      rescue StandardError => e
+        Rails.logger.warn("[difficulty_drafts] orphaned staged image #{staged_key}: #{e.message}")
+      end
+    end
+
+    def cleanup_canonical_image(record)
+      return if record.image_key.blank?
+
+      IconStorage.delete(record.image_key)
+    rescue StandardError => e
+      # A missing canonical image shouldn't block destroying the row.
+      Rails.logger.warn("[difficulty_drafts] failed to delete canonical image #{record.image_key}: #{e.message}")
+    end
+
+    def remove_temp_images(drafts)
+      drafts.each do |draft|
+        next unless draft.target_type == 'Difficulty'
+
+        key = draft.attributes_payload&.dig('image_key')
+        next unless key.is_a?(String) && key.start_with?("#{IMAGE_DRAFT_PREFIX}/")
+
+        begin
+          IconStorage.delete(key)
+        rescue StandardError => e
+          Rails.logger.warn("[difficulty_drafts] failed to delete temp image #{key}: #{e.message}")
+        end
+      end
+    end
+
+    # Accepts a raw PNG byte string or a base64-encoded string. Base64 input
+    # always comes through JSON as UTF-8, so the byte-pattern fast-path below
+    # has to compare on the binary view to avoid Encoding::CompatibilityError.
+    def decode_image(image_data)
+      return '' if image_data.blank?
+      return image_data if image_data.is_a?(String) && image_data.b.start_with?(IconUploadValidator::PNG_SIGNATURE)
+
+      Base64.decode64(image_data.to_s)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -203,6 +203,9 @@ Rails.application.routes.draw do
         post :commit
         delete '', action: :discard_all
       end
+      member do
+        post :upload_image
+      end
     end
 
     # Grid artifacts

--- a/db/migrate/20260512000000_add_image_key_to_difficulties.rb
+++ b/db/migrate/20260512000000_add_image_key_to_difficulties.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Adds an optional S3 key for tier icons. Canonical objects live at
+# images/difficulties/<id>.png. The DraftWorkspace stages uploads at
+# images/difficulties/_drafts/<draft_id>.png; the drafts prefix should
+# have an S3 lifecycle rule (e.g. 30-day expiry) to clean up orphans
+# from abandoned drafts that never reach commit or discard.
+class AddImageKeyToDifficulties < ActiveRecord::Migration[8.0]
+  def change
+    add_column :difficulties, :image_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_11_010000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_12_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -391,6 +391,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_11_010000) do
     t.string "color"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image_key"
     t.index ["slug"], name: "index_difficulties_on_slug", unique: true
     t.index ["sort_order"], name: "index_difficulties_on_sort_order"
   end

--- a/docs/follow-ups/party-difficulty.md
+++ b/docs/follow-ups/party-difficulty.md
@@ -4,6 +4,30 @@ Items surfaced during code review of the stacked `party-difficulty-*` PRs that w
 
 ---
 
+## Consolidate `IconStorage` / `IconUploadValidator` with `UploadedImageService`
+
+**Status:** deferred until after PR #414 (substitutions feature) merges. Tracked separately as a unification follow-up so both features get fixed before the consolidation happens.
+
+**What.** `-tier-images` introduced two service objects:
+
+- `app/services/icon_storage.rb` — S3 vs local backend branching, `put` / `copy` / `delete`, hardcoded `image/png` content type.
+- `app/services/icon_upload_validator.rb` — magic-byte PNG sniff, size cap, MiniMagick dimension check.
+
+PR #414 plans to introduce `UploadedImageService` (per `.context/attachments/pasted_text_2026-05-10_22-38-31.txt` — the R5 plan) covering the same surface: validate / store / delete for small PNG icons, configurable per-call.
+
+**What to do (after #414 lands).** Migrate `DraftWorkspace#attach_image!` / `promote_image_if_present` / `cleanup_canonical_image` / `remove_temp_images` to use `UploadedImageService` directly. Delete `IconStorage` and `IconUploadValidator`. Move the `_drafts/` prefix discipline into `DraftWorkspace` (the prefix is difficulty-specific; `UploadedImageService` should stay generic).
+
+**Why not consolidated upfront.** PR #414 isn't merged yet. Doing this stack first lets each feature land independently with its own review; unification is a follow-up PR off `main` after both ship.
+
+**Files to touch (later).**
+- Delete: `app/services/icon_storage.rb`, `app/services/icon_upload_validator.rb`.
+- Modify: `app/services/party_difficulty/draft_workspace.rb` (replace direct calls).
+- Add: `spec/services/uploaded_image_service_spec.rb` already in #414's plan; difficulty-side specs reuse it.
+
+**When to revisit.** When PR #414 merges to `main`.
+
+---
+
 ## Cache ruleset reads in `Calculator`
 
 **Status:** deferred during review of `jedmund/party-difficulty-admin`.

--- a/spec/services/party_difficulty/draft_workspace_spec.rb
+++ b/spec/services/party_difficulty/draft_workspace_spec.rb
@@ -90,4 +90,90 @@ RSpec.describe PartyDifficulty::DraftWorkspace do
       expect { described_class.for(user).discard! }.to change { DifficultyDraft.for_user(user).count }.to(0)
     end
   end
+
+  describe '#attach_image!' do
+    # 1x1 transparent PNG, base64-encoded — passes signature + dimension checks.
+    let(:png_base64) do
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+    end
+
+    before do
+      allow(IconStorage).to receive(:put)
+      allow(IconStorage).to receive(:copy)
+      allow(IconStorage).to receive(:delete)
+    end
+
+    it 'stages the upload at the draft-scoped key and records image_key on attributes' do
+      draft = workspace.stage!(
+        target_type: 'Difficulty', target_id: tier.id, operation: 'update', attributes: { name: 'Renamed' }
+      )
+
+      workspace.attach_image!(draft, image_data: png_base64, filename: 'tier.png')
+
+      expected_key = "images/difficulties/_drafts/#{draft.id}.png"
+      expect(IconStorage).to have_received(:put).with(expected_key, kind_of(String))
+      expect(draft.reload.attributes_payload['image_key']).to eq(expected_key)
+      expect(draft.attributes_payload['image_filename']).to eq('tier.png')
+    end
+
+    it 'raises an ImageValidationError when bytes are not a PNG' do
+      draft = workspace.stage!(
+        target_type: 'Difficulty', target_id: tier.id, operation: 'update', attributes: { name: 'x' }
+      )
+      junk = Base64.strict_encode64('not an image')
+
+      expect { workspace.attach_image!(draft, image_data: junk) }
+        .to raise_error(described_class::ImageValidationError, /PNG/)
+    end
+  end
+
+  describe '#commit! with staged image' do
+    let(:png_base64) do
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+    end
+
+    before do
+      allow(IconStorage).to receive(:put)
+      allow(IconStorage).to receive(:copy)
+      allow(IconStorage).to receive(:delete)
+    end
+
+    it 'promotes the staged image to the canonical key and writes image_key on the tier' do
+      draft = workspace.stage!(
+        target_type: 'Difficulty', target_id: tier.id, operation: 'update', attributes: { name: 'New' }
+      )
+      workspace.attach_image!(draft, image_data: png_base64)
+      staged_key = "images/difficulties/_drafts/#{draft.id}.png"
+      final_key = "images/difficulties/#{tier.id}.png"
+
+      described_class.for(user).commit!
+
+      expect(IconStorage).to have_received(:copy).with(staged_key, final_key)
+      expect(IconStorage).to have_received(:delete).with(staged_key)
+      expect(tier.reload.image_key).to eq(final_key)
+    end
+  end
+
+  describe '#discard! with staged image' do
+    let(:png_base64) do
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+    end
+
+    before do
+      allow(IconStorage).to receive(:put)
+      allow(IconStorage).to receive(:delete)
+    end
+
+    it 'removes temp images from storage' do
+      draft = workspace.stage!(
+        target_type: 'Difficulty', target_id: tier.id, operation: 'update', attributes: { name: 'x' }
+      )
+      workspace.attach_image!(draft, image_data: png_base64)
+      staged_key = "images/difficulties/_drafts/#{draft.id}.png"
+
+      described_class.for(user).discard!
+
+      expect(IconStorage).to have_received(:delete).with(staged_key)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Tiers can now carry an optional icon (PNG ≤128×128, ≤256KB) versioned with `updated_at` for cache-busting.
- New `IconStorage` service abstracts the storage backend: S3 in production, `public/<key>` (served by Rails) in development so dev uploads don't need AWS creds.
- New `IconUploadValidator` is the canonical PNG/dimension/size validator; intended to be the shared validator for any other editor-uploadable icon (e.g. Roles when they grow drafts).
- `DraftWorkspace#attach_image!` validates the bytes, writes the upload to `images/difficulties/_drafts/<draft_id>.png`, and stores that key on the draft's `attributes_payload`. On `commit!` it copies the staged object to `images/difficulties/<canonical_id>.png` and writes that final key onto the row; `discard!` and per-draft delete clean up temp objects from storage.
- `POST /difficulty_drafts/:id/upload_image` accepts `{ image: <base64>, filename? }` and proxies to `attach_image!`.

## Notes
- Bucket lifecycle: production should have a 30-day expiry rule on `images/difficulties/_drafts/` to clean up orphan temp objects from abandoned drafts that never reach commit or discard.
- The web side handles the UI on `jedmund/hensei-web#…`.

## Test plan
- [ ] `bundle exec rspec spec/services/party_difficulty/draft_workspace_spec.rb` (10 examples, includes attach/commit/discard image specs).
- [ ] Locally: editor uploads a tier icon → file lands at `public/images/difficulties/_drafts/<draft_id>.png`; commit → file moves to `public/images/difficulties/<tier_id>.png` and the row's `image_key` updates.
- [ ] Discard a pending draft with a staged icon → temp file removed from disk.
- [ ] Reject non-PNG / oversized uploads with a 422 + clear message.

---

## Review pass

**Resolved**
- [Medium] `promote_image_if_present` did `copy → delete → update!`; if the DB write failed, the canonical object was overwritten and the staged key was already gone — reordered to `copy → update! → best-effort delete`, so retries are idempotent and a partial run leaves the canonical key and DB in sync. Staged-key delete failures log a warning instead of aborting the commit (the bucket lifecycle rule sweeps the orphan).
- [Medium] `IconStorage.copy` + `delete` were not atomic and a `delete` failure aborted the whole commit — same fix; deletes are best-effort.
- [Medium] Blueprint field was named `image_key` but emitted `<key>?v=<timestamp>`, which is neither a literal key nor a full URL — renamed the field to `image_url` (host-relative URL with cache-buster, frontend prepends configured host).
- [Medium] `decode_image` fast-path compared a UTF-8 JSON string against an ASCII-8BIT `PNG_SIGNATURE` via `start_with?`, which could raise `Encoding::CompatibilityError` — compare on `image_data.b.start_with?(...)`.
- [Medium/Possible] No request body size guard; a malicious client could send a multi-MB base64 payload that the server would decode and validate just to reject — added an early `request.content_length > 512KB` check returning 413.
- Rubocop: `File.delete(path) if File.exist?(path)` race in the local backend → `FileUtils.rm_f(local_path(key))`.

**Inherited from #412**
- Image promote/cleanup now goes through `lock_and_verify`, so optimistic concurrency covers tier-with-icon edits too.

**Deferred** (tracked in `docs/follow-ups/party-difficulty.md`)
- Consolidate `IconStorage` + `IconUploadValidator` with `UploadedImageService` introduced in #414 (substitutions feature). Held until #414 merges so each feature ships independently; unification happens off `main`.
- Throttling on `/difficulty_drafts/:id/upload_image` — editor-only + the 512KB body cap is reasonable mitigation; broader `Rack::Attack` work is separate.
