### PR TITLE
fix issues found in roles & substitutions review

### DIFF
--- a/app/blueprints/api/v1/substitution_blueprint.rb
+++ b/app/blueprints/api/v1/substitution_blueprint.rb
@@ -5,14 +5,16 @@ module Api
     class SubstitutionBlueprint < ApiBlueprint
       field :position
 
-      association :substitute_grid, name: :grid_character, blueprint: GridCharacterBlueprint, view: :nested,
-                  if: ->(_field_name, sub, _options) { sub.substitute_grid_type == 'GridCharacter' }
-
-      association :substitute_grid, name: :grid_weapon, blueprint: GridWeaponBlueprint, view: :nested,
-                  if: ->(_field_name, sub, _options) { sub.substitute_grid_type == 'GridWeapon' }
-
-      association :substitute_grid, name: :grid_summon, blueprint: GridSummonBlueprint, view: :nested,
-                  if: ->(_field_name, sub, _options) { sub.substitute_grid_type == 'GridSummon' }
+      # Keeps the wire shape stable (three discriminated keys) — clients pick
+      # the right one by checking which is present.
+      {
+        'GridCharacter' => [:grid_character, GridCharacterBlueprint],
+        'GridWeapon'    => [:grid_weapon,    GridWeaponBlueprint],
+        'GridSummon'    => [:grid_summon,    GridSummonBlueprint]
+      }.each do |type, (name, blueprint)|
+        association :substitute_grid, name: name, blueprint: blueprint, view: :nested,
+                    if: ->(_field_name, sub, _options) { sub.substitute_grid_type == type }
+      end
     end
   end
 end

--- a/app/controllers/api/v1/grid_character_roles_controller.rb
+++ b/app/controllers/api/v1/grid_character_roles_controller.rb
@@ -57,6 +57,17 @@ module Api
         entries = params[:roles]
         return render json: { error: 'roles array required' }, status: :unprocessable_entity if entries.blank?
 
+        # Validate the whole batch before opening the transaction so a bad id in
+        # entry N doesn't roll back the N-1 successful updates and leave the
+        # caller without a usable error.
+        requested_ids = entries.map { |e| e[:id] }
+        known_ids = GridCharacterRole.where(id: requested_ids).pluck(:id)
+        missing = requested_ids - known_ids
+        unless missing.empty?
+          return render json: { error: 'unknown role ids', ids: missing },
+                        status: :unprocessable_entity
+        end
+
         GridCharacterRole.transaction do
           entries.each do |entry|
             GridCharacterRole.find(entry[:id]).update!(sort_order: entry[:sort_order])
@@ -125,8 +136,9 @@ module Api
           tmp.write(decoded)
           tmp.flush
 
+          # The PNG magic-byte check above is already sufficient for type; this
+          # MiniMagick handle is here for the dimension check.
           image = MiniMagick::Image.open(tmp.path)
-          return 'Icon must be a PNG' unless image.type == 'PNG'
 
           if image.width > ICON_MAX_DIMENSION || image.height > ICON_MAX_DIMENSION
             return "Icon must be #{ICON_MAX_DIMENSION}x#{ICON_MAX_DIMENSION} or smaller"

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -444,7 +444,9 @@ module Api
 
         return render_not_found_response('party') unless @party
 
-        preload_substitute_grids!(@party.characters + @party.weapons + @party.summons)
+        # Most parties have zero substitutes; a single EXISTS lookup is far cheaper
+        # than the three collection-ownership queries `preload_substitute_grids!` runs.
+        preload_substitute_grids!(@party.characters + @party.weapons + @party.summons) if @party.has_substitutions?
       end
 
       # Loads the party by its id.

--- a/app/controllers/api/v1/substitutions_controller.rb
+++ b/app/controllers/api/v1/substitutions_controller.rb
@@ -5,6 +5,8 @@ module Api
     class SubstitutionsController < ApiController
       include PartyAuthorizationConcern
 
+      DUPLICATE_ERROR = 'item is already a substitute for this slot'
+
       before_action :restrict_access
       before_action :set_party
       before_action :authorize_party!
@@ -14,7 +16,6 @@ module Api
         grid_type = substitution_params[:grid_type]
         grid_id = substitution_params[:grid_id]
         item_id = substitution_params[:item_id]
-        position = substitution_params[:position] || next_position(grid_type, grid_id)
 
         grid_class = grid_class_for(grid_type)
         return render json: { error: "invalid grid_type: #{grid_type}" }, status: :unprocessable_entity unless grid_class
@@ -23,44 +24,66 @@ module Api
         return render_not_found_response('grid item') unless grid_item
 
         item_fk = item_foreign_key(grid_type)
-
-        if substitute_already_present?(grid_type, grid_id, item_fk, item_id)
-          return render json: { error: 'item is already a substitute for this slot' }, status: :unprocessable_entity
+        canonical = ITEM_CLASS_FOR_GRID[grid_type]&.find_by(id: item_id)
+        unless canonical
+          return render json: { error: "unknown item_id: #{item_id}" }, status: :unprocessable_entity
         end
 
-        substitute = grid_class.create!(
-          party: @party,
-          item_fk => item_id,
-          position: grid_item.position,
-          uncap_level: 0,
-          is_substitute: true
-        )
+        substitution = ApplicationRecord.transaction do
+          substitute = grid_class.create!(
+            party: @party,
+            item_fk => item_id,
+            position: grid_item.position,
+            uncap_level: max_uncap_level_for(grid_type, canonical),
+            is_substitute: true
+          )
 
-        substitution = Substitution.create!(
-          grid_type: grid_type,
-          grid_id: grid_id,
-          substitute_grid_type: grid_type,
-          substitute_grid_id: substitute.id,
-          position: position.to_i
-        )
+          Substitution.create!(
+            grid_type: grid_type,
+            grid_id: grid_id,
+            substitute_grid_type: grid_type,
+            substitute_grid_id: substitute.id,
+            position: substitution_params[:position].presence&.to_i || next_position(grid_type, grid_id)
+          )
+        end
 
         @party.mark_updated!
-
         render json: SubstitutionBlueprint.render(substitution), status: :created
+      rescue ActiveRecord::RecordNotUnique
+        # Either two parallel requests added the same canonical item to this slot
+        # (caught by index_*_unique_substitute on the grid_*items table) or two
+        # parallel requests claimed the same position (caught by
+        # index_substitutions_on_slot_position). The user-visible error is the
+        # same in both cases.
+        render json: { error: DUPLICATE_ERROR }, status: :unprocessable_entity
+      rescue ActiveRecord::InvalidForeignKey
+        render json: { error: "unknown item_id: #{params.dig(:substitution, :item_id)}" },
+               status: :unprocessable_entity
       end
 
       def update
-        @substitution.update!(position: substitution_params[:position])
-        @party.mark_updated!
+        if substitution_params[:position].blank?
+          return render json: { error: 'position is required' }, status: :unprocessable_entity
+        end
+
+        ApplicationRecord.transaction do
+          @substitution.update!(position: substitution_params[:position])
+          @party.mark_updated!
+        end
 
         render json: SubstitutionBlueprint.render(@substitution)
+      rescue ActiveRecord::RecordNotUnique
+        render json: { error: 'another substitution already occupies that position' },
+               status: :unprocessable_entity
       end
 
       def destroy
-        substitute = @substitution.substitute_grid
-        @substitution.destroy!
-        substitute&.destroy!
-        @party.mark_updated!
+        ApplicationRecord.transaction do
+          substitute = @substitution.substitute_grid
+          @substitution.destroy!
+          substitute&.destroy!
+          @party.mark_updated!
+        end
 
         head :no_content
       end
@@ -84,14 +107,24 @@ module Api
         )
       end
 
+      # Counts existing rows rather than MAX+1: after deletes, MAX+1 can produce
+      # positions >= 10 while fewer than 10 rows exist (which would then fail
+      # the numericality bound). The new unique index on (grid_type, grid_id,
+      # position) prevents collisions if two creates race.
       def next_position(grid_type, grid_id)
-        Substitution.where(grid_type: grid_type, grid_id: grid_id).maximum(:position).to_i + 1
+        Substitution.where(grid_type: grid_type, grid_id: grid_id).count
       end
 
       GRID_TYPE_FOREIGN_KEYS = {
         'GridCharacter' => :character_id,
         'GridWeapon' => :weapon_id,
         'GridSummon' => :summon_id
+      }.freeze
+
+      ITEM_CLASS_FOR_GRID = {
+        'GridCharacter' => Character,
+        'GridWeapon' => Weapon,
+        'GridSummon' => Summon
       }.freeze
 
       def item_foreign_key(grid_type)
@@ -105,14 +138,48 @@ module Api
         grid_type.constantize
       end
 
-      # Reject if this item is already a substitute for the same parent slot.
-      # Substitutes per slot are bounded (the model caps at 10), so loading them
-      # all and comparing in Ruby is fine and avoids polymorphic-join gymnastics.
-      def substitute_already_present?(grid_type, grid_id, item_fk, item_id)
-        Substitution.where(grid_type: grid_type, grid_id: grid_id)
-                    .includes(:substitute_grid)
-                    .filter_map(&:substitute_grid)
-                    .any? { |sg| sg[item_fk] == item_id }
+      # Derives the natural max uncap for the canonical item so a substitute is
+      # created at the same ceiling its real counterpart would use, rather than
+      # the previous hardcoded 0.
+      def max_uncap_level_for(grid_type, canonical)
+        case grid_type
+        when 'GridWeapon'
+          weapon_max_uncap(canonical)
+        when 'GridCharacter'
+          character_max_uncap(canonical)
+        when 'GridSummon'
+          summon_max_uncap(canonical)
+        end
+      end
+
+      def weapon_max_uncap(weapon)
+        return 6 if weapon.transcendence
+        return 5 if weapon.ulb
+        return 4 if weapon.flb
+
+        3
+      end
+
+      def character_max_uncap(character)
+        if character.special
+          return 5 if character.transcendence
+          return 4 if character.flb
+
+          3
+        else
+          return 6 if character.transcendence
+          return 5 if character.flb
+
+          4
+        end
+      end
+
+      def summon_max_uncap(summon)
+        return 6 if summon.transcendence
+        return 5 if summon.ulb
+        return 4 if summon.flb
+
+        3
       end
     end
   end

--- a/app/controllers/concerns/substitute_grid_preloading.rb
+++ b/app/controllers/concerns/substitute_grid_preloading.rb
@@ -46,6 +46,14 @@ module SubstituteGridPreloading
 
   private
 
+  # (collection_class, fk-on-grid-row) for each grid type. The blueprint reads
+  # `owned` from the grid row, so the fk we look up is the one on the row.
+  OWNERSHIP_BY_GRID = {
+    GridCharacter => [CollectionCharacter, :character_id],
+    GridWeapon    => [CollectionWeapon, :weapon_id],
+    GridSummon    => [CollectionSummon, :summon_id]
+  }.freeze
+
   # Sets the virtual `owned` attribute on each substitute_grid so the
   # blueprint can render whether current_user has the underlying entity in
   # their collection.
@@ -55,29 +63,14 @@ module SubstituteGridPreloading
     substitute_grids = substitutions.filter_map(&:substitute_grid)
     return if substitute_grids.empty?
 
-    char_subs = substitute_grids.select { |s| s.is_a?(GridCharacter) }
-    weapon_subs = substitute_grids.select { |s| s.is_a?(GridWeapon) }
-    summon_subs = substitute_grids.select { |s| s.is_a?(GridSummon) }
+    substitute_grids.group_by(&:class).each do |klass, grids|
+      collection_class, fk = OWNERSHIP_BY_GRID[klass]
+      next unless collection_class
 
-    if char_subs.any?
-      owned = CollectionCharacter.where(user_id: current_user.id,
-                                        character_id: char_subs.map(&:character_id))
-                                 .pluck(:character_id).to_set
-      char_subs.each { |s| s.owned = owned.include?(s.character_id) }
+      owned = collection_class.where(user_id: current_user.id,
+                                     fk => grids.map(&fk))
+                              .pluck(fk).to_set
+      grids.each { |g| g.owned = owned.include?(g.send(fk)) }
     end
-
-    if weapon_subs.any?
-      owned = CollectionWeapon.where(user_id: current_user.id,
-                                     weapon_id: weapon_subs.map(&:weapon_id))
-                              .pluck(:weapon_id).to_set
-      weapon_subs.each { |s| s.owned = owned.include?(s.weapon_id) }
-    end
-
-    return if summon_subs.empty?
-
-    owned = CollectionSummon.where(user_id: current_user.id,
-                                   summon_id: summon_subs.map(&:summon_id))
-                            .pluck(:summon_id).to_set
-    summon_subs.each { |s| s.owned = owned.include?(s.summon_id) }
   end
 end

--- a/app/models/grid_character.rb
+++ b/app/models/grid_character.rb
@@ -26,10 +26,11 @@ class GridCharacter < ApplicationRecord
              inverse_of: :characters
   belongs_to :collection_character, optional: true
 
-  has_many :grid_character_role_assignments, dependent: :destroy
+  has_many :grid_character_role_assignments, dependent: :destroy, inverse_of: :grid_character
   has_many :grid_character_roles, through: :grid_character_role_assignments
 
   has_many :substitutions, as: :grid, dependent: :destroy
+  has_many :substitute_of, class_name: 'Substitution', as: :substitute_grid, dependent: :destroy
 
   has_one :grid_artifact, dependent: :destroy
 
@@ -67,6 +68,12 @@ class GridCharacter < ApplicationRecord
     enable
     include_association :grid_artifact
     exclude_association :grid_character_role_assignments
+    # Substitutions are remapped explicitly by Party#create_remapped_substitutions
+    # so the polymorphic foreign keys point at the new grid items. Letting amoeba
+    # also clone them produces duplicate rows that violate the uniqueness index
+    # on (grid_type, grid_id, position).
+    exclude_association :substitutions
+    exclude_association :substitute_of
     set ring1: { modifier: nil, strength: nil }
     set ring2: { modifier: nil, strength: nil }
     set ring3: { modifier: nil, strength: nil }

--- a/app/models/grid_character_role.rb
+++ b/app/models/grid_character_role.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class GridCharacterRole < ApplicationRecord
-  has_many :grid_character_role_assignments, dependent: :destroy
+  has_many :grid_character_role_assignments, dependent: :destroy, inverse_of: :grid_character_role
   has_many :grid_characters, through: :grid_character_role_assignments
 
   validates :name_en, presence: true

--- a/app/models/grid_character_role_assignment.rb
+++ b/app/models/grid_character_role_assignment.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class GridCharacterRoleAssignment < ApplicationRecord
-  belongs_to :grid_character
-  belongs_to :grid_character_role
+  belongs_to :grid_character, inverse_of: :grid_character_role_assignments
+  belongs_to :grid_character_role, inverse_of: :grid_character_role_assignments
 
   validates :grid_character_role_id, uniqueness: { scope: :grid_character_id }
 end

--- a/app/models/grid_summon.rb
+++ b/app/models/grid_summon.rb
@@ -18,6 +18,7 @@ class GridSummon < ApplicationRecord
   belongs_to :collection_summon, optional: true
 
   has_many :substitutions, as: :grid, dependent: :destroy
+  has_many :substitute_of, class_name: 'Substitution', as: :substitute_grid, dependent: :destroy
   validates_presence_of :party
 
   # Associations the nested blueprint walks. Reused by controllers and the

--- a/app/models/grid_weapon.rb
+++ b/app/models/grid_weapon.rb
@@ -33,6 +33,7 @@ class GridWeapon < ApplicationRecord
   validates_presence_of :party
 
   has_many :substitutions, as: :grid, dependent: :destroy
+  has_many :substitute_of, class_name: 'Substitution', as: :substitute_grid, dependent: :destroy
 
   belongs_to :weapon_key1, class_name: 'WeaponKey', foreign_key: :weapon_key1_id, optional: true
   belongs_to :weapon_key2, class_name: 'WeaponKey', foreign_key: :weapon_key2_id, optional: true

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -160,10 +160,14 @@ class Party < ApplicationRecord
            class_name: 'GridSummon',
            inverse_of: :party
 
+  # Uses :destroy on all three so the grid items' own callbacks fire — most
+  # importantly `has_many :substitutions, ..., dependent: :destroy`. :delete_all
+  # would skip callbacks and leave orphan substitution rows pointing at deleted
+  # grid ids.
   has_many :all_characters,
            foreign_key: 'party_id',
            class_name: 'GridCharacter',
-           dependent: :delete_all,
+           dependent: :destroy,
            inverse_of: :party
 
   has_many :all_weapons,
@@ -175,7 +179,7 @@ class Party < ApplicationRecord
   has_many :all_summons,
            foreign_key: 'party_id',
            class_name: 'GridSummon',
-           dependent: :delete_all,
+           dependent: :destroy,
            inverse_of: :party
 
   has_many :favorites, dependent: :destroy
@@ -276,6 +280,25 @@ class Party < ApplicationRecord
   # @return [Boolean] true if the update succeeded.
   def mark_updated!
     update_column(:last_updated, Time.current)
+  end
+
+  ##
+  # Returns true iff any grid item in this party has at least one substitution.
+  #
+  # Uses a single EXISTS query over substitutions, scoped by polymorphic
+  # (grid_type, grid_id) pairs. Most parties have zero substitutes, so this
+  # cheap predicate lets the read path skip the heavier preload_substitute_grids!
+  # work in SubstituteGridPreloading.
+  #
+  # @return [Boolean]
+  def has_substitutions?
+    return @has_substitutions if defined?(@has_substitutions)
+
+    @has_substitutions = Substitution
+                         .where(grid_type: 'GridCharacter', grid_id: GridCharacter.where(party_id: id).select(:id))
+                         .or(Substitution.where(grid_type: 'GridWeapon', grid_id: GridWeapon.where(party_id: id).select(:id)))
+                         .or(Substitution.where(grid_type: 'GridSummon', grid_id: GridSummon.where(party_id: id).select(:id)))
+                         .exists?
   end
 
   ##
@@ -587,24 +610,32 @@ class Party < ApplicationRecord
   end
 
   def remap_substitutions_for(grid_type, old_items, new_items, item_fk)
+    new_index = new_items.index_by { |ni| [ni.send(item_fk), ni.position, ni.is_substitute] }
+    old_by_id = old_items.index_by(&:id)
+
     old_items.each do |old_item|
       old_item.substitutions.each do |sub|
-        new_grid = new_items.detect do |ni|
-          ni.send(item_fk) == old_item.send(item_fk) &&
-            ni.position == old_item.position &&
-            ni.is_substitute == old_item.is_substitute
+        new_grid = new_index[[old_item.send(item_fk), old_item.position, old_item.is_substitute]]
+        old_sub_grid = old_by_id[sub.substitute_grid_id]
+
+        unless old_sub_grid
+          Rails.logger.warn(
+            "[Party#remap_substitutions_for] skip: substitute grid #{sub.substitute_grid_id} " \
+            "missing from source party=#{@_source_party_for_remap&.id} type=#{grid_type}"
+          )
+          next
         end
 
-        old_sub_grid = old_items.detect { |oi| oi.id == sub.substitute_grid_id }
-        next unless old_sub_grid
+        new_sub_grid = new_index[[old_sub_grid.send(item_fk), old_sub_grid.position, old_sub_grid.is_substitute]]
 
-        new_sub_grid = new_items.detect do |ni|
-          ni.send(item_fk) == old_sub_grid.send(item_fk) &&
-            ni.position == old_sub_grid.position &&
-            ni.is_substitute == old_sub_grid.is_substitute
+        unless new_grid && new_sub_grid
+          Rails.logger.warn(
+            "[Party#remap_substitutions_for] skip: no new mapping for sub=#{sub.id} " \
+            "source=#{@_source_party_for_remap&.id} target=#{id} type=#{grid_type} " \
+            "missing=#{new_grid.nil? ? 'new_grid' : 'new_sub_grid'}"
+          )
+          next
         end
-
-        next unless new_grid && new_sub_grid
 
         Substitution.create!(
           grid_type: grid_type,

--- a/app/models/substitution.rb
+++ b/app/models/substitution.rb
@@ -8,7 +8,7 @@ class Substitution < ApplicationRecord
                        numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 10 }
 
   validate :grid_types_must_match
-  validate :substitution_cap
+  validate :no_self_substitution
 
   private
 
@@ -20,14 +20,11 @@ class Substitution < ApplicationRecord
     end
   end
 
-  def substitution_cap
-    return unless grid.present?
+  def no_self_substitution
+    return if grid_id.blank? || substitute_grid_id.blank?
 
-    existing = Substitution.where(grid_type: grid_type, grid_id: grid_id)
-    existing = existing.where.not(id: id) if persisted?
-
-    if existing.count >= 10
-      errors.add(:base, 'maximum of 10 substitutions per slot')
+    if grid_type == substitute_grid_type && grid_id == substitute_grid_id
+      errors.add(:substitute_grid, 'cannot reference itself')
     end
   end
 end

--- a/db/migrate/20260510020000_add_unique_substitute_indexes_to_grid_items.rb
+++ b/db/migrate/20260510020000_add_unique_substitute_indexes_to_grid_items.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddUniqueSubstituteIndexesToGridItems < ActiveRecord::Migration[8.0]
+  ITEM_FOREIGN_KEYS = {
+    grid_weapons: :weapon_id,
+    grid_characters: :character_id,
+    grid_summons: :summon_id
+  }.freeze
+
+  def change
+    ITEM_FOREIGN_KEYS.each do |table, fk|
+      add_index table,
+                [:party_id, :position, fk],
+                unique: true,
+                where: 'is_substitute',
+                name: "index_#{table}_unique_substitute"
+    end
+  end
+end

--- a/db/migrate/20260510020001_add_unique_position_to_substitutions.rb
+++ b/db/migrate/20260510020001_add_unique_position_to_substitutions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddUniquePositionToSubstitutions < ActiveRecord::Migration[8.0]
+  def change
+    # The original (grid_type, grid_id, substitute_grid_type, substitute_grid_id)
+    # index cannot fire — substitute_grid_id is freshly generated on every insert,
+    # so the tuple is unique by construction. Replace it with an index that
+    # actually enforces the slot ordering invariant.
+    remove_index :substitutions, name: 'index_substitutions_uniqueness'
+
+    add_index :substitutions,
+              %i[grid_type grid_id position],
+              unique: true,
+              name: 'index_substitutions_on_slot_position'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_10_015531) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_10_020001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -493,6 +493,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_10_015531) do
     t.index ["awakening_id"], name: "index_grid_characters_on_awakening_id"
     t.index ["character_id"], name: "index_grid_characters_on_character_id"
     t.index ["collection_character_id"], name: "index_grid_characters_on_collection_character_id"
+    t.index ["party_id", "position", "character_id"], name: "index_grid_characters_unique_substitute", unique: true, where: "is_substitute"
     t.index ["party_id", "position"], name: "index_grid_characters_on_party_id_and_position"
     t.index ["party_id"], name: "index_grid_characters_on_party_id"
   end
@@ -514,6 +515,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_10_015531) do
     t.jsonb "description"
     t.index ["collection_summon_id"], name: "index_grid_summons_on_collection_summon_id"
     t.index ["orphaned"], name: "index_grid_summons_on_orphaned"
+    t.index ["party_id", "position", "summon_id"], name: "index_grid_summons_unique_substitute", unique: true, where: "is_substitute"
     t.index ["party_id", "position"], name: "index_grid_summons_on_party_id_and_position"
     t.index ["party_id"], name: "index_grid_summons_on_party_id"
     t.index ["summon_id"], name: "index_grid_summons_on_summon_id"
@@ -563,6 +565,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_10_015531) do
     t.index ["befoulment_modifier_id"], name: "index_grid_weapons_on_befoulment_modifier_id"
     t.index ["collection_weapon_id"], name: "index_grid_weapons_on_collection_weapon_id"
     t.index ["orphaned"], name: "index_grid_weapons_on_orphaned"
+    t.index ["party_id", "position", "weapon_id"], name: "index_grid_weapons_unique_substitute", unique: true, where: "is_substitute"
     t.index ["party_id", "position"], name: "index_grid_weapons_on_party_id_and_position"
     t.index ["party_id"], name: "index_grid_weapons_on_party_id"
     t.index ["weapon_id"], name: "index_grid_weapons_on_weapon_id"
@@ -955,7 +958,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_10_015531) do
     t.integer "position", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["grid_type", "grid_id", "substitute_grid_type", "substitute_grid_id"], name: "index_substitutions_uniqueness", unique: true
+    t.index ["grid_type", "grid_id", "position"], name: "index_substitutions_on_slot_position", unique: true
     t.index ["grid_type", "grid_id"], name: "index_substitutions_on_grid"
     t.index ["substitute_grid_type", "substitute_grid_id"], name: "index_substitutions_on_substitute_grid"
   end

--- a/spec/concerns/substitute_grid_preloading_spec.rb
+++ b/spec/concerns/substitute_grid_preloading_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubstituteGridPreloading, type: :concern do
+  # Minimal host that just exposes the concern and a current_user accessor.
+  let(:host_class) do
+    Class.new do
+      include SubstituteGridPreloading
+      attr_accessor :current_user
+    end
+  end
+
+  let(:host) { host_class.new }
+  let(:user) { create(:user) }
+  let(:party) { create(:party, user: user) }
+  let(:weapon) { Weapon.find_by!(granblue_id: '1040611300') }
+  let(:other_weapon) { Weapon.find_by!(granblue_id: '1040912100') }
+
+  before { host.current_user = user }
+
+  def collect_sql_queries
+    queries = []
+    subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |_n, _s, _f, _id, payload|
+      next if payload[:name].in?(%w[SCHEMA TRANSACTION])
+
+      queries << payload[:sql]
+    end
+    yield
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+    queries
+  end
+
+  it 'hydrates substitute_grid records and stamps ownership in a bounded query count' do
+    gw = create(:grid_weapon, party: party, weapon: weapon)
+    sw1 = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
+    sw2 = create(:grid_weapon, party: party, weapon: weapon, is_substitute: true, position: 1)
+    create(:substitution, grid: gw, substitute_grid: sw1, position: 0)
+    create(:substitution, grid: gw, substitute_grid: sw2, position: 1)
+
+    # Source user owns one of the canonical weapons; the other should report unowned.
+    create(:collection_weapon, user: user, weapon: other_weapon)
+
+    # Reload from the party so the substitutions association is unloaded and
+    # gets preloaded the same way the controller would.
+    fresh_gw = party.weapons.includes(substitutions: :substitute_grid).find(gw.id)
+
+    queries = collect_sql_queries do
+      host.send(:preload_substitute_grids!, [fresh_gw])
+    end
+
+    # Bound the queries: nested-preloads of the substitute grid associations
+    # plus one CollectionWeapon ownership lookup. Should NOT scale with the
+    # number of substitute rows. Slack is for Rails-internal noise; if this
+    # ever drifts above ~10, that's the N+1 the concern exists to prevent.
+    expect(queries.count).to be <= 6
+
+    subs = fresh_gw.substitutions.to_a
+    owned_flags = subs.map { |s| s.substitute_grid.owned }
+    expect(owned_flags).to match_array([true, false])
+  end
+
+  it 'no-ops when there are no substitutions' do
+    gw = create(:grid_weapon, party: party, weapon: weapon)
+    fresh_gw = party.weapons.includes(:substitutions).find(gw.id)
+
+    expect { host.send(:preload_substitute_grids!, [fresh_gw]) }.not_to raise_error
+  end
+end

--- a/spec/models/grid_character_role_spec.rb
+++ b/spec/models/grid_character_role_spec.rb
@@ -15,6 +15,25 @@ RSpec.describe GridCharacterRole, type: :model do
     end
   end
 
+  describe 'attributes' do
+    it 'round-trips name_jp' do
+      role = create(:grid_character_role, name_en: 'Attacker', name_jp: 'アタッカー')
+      expect(role.reload.name_jp).to eq('アタッカー')
+    end
+
+    it 'persists sort_order when explicitly set' do
+      role = create(:grid_character_role, sort_order: 7)
+      expect(role.reload.sort_order).to eq(7)
+    end
+
+    it 'leaves sort_order nil when not assigned at the model level' do
+      # Controller is responsible for defaulting via next_sort_order; the model
+      # itself does not default sort_order. Lock that contract.
+      role = GridCharacterRole.create!(name_en: 'Sortless', name_jp: nil, sort_order: nil)
+      expect(role.sort_order).to be_nil
+    end
+  end
+
   describe 'associations' do
     it 'has many characters through assignments' do
       role = create(:grid_character_role)

--- a/spec/models/party_remix_substitutions_spec.rb
+++ b/spec/models/party_remix_substitutions_spec.rb
@@ -56,4 +56,54 @@ RSpec.describe 'Party remix substitution remap', type: :model do
     new_party = remix(source_party)
     expect(Substitution.where(grid_id: new_party.all_weapons.pluck(:id)).count).to eq(1)
   end
+
+  it 'logs and skips when the old substitute grid id is missing from the source set' do
+    gw = create(:grid_weapon, party: source_party, weapon: weapon)
+    sw = create(:grid_weapon, party: source_party, weapon: other_weapon, is_substitute: true)
+    sub = create(:substitution, grid: gw, substitute_grid: sw, position: 0)
+
+    # Force the "old substitute grid missing" branch by repointing the
+    # substitution at a non-existent uuid. The polymorphic column has no FK
+    # constraint so we can drop straight to update_columns.
+    sub.update_columns(substitute_grid_id: SecureRandom.uuid)
+
+    allow(Rails.logger).to receive(:warn)
+    new_party = remix(source_party)
+
+    expect(Rails.logger).to have_received(:warn).with(/substitute grid .* missing from source/)
+    expect(Substitution.where(grid_id: new_party.all_weapons.pluck(:id))).to be_empty
+  end
+end
+
+RSpec.describe 'Party#has_substitutions?', type: :model do
+  let(:party) { create(:party) }
+  let(:weapon) { Weapon.find_by!(granblue_id: '1040611300') }
+  let(:other_weapon) { Weapon.find_by!(granblue_id: '1040912100') }
+
+  it 'is false when the party has no substitutions' do
+    create(:grid_weapon, party: party, weapon: weapon)
+    expect(party.has_substitutions?).to be false
+  end
+
+  it 'is true once any grid type carries a substitution' do
+    gw = create(:grid_weapon, party: party, weapon: weapon)
+    sw = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
+    create(:substitution, grid: gw, substitute_grid: sw, position: 0)
+
+    expect(party.has_substitutions?).to be true
+  end
+
+  it 'memoizes per instance' do
+    gw = create(:grid_weapon, party: party, weapon: weapon)
+
+    expect(party.has_substitutions?).to be false
+
+    # A new substitution after the first call should not flip the cached value
+    # on the same instance — callers needing fresh state must re-fetch.
+    sw = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
+    create(:substitution, grid: gw, substitute_grid: sw, position: 0)
+
+    expect(party.has_substitutions?).to be false
+    expect(Party.find(party.id).has_substitutions?).to be true
+  end
 end

--- a/spec/models/party_remix_substitutions_spec.rb
+++ b/spec/models/party_remix_substitutions_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Covers Party#create_remapped_substitutions / remap_substitutions_for, which
+# fires after_create when a remix has `_source_party_for_remap` set. The amoeba
+# config on Party copies the grid items; this callback copies the substitution
+# join rows pointing at them.
+RSpec.describe 'Party remix substitution remap', type: :model do
+  let(:source_party) { create(:party) }
+  let(:weapon)       { Weapon.find_by!(granblue_id: '1040611300') }
+  let(:other_weapon) { Weapon.find_by!(granblue_id: '1040912100') }
+
+  def remix(source)
+    new_party = source.amoeba_dup
+    new_party._source_party_for_remap = source
+    new_party.save!
+    new_party
+  end
+
+  it 'recreates substitutions across all three grid types' do
+    # Weapon side
+    gw   = create(:grid_weapon, party: source_party, weapon: weapon)
+    sw   = create(:grid_weapon, party: source_party, weapon: other_weapon, is_substitute: true)
+    create(:substitution, grid: gw, substitute_grid: sw, position: 0)
+
+    # Character side
+    character        = Character.first
+    other_character  = Character.where.not(id: character.id).first
+    gc = create(:grid_character, party: source_party, character: character)
+    sc = create(:grid_character, party: source_party, character: other_character, is_substitute: true)
+    create(:substitution, grid: gc, substitute_grid: sc, position: 0)
+
+    # Summon side
+    summon        = Summon.first
+    other_summon  = Summon.where.not(id: summon.id).first
+    gs = create(:grid_summon, party: source_party, summon: summon)
+    ss = create(:grid_summon, party: source_party, summon: other_summon, is_substitute: true)
+    create(:substitution, grid: gs, substitute_grid: ss, position: 0)
+
+    new_party = remix(source_party)
+
+    new_party_grid_ids = (new_party.all_characters + new_party.all_weapons + new_party.all_summons).map(&:id)
+    remixed_subs = Substitution.where(grid_id: new_party_grid_ids)
+
+    expect(remixed_subs.count).to eq(3)
+    expect(remixed_subs.pluck(:grid_type).sort).to eq(%w[GridCharacter GridSummon GridWeapon])
+    expect(remixed_subs.pluck(:position).uniq).to eq([0])
+  end
+
+  it 'does not duplicate when remixed twice' do
+    gw = create(:grid_weapon, party: source_party, weapon: weapon)
+    sw = create(:grid_weapon, party: source_party, weapon: other_weapon, is_substitute: true)
+    create(:substitution, grid: gw, substitute_grid: sw, position: 0)
+
+    new_party = remix(source_party)
+    expect(Substitution.where(grid_id: new_party.all_weapons.pluck(:id)).count).to eq(1)
+  end
+end

--- a/spec/models/substitution_spec.rb
+++ b/spec/models/substitution_spec.rb
@@ -53,27 +53,31 @@ RSpec.describe Substitution, type: :model do
       expect(sub).to be_valid
     end
 
-    it 'enforces uniqueness of grid + substitute_grid pair' do
+    it 'rejects self-substitution' do
       gw = create(:grid_weapon, party: party, weapon: weapon)
-      sw = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
-      create(:substitution, grid: gw, substitute_grid: sw, position: 0)
-
-      duplicate = build(:substitution, grid: gw, substitute_grid: sw, position: 1)
-      expect { duplicate.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+      sub = build(:substitution, grid: gw, substitute_grid: gw, position: 0)
+      expect(sub).not_to be_valid
+      expect(sub.errors[:substitute_grid]).to include('cannot reference itself')
     end
 
-    it 'enforces 10-per-slot cap' do
+    it 'enforces uniqueness of position within a slot' do
       gw = create(:grid_weapon, party: party, weapon: weapon)
+      sw1 = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
+      sw2 = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true, position: 1)
+      create(:substitution, grid: gw, substitute_grid: sw1, position: 0)
 
-      10.times do |i|
-        sw = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
-        create(:substitution, grid: gw, substitute_grid: sw, position: i)
-      end
+      duplicate = build(:substitution, grid: gw, substitute_grid: sw2, position: 0)
+      expect { duplicate.save!(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
 
-      extra = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
-      sub = build(:substitution, grid: gw, substitute_grid: extra, position: 0)
-      expect(sub).not_to be_valid
-      expect(sub.errors[:base]).to include('maximum of 10 substitutions per slot')
+    it 'allows the same position for different parent slots' do
+      gw1 = create(:grid_weapon, party: party, weapon: weapon)
+      gw2 = create(:grid_weapon, party: party, weapon: other_weapon, position: 1)
+      sw1 = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
+      sw2 = create(:grid_weapon, party: party, weapon: weapon, is_substitute: true, position: 1)
+
+      create(:substitution, grid: gw1, substitute_grid: sw1, position: 0)
+      expect { create(:substitution, grid: gw2, substitute_grid: sw2, position: 0) }.not_to raise_error
     end
   end
 
@@ -86,12 +90,22 @@ RSpec.describe Substitution, type: :model do
       expect { gw.destroy }.to change(Substitution, :count).by(-1)
     end
 
-    it 'does not destroy the substitute grid item when substitution is destroyed' do
+    it 'destroys substitutions when substitute grid item is destroyed' do
       gw = create(:grid_weapon, party: party, weapon: weapon)
       sw = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
-      sub = create(:substitution, grid: gw, substitute_grid: sw, position: 0)
+      create(:substitution, grid: gw, substitute_grid: sw, position: 0)
 
-      expect { sub.destroy }.not_to change(GridWeapon, :count)
+      expect { sw.destroy }.to change(Substitution, :count).by(-1)
+    end
+
+    it 'destroys all substitutions and substitute rows when the party is destroyed' do
+      gw = create(:grid_weapon, party: party, weapon: weapon)
+      sw = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
+      create(:substitution, grid: gw, substitute_grid: sw, position: 0)
+
+      expect { party.destroy }
+        .to change(Substitution, :count).by(-1)
+        .and change(GridWeapon.where(is_substitute: true), :count).by(-1)
     end
   end
 end

--- a/spec/requests/api/v1/grid_character_roles_spec.rb
+++ b/spec/requests/api/v1/grid_character_roles_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe 'GridCharacterRoles API', type: :request do
       expect {
         delete "/api/v1/grid_character_roles/#{role.id}", headers: editor_headers
       }.to change(GridCharacterRole, :count).by(-1)
-        .and change(GridCharacterRoleAssignment, :count).by(-1)
+                                            .and change(GridCharacterRoleAssignment, :count).by(-1)
 
       expect(response).to have_http_status(:no_content)
     end
@@ -152,6 +152,22 @@ RSpec.describe 'GridCharacterRoles API', type: :request do
     it 'returns 422 when roles array missing' do
       post '/api/v1/grid_character_roles/reorder', params: {}, headers: editor_headers, as: :json
       expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns 422 with the missing ids and rolls back when a role id is unknown' do
+      bogus = SecureRandom.uuid
+      original_sort_orders = [role1.sort_order, role2.sort_order]
+
+      post '/api/v1/grid_character_roles/reorder',
+           params: { roles: [{ id: role1.id, sort_order: 9 }, { id: bogus, sort_order: 1 }] },
+           headers: editor_headers, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body['ids']).to include(bogus)
+
+      # The valid update is rejected up front, not partially applied.
+      expect([role1.reload.sort_order, role2.reload.sort_order]).to eq(original_sort_orders)
     end
 
     it 'returns unauthorized for regular user' do

--- a/spec/requests/api/v1/grid_character_roles_spec.rb
+++ b/spec/requests/api/v1/grid_character_roles_spec.rb
@@ -219,6 +219,25 @@ RSpec.describe 'GridCharacterRoles API', type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
     end
 
+    it 'rejects an oversized icon (>128x128)' do
+      oversize_png = Tempfile.create(['oversize', '.png']) do |tmp|
+        tmp.binmode
+        MiniMagick::Tool::Magick.new do |c|
+          c.size '200x200'
+          c << 'xc:transparent'
+          c << tmp.path
+        end
+        File.binread(tmp.path)
+      end
+
+      post "/api/v1/grid_character_roles/#{role.id}/upload_icon",
+           params: { image: Base64.strict_encode64(oversize_png), filename: 'icon.png' },
+           headers: editor_headers, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)['error']).to match(/128x128 or smaller/)
+    end
+
     it 'returns unauthorized for regular user' do
       post "/api/v1/grid_character_roles/#{role.id}/upload_icon",
            params: { image: tiny_png_b64 },

--- a/spec/requests/api/v1/substitutions_spec.rb
+++ b/spec/requests/api/v1/substitutions_spec.rb
@@ -376,6 +376,66 @@ RSpec.describe 'Substitutions API', type: :request do
                  end
       expect(GridWeapon.find(Substitution.last.substitute_grid_id).uncap_level).to eq(expected)
     end
+
+    it 'matches the canonical character\'s max uncap (special branch)' do
+      character = Character.first
+      other_character = Character.where.not(id: character.id).first
+      grid_character = create(:grid_character, party: party, character: character)
+
+      params = {
+        substitution: {
+          party_id: party.id,
+          grid_type: 'GridCharacter',
+          grid_id: grid_character.id,
+          item_id: other_character.id,
+          position: 0
+        }
+      }
+
+      post '/api/v1/substitutions', params: params.to_json, headers: headers
+
+      expected = if other_character.special
+                   if other_character.transcendence
+                     5
+                   else
+                     other_character.flb ? 4 : 3
+                   end
+                 elsif other_character.transcendence
+                   6
+                 else
+                   other_character.flb ? 5 : 4
+                 end
+      expect(GridCharacter.find(Substitution.last.substitute_grid_id).uncap_level).to eq(expected)
+    end
+
+    it 'matches the canonical summon\'s max uncap' do
+      summon = Summon.first
+      other_summon = Summon.where.not(id: summon.id).first
+      grid_summon = create(:grid_summon, party: party, summon: summon)
+
+      params = {
+        substitution: {
+          party_id: party.id,
+          grid_type: 'GridSummon',
+          grid_id: grid_summon.id,
+          item_id: other_summon.id,
+          position: 0
+        }
+      }
+
+      post '/api/v1/substitutions', params: params.to_json, headers: headers
+
+      expected = if other_summon.transcendence
+                   6
+                 elsif other_summon.ulb
+                   5
+                 elsif other_summon.flb
+                   4
+                 else
+                   3
+                 end
+      expect(GridSummon.find(Substitution.last.substitute_grid_id).uncap_level).to eq(expected)
+    end
   end
 
   describe '11th substitute' do

--- a/spec/requests/api/v1/substitutions_spec.rb
+++ b/spec/requests/api/v1/substitutions_spec.rb
@@ -312,4 +312,139 @@ RSpec.describe 'Substitutions API', type: :request do
       expect(JSON.parse(response.body)['error']).to match(/already a substitute/i)
     end
   end
+
+  describe 'invalid item_id' do
+    it 'returns 422 (not 500) when item_id does not exist' do
+      grid_weapon = create(:grid_weapon, party: party, weapon: weapon)
+
+      params = {
+        substitution: {
+          party_id: party.id,
+          grid_type: 'GridWeapon',
+          grid_id: grid_weapon.id,
+          item_id: SecureRandom.uuid
+        }
+      }
+
+      expect do
+        post '/api/v1/substitutions', params: params.to_json, headers: headers
+      end.not_to change(Substitution, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)['error']).to match(/unknown item_id/i)
+    end
+  end
+
+  describe 'PUT with missing position' do
+    it 'returns 422 when position is nil' do
+      grid_weapon = create(:grid_weapon, party: party, weapon: weapon)
+      sub_weapon = create(:grid_weapon, party: party, weapon: other_weapon, is_substitute: true)
+      substitution = create(:substitution, grid: grid_weapon, substitute_grid: sub_weapon, position: 0)
+
+      put "/api/v1/substitutions/#{substitution.id}",
+          params: { substitution: { party_id: party.id } }.to_json,
+          headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(substitution.reload.position).to eq(0)
+    end
+  end
+
+  describe 'substitute uncap_level' do
+    it 'matches the canonical weapon\'s max uncap' do
+      grid_weapon = create(:grid_weapon, party: party, weapon: weapon)
+      params = {
+        substitution: {
+          party_id: party.id,
+          grid_type: 'GridWeapon',
+          grid_id: grid_weapon.id,
+          item_id: other_weapon.id,
+          position: 0
+        }
+      }
+
+      post '/api/v1/substitutions', params: params.to_json, headers: headers
+
+      expected = if other_weapon.transcendence
+                   6
+                 elsif other_weapon.ulb
+                   5
+                 elsif other_weapon.flb
+                   4
+                 else
+                   3
+                 end
+      expect(GridWeapon.find(Substitution.last.substitute_grid_id).uncap_level).to eq(expected)
+    end
+  end
+
+  describe '11th substitute' do
+    it 'returns 422 when the slot already has 10 substitutes' do
+      grid_weapon = create(:grid_weapon, party: party, weapon: weapon)
+
+      # 10 distinct canonical weapons (the unique-substitute index forbids
+      # repeating the same canonical weapon in the same slot).
+      filler_weapons = Weapon.where.not(id: weapon.id).limit(11).to_a
+      raise 'need 11 distinct weapons in test seeds' if filler_weapons.length < 11
+
+      filler_weapons.first(10).each_with_index do |w, i|
+        sw = create(:grid_weapon, party: party, weapon: w, is_substitute: true)
+        create(:substitution, grid: grid_weapon, substitute_grid: sw, position: i)
+      end
+
+      params = {
+        substitution: {
+          party_id: party.id,
+          grid_type: 'GridWeapon',
+          grid_id: grid_weapon.id,
+          item_id: filler_weapons.last.id
+        }
+      }
+
+      expect do
+        post '/api/v1/substitutions', params: params.to_json, headers: headers
+      end.not_to change(Substitution, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe 'GridSummon substitution flow' do
+    let(:summon) { Summon.first }
+    let(:other_summon) { Summon.where.not(id: summon.id).first }
+    let(:grid_summon) { create(:grid_summon, party: party, summon: summon) }
+
+    it 'creates a substitution and a substitute grid summon' do
+      params = {
+        substitution: {
+          party_id: party.id,
+          grid_type: 'GridSummon',
+          grid_id: grid_summon.id,
+          item_id: other_summon.id,
+          position: 0
+        }
+      }
+
+      expect do
+        post '/api/v1/substitutions', params: params.to_json, headers: headers
+      end.to change(Substitution, :count).by(1)
+                                         .and change(GridSummon, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body).to have_key('grid_summon')
+    end
+
+    it 'destroys the substitute summon row on delete' do
+      sub_summon = create(:grid_summon, party: party, summon: other_summon, is_substitute: true)
+      substitution = create(:substitution, grid: grid_summon, substitute_grid: sub_summon, position: 0)
+
+      expect do
+        delete "/api/v1/substitutions/#{substitution.id}",
+               params: { substitution: { party_id: party.id } }.to_json,
+               headers: headers
+      end.to change(Substitution, :count).by(-1)
+                                         .and change(GridSummon, :count).by(-1)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Addresses the review findings on PR #369 (`Add substitutions feature`). 5 small commits — see each commit message for the full rationale.

| Commit | What |
|---|---|
| `enforce substitution invariants at the DB layer` | New partial unique indexes on `grid_*items` rows where `is_substitute`; new unique `(grid_type, grid_id, position)` index on `substitutions`; drop the old `substitutions` index that could never fire; drop count-based cap validation; add `no_self_substitution` |
| `fix party destroy cascade and remix substitution remap` | `all_characters`/`all_summons` → `dependent: :destroy`; reverse-side `substitute_of` on grid models so destroying a substitute item also cleans up the join row; exclude substitutions from amoeba on `GridCharacter` so the remap callback is the sole writer; hash-lookup rewrite + logged skips for `remap_substitutions_for`; `inverse_of` on role + assignment |
| `harden substitutions controller` | Transactions around create/update/destroy; rescue `RecordNotUnique` → 422; pre-check canonical item → 422 instead of 500 on bogus `item_id`; derive `uncap_level` from the canonical item's max; reject nil position on PUT; `next_position` uses `COUNT(*)` instead of `MAX+1` |
| `validate roles reorder ids up front and drop redundant icon check` | Pre-validate all ids before opening the transaction; respond 422 `{ ids: [...] }` instead of generic 404 mid-rollback; drop redundant `image.type == 'PNG'` check (magic-byte check already covers it) |
| `skip substitute preload on parties with none` | New `Party#has_substitutions?` (single memoized `EXISTS`); gate `preload_substitute_grids!` on it so the 3-query tax only runs when needed; DRY the three ownership-stamping blocks via `group_by(&:class)` + table; DRY the blueprint association declarations while preserving the wire shape |

## What's not in this PR

- **R5** (orphan S3 objects on role destroy) is deliberately deferred. A short follow-up plan is in `.context/r5-image-upload-service-plan.md`, scoped to extract a reusable upload/validate/delete service that the upcoming image-upload feature can share.

## Test plan

- [x] `bundle exec rubocop` clean
- [x] `bundle exec rspec` — 2401 examples, 0 failures
- [x] New specs cover: position uniqueness per slot, self-substitution rejection, party-destroy cascade through substitutions, three-grid-type remix, 11th-substitute API rejection, `uncap_level` matches canonical max, nil-position PUT, bogus `item_id` 422, GridSummon end-to-end, reorder partial-failure rollback, preloading query count bound, role `name_jp` round-trip + `sort_order` defaulting
- [ ] Manual: exercise add/remove/reorder substitutes in hensei-web against the API; remix a party with substitutions and confirm shape carries over