### PR TITLE
expose per-field drift on grid items

### DIFF
--- a/app/blueprints/api/v1/collection_character_blueprint.rb
+++ b/app/blueprints/api/v1/collection_character_blueprint.rb
@@ -4,8 +4,23 @@ module Api
       identifier :id
 
       fields :uncap_level, :transcendence_step, :perpetuity,
-             :ring1, :ring2, :ring3, :ring4, :earring,
              :created_at, :updated_at
+
+      # Positional ring loadout. Always emitted as a length-4 array so callers
+      # can index into a fixed slot (ring1 = ATK, ring2 = HP, ring3/4 = optional
+      # secondary/tertiary). Empty slots are null.
+      field :over_mastery do |obj|
+        [obj.ring1, obj.ring2, obj.ring3, obj.ring4].map do |ring|
+          serialize_ring(ring)
+        end
+      end
+
+      # Single earring slot or null when unset. Renamed from `earring` to
+      # `aetherial_mastery` so it matches the GridCharacter shape — both
+      # sides now read the same key.
+      field :aetherial_mastery do |obj|
+        serialize_ring(obj.earring)
+      end
 
       field :awakening do |obj|
         if obj.awakening.present?
@@ -20,6 +35,19 @@ module Api
 
       view :full do
         association :character, blueprint: CharacterBlueprint, view: :full
+      end
+
+      # Coerces a ring/earring JSONB hash into the canonical { modifier, strength }
+      # shape, or nil for any "empty" representation (null, missing keys, zeros).
+      def self.serialize_ring(ring)
+        return nil if ring.blank?
+
+        modifier = ring['modifier']
+        strength = ring['strength']
+        return nil if modifier.nil? || modifier.to_i.zero?
+        return nil if strength.nil? || strength.to_i.zero?
+
+        { modifier: modifier.to_i, strength: strength.to_i }
       end
     end
   end

--- a/app/blueprints/api/v1/grid_character_blueprint.rb
+++ b/app/blueprints/api/v1/grid_character_blueprint.rb
@@ -13,6 +13,9 @@ module Api
       field :out_of_sync, if: ->(_field, gc, _options) { gc.collection_character_id.present? } do |gc|
         gc.out_of_sync?
       end
+      field :out_of_sync_fields, if: ->(_field, gc, _options) { gc.collection_character_id.present? } do |gc|
+        gc.out_of_sync_fields
+      end
       # Stamped by SubstituteGridPreloading when this is rendered as a
       # substitute. Indicates whether current_user owns the underlying
       # character in their collection.
@@ -24,7 +27,7 @@ module Api
 
       # Minimal view for party list cards
       view :list do
-        excludes :perpetuity, :collection_character_id, :out_of_sync
+        excludes :perpetuity, :collection_character_id, :out_of_sync, :out_of_sync_fields
         association :character, blueprint: CharacterBlueprint, view: :list
       end
 

--- a/app/blueprints/api/v1/grid_character_blueprint.rb
+++ b/app/blueprints/api/v1/grid_character_blueprint.rb
@@ -69,30 +69,19 @@ module Api
           }
         end
 
-        field :over_mastery, if: lambda { |_fn, obj, _opt|
-          obj.ring1.present? && obj.ring2.present? && !obj.ring1['modifier'].nil? && !obj.ring2['modifier'].nil?
-        } do |c|
-          mapped_rings = [c.ring1, c.ring2, c.ring3, c.ring4].each_with_object([]) do |ring, arr|
-            # Skip if the ring is nil or its modifier is blank.
-            next if ring.blank? || ring['modifier'].blank?
-
-            # Convert the string values to numbers.
-            mod = ring['modifier'].to_i
-
-            # Only include if modifier is non-zero.
-            next if mod.zero?
-
-            arr << { modifier: mod, strength: ring['strength'].to_i }
+        # Positional ring loadout shared with CollectionCharacterBlueprint —
+        # always emitted as a length-4 array. Empty slots are null so frontend
+        # readers can rely on positional access (overMastery[0] is ATK,
+        # overMastery[1] is HP, etc.).
+        field :over_mastery do |c|
+          [c.ring1, c.ring2, c.ring3, c.ring4].map do |ring|
+            CollectionCharacterBlueprint.serialize_ring(ring)
           end
-
-          mapped_rings
         end
 
-        field :aetherial_mastery, if: ->(_fn, obj, _opt) { obj.earring.present? && !obj.earring['modifier'].nil? } do |gc, _options|
-          {
-            modifier: gc.earring['modifier'].to_i,
-            strength: gc.earring['strength'].to_i
-          }
+        # Single earring slot or null. Same shape as CollectionCharacter.
+        field :aetherial_mastery do |gc, _options|
+          CollectionCharacterBlueprint.serialize_ring(gc.earring)
         end
       end
     end

--- a/app/blueprints/api/v1/grid_summon_blueprint.rb
+++ b/app/blueprints/api/v1/grid_summon_blueprint.rb
@@ -9,6 +9,9 @@ module Api
       field :out_of_sync, if: ->(_field, gs, _options) { gs.collection_summon_id.present? } do |gs|
         gs.out_of_sync?
       end
+      field :out_of_sync_fields, if: ->(_field, gs, _options) { gs.collection_summon_id.present? } do |gs|
+        gs.out_of_sync_fields
+      end
       field :owned, if: ->(_field, gs, _options) { !gs.owned.nil? }
 
       view :preview do
@@ -18,7 +21,7 @@ module Api
       # Minimal view for party list cards
       view :list do
         excludes :quick_summon,
-                 :orphaned, :collection_summon_id, :out_of_sync
+                 :orphaned, :collection_summon_id, :out_of_sync, :out_of_sync_fields
         association :summon, blueprint: SummonBlueprint, view: :list
       end
 

--- a/app/blueprints/api/v1/grid_summon_blueprint.rb
+++ b/app/blueprints/api/v1/grid_summon_blueprint.rb
@@ -3,7 +3,8 @@
 module Api
   module V1
     class GridSummonBlueprint < ApiBlueprint
-      fields :main, :friend, :position, :quick_summon, :uncap_level, :transcendence_step, :orphaned
+      fields :main, :friend, :position, :quick_summon, :uncap_level, :transcendence_step, :orphaned,
+             :notes_synced
 
       field :collection_summon_id
       field :out_of_sync, if: ->(_field, gs, _options) { gs.collection_summon_id.present? } do |gs|
@@ -21,7 +22,7 @@ module Api
       # Minimal view for party list cards
       view :list do
         excludes :quick_summon,
-                 :orphaned, :collection_summon_id, :out_of_sync, :out_of_sync_fields
+                 :orphaned, :collection_summon_id, :out_of_sync, :out_of_sync_fields, :notes_synced
         association :summon, blueprint: SummonBlueprint, view: :list
       end
 

--- a/app/blueprints/api/v1/grid_weapon_blueprint.rb
+++ b/app/blueprints/api/v1/grid_weapon_blueprint.rb
@@ -3,7 +3,8 @@
 module Api
   module V1
     class GridWeaponBlueprint < ApiBlueprint
-      fields :mainhand, :position, :uncap_level, :transcendence_step, :element, :exorcism_level, :orphaned
+      fields :mainhand, :position, :uncap_level, :transcendence_step, :element, :exorcism_level, :orphaned,
+             :notes_synced
 
       field :collection_weapon_id
       field :out_of_sync, if: ->(_field, gw, _options) { gw.collection_weapon_id.present? } do |gw|
@@ -21,7 +22,7 @@ module Api
       # Minimal view for party list cards
       view :list do
         excludes :exorcism_level,
-                 :orphaned, :collection_weapon_id, :out_of_sync, :out_of_sync_fields
+                 :orphaned, :collection_weapon_id, :out_of_sync, :out_of_sync_fields, :notes_synced
         association :weapon, blueprint: WeaponBlueprint, view: :list
       end
 

--- a/app/blueprints/api/v1/grid_weapon_blueprint.rb
+++ b/app/blueprints/api/v1/grid_weapon_blueprint.rb
@@ -9,6 +9,9 @@ module Api
       field :out_of_sync, if: ->(_field, gw, _options) { gw.collection_weapon_id.present? } do |gw|
         gw.out_of_sync?
       end
+      field :out_of_sync_fields, if: ->(_field, gw, _options) { gw.collection_weapon_id.present? } do |gw|
+        gw.out_of_sync_fields
+      end
       field :owned, if: ->(_field, gw, _options) { !gw.owned.nil? }
 
       view :preview do
@@ -18,7 +21,7 @@ module Api
       # Minimal view for party list cards
       view :list do
         excludes :exorcism_level,
-                 :orphaned, :collection_weapon_id, :out_of_sync
+                 :orphaned, :collection_weapon_id, :out_of_sync, :out_of_sync_fields
         association :weapon, blueprint: WeaponBlueprint, view: :list
       end
 

--- a/app/controllers/api/v1/grid_characters_controller.rb
+++ b/app/controllers/api/v1/grid_characters_controller.rb
@@ -263,7 +263,7 @@ module Api
           )
         end
 
-        @grid_character.sync_from_collection!
+        @grid_character.sync_from_collection!(fields: sync_fields_param)
         render json: GridCharacterBlueprint.render(@grid_character.reload,
                                                    root: :grid_character,
                                                    view: :nested)
@@ -287,7 +287,7 @@ module Api
           return render_unauthorized_response
         end
 
-        @grid_character.sync_to_collection!
+        @grid_character.sync_to_collection!(fields: sync_fields_param)
         render json: GridCharacterBlueprint.render(@grid_character.reload,
                                                    root: :grid_character,
                                                    view: :nested)
@@ -323,6 +323,17 @@ module Api
       end
 
       private
+
+      ##
+      # Pulls the optional `fields` array (camelCase keys) from the request body
+      # used by per-section sync. Returns nil when omitted so the model falls
+      # back to syncing every tracked column.
+      def sync_fields_param
+        raw = params[:fields]
+        return nil if raw.blank?
+
+        Array(raw).map(&:to_s).reject(&:blank?)
+      end
 
       ##
       # Builds a new grid character using the transformed parameters.

--- a/app/controllers/api/v1/grid_summons_controller.rb
+++ b/app/controllers/api/v1/grid_summons_controller.rb
@@ -71,9 +71,30 @@ module Api
       def update
         @grid_summon.attributes = summon_params
 
-        return render json: GridSummonBlueprint.render(@grid_summon, view: :nested, root: :grid_summon) if @grid_summon.save
+        sync_flag_change = nil
+        if summon_params.key?(:notes_synced)
+          sync_flag_change = ActiveModel::Type::Boolean.new.cast(summon_params[:notes_synced])
+        end
+        description_in_payload = summon_params.key?(:description)
 
-        render_validation_error_response(@grid_summon)
+        ActiveRecord::Base.transaction do
+          raise ActiveRecord::Rollback unless @grid_summon.save
+
+          if sync_flag_change == true
+            NotesSync.enable_sync!(@grid_summon)
+          elsif sync_flag_change == false
+            NotesSync.disable_sync!(@grid_summon)
+          elsif description_in_payload
+            NotesSync.propagate_description!(@grid_summon)
+          end
+        end
+
+        if @grid_summon.errors.empty?
+          @grid_summon.reload
+          render json: GridSummonBlueprint.render(@grid_summon, view: :nested, root: :grid_summon)
+        else
+          render_validation_error_response(@grid_summon)
+        end
       end
 
       ##
@@ -364,6 +385,9 @@ module Api
 
         @party.mark_updated!
         summon.sync_from_collection! if summon.collection_summon_id.present?
+        # Auto-join an existing notes sync group when this is a duplicate of a
+        # summon already in a synced group.
+        NotesSync.adopt_for_new_item!(summon)
         summon.reload
         output = render_grid_summon_view(summon)
         render json: output, status: :created
@@ -539,7 +563,7 @@ module Api
       def summon_params
         permitted = params.require(:summon).permit(:id, :party_id, :summon_id, :collection_summon_id,
                                                    :position, :main, :friend, :quick_summon,
-                                                   :uncap_level, :transcendence_step)
+                                                   :uncap_level, :transcendence_step, :notes_synced)
         permit_description(permitted, params[:summon])
       end
 

--- a/app/controllers/api/v1/grid_summons_controller.rb
+++ b/app/controllers/api/v1/grid_summons_controller.rb
@@ -264,7 +264,7 @@ module Api
           )
         end
 
-        @grid_summon.sync_from_collection!
+        @grid_summon.sync_from_collection!(fields: sync_fields_param)
         render json: GridSummonBlueprint.render(@grid_summon.reload,
                                                 root: :grid_summon,
                                                 view: :nested)
@@ -285,7 +285,7 @@ module Api
           return render_unauthorized_response
         end
 
-        @grid_summon.sync_to_collection!
+        @grid_summon.sync_to_collection!(fields: sync_fields_param)
         render json: GridSummonBlueprint.render(@grid_summon.reload,
                                                 root: :grid_summon,
                                                 view: :nested)
@@ -392,6 +392,17 @@ module Api
       end
 
       private
+
+      ##
+      # Pulls the optional `fields` array (camelCase keys) from the request body
+      # used by per-section sync. Returns nil when omitted so the model falls
+      # back to syncing every tracked column.
+      def sync_fields_param
+        raw = params[:fields]
+        return nil if raw.blank?
+
+        Array(raw).map(&:to_s).reject(&:blank?)
+      end
 
       ##
       # Finds the party based on the provided party_id parameter.

--- a/app/controllers/api/v1/grid_weapons_controller.rb
+++ b/app/controllers/api/v1/grid_weapons_controller.rb
@@ -271,7 +271,7 @@ module Api
           )
         end
 
-        @grid_weapon.sync_from_collection!
+        @grid_weapon.sync_from_collection!(fields: sync_fields_param)
         render json: GridWeaponBlueprint.render(@grid_weapon.reload,
                                                 root: :grid_weapon,
                                                 view: :full)
@@ -292,7 +292,7 @@ module Api
           return render_unauthorized_response
         end
 
-        @grid_weapon.sync_to_collection!
+        @grid_weapon.sync_to_collection!(fields: sync_fields_param)
         render json: GridWeaponBlueprint.render(@grid_weapon.reload,
                                                 root: :grid_weapon,
                                                 view: :full)
@@ -345,6 +345,17 @@ module Api
       end
 
       private
+
+      ##
+      # Pulls the optional `fields` array (camelCase keys) from the request body
+      # used by per-section sync. Returns nil when omitted so the model falls
+      # back to syncing every tracked column.
+      def sync_fields_param
+        raw = params[:fields]
+        return nil if raw.blank?
+
+        Array(raw).map(&:to_s).reject(&:blank?)
+      end
 
       ##
       # Computes the maximum uncap level for a given weapon based on its flags.

--- a/app/controllers/api/v1/grid_weapons_controller.rb
+++ b/app/controllers/api/v1/grid_weapons_controller.rb
@@ -69,6 +69,12 @@ module Api
       def update
         normalize_ax_fields!
 
+        sync_flag_change = nil
+        if weapon_params.key?(:notes_synced)
+          sync_flag_change = ActiveModel::Type::Boolean.new.cast(weapon_params[:notes_synced])
+        end
+        description_in_payload = weapon_params.key?(:description)
+
         ActiveRecord::Base.transaction do
           unless @grid_weapon.update(weapon_params.except(:bullets))
             raise ActiveRecord::Rollback
@@ -76,6 +82,16 @@ module Api
 
           if params.dig(:weapon, :bullets).present?
             update_bullet_loadout!(@grid_weapon, params[:weapon][:bullets])
+          end
+
+          # Fan out notes sync changes inside the same transaction so the
+          # group's description/flag can't drift if the rest of the request fails.
+          if sync_flag_change == true
+            NotesSync.enable_sync!(@grid_weapon)
+          elsif sync_flag_change == false
+            NotesSync.disable_sync!(@grid_weapon)
+          elsif description_in_payload
+            NotesSync.propagate_description!(@grid_weapon)
           end
         end
 
@@ -456,6 +472,10 @@ module Api
         if weapon.save
           @party.mark_updated!
           weapon.sync_from_collection! if weapon.collection_weapon_id.present?
+          # If another copy of this weapon in the party already runs a notes
+          # sync group, the new slot auto-joins so the user doesn't have to
+          # re-toggle the switch on it.
+          NotesSync.adopt_for_new_item!(weapon)
           weapon.reload
           output = GridWeaponBlueprint.render(weapon, view: :full, root: :grid_weapon)
           render json: output, status: :created
@@ -602,6 +622,7 @@ module Api
           :ax_modifier1_id, :ax_modifier2_id, :ax_strength1, :ax_strength2,
           :befoulment_modifier_id, :befoulment_strength, :exorcism_level,
           :awakening_id, :awakening_level,
+          :notes_synced,
           bullets: [:position, :bullet_id]
         ).then { |p| permit_description(p, params[:weapon]) }
       end

--- a/app/controllers/api/v1/substitutions_controller.rb
+++ b/app/controllers/api/v1/substitutions_controller.rb
@@ -43,13 +43,18 @@ module Api
             is_substitute: true
           )
 
-          Substitution.create!(
+          row = Substitution.create!(
             grid_type: grid_type,
             grid_id: grid_id,
             substitute_grid_type: grid_type,
             substitute_grid_id: substitute.id,
             position: substitution_params[:position].presence&.to_i || next_position(grid_type, grid_id)
           )
+
+          # Mirror the change to siblings if this slot belongs to a notes sync
+          # group. Reload to pick up the freshly-created row.
+          NotesSync.propagate_substitutions!(grid_item.reload)
+          row
         end
 
         @party.mark_updated!
@@ -74,6 +79,7 @@ module Api
         ApplicationRecord.transaction do
           @substitution.update!(position: substitution_params[:position])
           @party.mark_updated!
+          NotesSync.propagate_substitutions!(@substitution.grid)
         end
 
         render json: SubstitutionBlueprint.render(@substitution)
@@ -83,11 +89,13 @@ module Api
       end
 
       def destroy
+        primary = @substitution.grid
         ApplicationRecord.transaction do
           substitute = @substitution.substitute_grid
           @substitution.destroy!
           substitute&.destroy!
           @party.mark_updated!
+          NotesSync.propagate_substitutions!(primary)
         end
 
         head :no_content
@@ -155,6 +163,10 @@ module Api
             by_id[id].update!(position: (e['position'] || e[:position]).to_i)
           end
           @party.mark_updated!
+          # Reorder runs on a single primary slot — fan out the new order to
+          # any siblings sharing the notes sync group.
+          primary = grid_type.constantize.find_by(id: grid_id)
+          NotesSync.propagate_substitutions!(primary) if primary
         end
 
         ordered = Substitution.where(grid_type: grid_type, grid_id: grid_id).order(:position)

--- a/app/models/grid_character.rb
+++ b/app/models/grid_character.rb
@@ -279,18 +279,29 @@ class GridCharacter < ApplicationRecord
   #
   # @return [Boolean] true if any customization differs from collection
   def out_of_sync?
-    return false unless collection_character.present?
+    out_of_sync_fields.any?
+  end
 
-    uncap_level != collection_character.uncap_level ||
-      transcendence_step != collection_character.transcendence_step ||
-      perpetuity != collection_character.perpetuity ||
-      ring1 != collection_character.ring1 ||
-      ring2 != collection_character.ring2 ||
-      ring3 != collection_character.ring3 ||
-      ring4 != collection_character.ring4 ||
-      earring != collection_character.earring ||
-      awakening_id != collection_character.awakening_id ||
-      awakening_level != collection_character.awakening_level
+  ##
+  # Returns the list of fields that differ from the linked collection character.
+  # Uses camelCase keys matching the frontend's grid item shape so the UI can
+  # mark exactly the sections/rows that drifted. Ring drift uses dotted keys
+  # (overMastery.0..3) so the corresponding ring rows can highlight individually.
+  def out_of_sync_fields
+    return [] unless collection_character.present?
+
+    fields = []
+    fields << 'uncapLevel' if uncap_level != collection_character.uncap_level
+    fields << 'transcendenceStep' if transcendence_step != collection_character.transcendence_step
+    fields << 'perpetuity' if perpetuity != collection_character.perpetuity
+    fields << 'overMastery.0' if ring1 != collection_character.ring1
+    fields << 'overMastery.1' if ring2 != collection_character.ring2
+    fields << 'overMastery.2' if ring3 != collection_character.ring3
+    fields << 'overMastery.3' if ring4 != collection_character.ring4
+    fields << 'aetherialMastery' if earring != collection_character.earring
+    fields << 'awakeningId' if awakening_id != collection_character.awakening_id
+    fields << 'awakeningLevel' if awakening_level != collection_character.awakening_level
+    fields
   end
 
   private

--- a/app/models/grid_character.rb
+++ b/app/models/grid_character.rb
@@ -224,53 +224,58 @@ class GridCharacter < ApplicationRecord
     GridCharacterBlueprint
   end
 
+  # Maps the camelCase keys emitted by #out_of_sync_fields to the underlying
+  # column names. Used by the per-field sync flow so the frontend can target
+  # individual sections (Uncap & Transcendence, Awakening, a single ring)
+  # rather than overwriting every field on each sync.
+  SYNC_FIELD_MAP = {
+    'uncapLevel' => %i[uncap_level],
+    'transcendenceStep' => %i[transcendence_step],
+    'perpetuity' => %i[perpetuity],
+    'overMastery.0' => %i[ring1],
+    'overMastery.1' => %i[ring2],
+    'overMastery.2' => %i[ring3],
+    'overMastery.3' => %i[ring4],
+    'aetherialMastery' => %i[earring],
+    'awakeningId' => %i[awakening_id],
+    'awakeningLevel' => %i[awakening_level]
+  }.freeze
+
+  ALL_SYNC_COLUMNS = SYNC_FIELD_MAP.values.flatten.uniq.freeze
+
   ##
   # Syncs customizations from the linked collection character.
   #
-  # Copies uncap level, transcendence, rings, earring, and awakening from the collection.
-  # No-op if no collection character is linked.
+  # When `fields:` is omitted, every tracked column is copied. When provided,
+  # only the columns mapped from those camelCase keys are touched, leaving
+  # other fields alone.
   #
+  # @param fields [Array<String>, nil] optional list of camelCase keys to sync
   # @return [Boolean] true if sync was performed, false if no collection link
-  def sync_from_collection!
+  def sync_from_collection!(fields: nil)
     return false unless collection_character.present?
 
-    update!(
-      uncap_level: collection_character.uncap_level,
-      transcendence_step: collection_character.transcendence_step,
-      perpetuity: collection_character.perpetuity,
-      ring1: collection_character.ring1,
-      ring2: collection_character.ring2,
-      ring3: collection_character.ring3,
-      ring4: collection_character.ring4,
-      earring: collection_character.earring,
-      awakening_id: collection_character.awakening_id,
-      awakening_level: collection_character.awakening_level
-    )
+    columns = sync_columns_for(fields)
+    return true if columns.empty?
+
+    update!(columns.index_with { |col| collection_character.public_send(col) })
     true
   end
 
   ##
   # Syncs customizations from this grid character to the linked collection character.
   #
-  # Copies uncap level, transcendence, rings, earring, and awakening to the collection.
-  # No-op if no collection character is linked.
+  # Same field scoping as #sync_from_collection!.
   #
+  # @param fields [Array<String>, nil] optional list of camelCase keys to sync
   # @return [Boolean] true if sync was performed, false if no collection link
-  def sync_to_collection!
+  def sync_to_collection!(fields: nil)
     return false unless collection_character.present?
 
-    collection_character.update!(
-      uncap_level: uncap_level,
-      transcendence_step: transcendence_step,
-      perpetuity: perpetuity,
-      ring1: ring1,
-      ring2: ring2,
-      ring3: ring3,
-      ring4: ring4,
-      earring: earring,
-      awakening_id: awakening_id,
-      awakening_level: awakening_level
-    )
+    columns = sync_columns_for(fields)
+    return true if columns.empty?
+
+    collection_character.update!(columns.index_with { |col| public_send(col) })
     true
   end
 
@@ -305,6 +310,12 @@ class GridCharacter < ApplicationRecord
   end
 
   private
+
+  def sync_columns_for(fields)
+    return ALL_SYNC_COLUMNS if fields.blank?
+
+    fields.flat_map { |key| SYNC_FIELD_MAP[key] || [] }.uniq
+  end
 
   def increment_party_counter
     Party.increment_counter(:characters_count, party_id)

--- a/app/models/grid_summon.rb
+++ b/app/models/grid_summon.rb
@@ -106,10 +106,19 @@ class GridSummon < ApplicationRecord
   #
   # @return [Boolean] true if any customization differs from collection
   def out_of_sync?
-    return false unless collection_summon.present?
+    out_of_sync_fields.any?
+  end
 
-    uncap_level != collection_summon.uncap_level ||
-      transcendence_step != collection_summon.transcendence_step
+  ##
+  # Returns the list of fields that differ from the linked collection summon.
+  # Uses camelCase keys matching the frontend's grid item shape.
+  def out_of_sync_fields
+    return [] unless collection_summon.present?
+
+    fields = []
+    fields << 'uncapLevel' if uncap_level != collection_summon.uncap_level
+    fields << 'transcendenceStep' if transcendence_step != collection_summon.transcendence_step
+    fields
   end
 
   ##

--- a/app/models/grid_summon.rb
+++ b/app/models/grid_summon.rb
@@ -73,31 +73,42 @@ class GridSummon < ApplicationRecord
     update!(orphaned: true, collection_summon_id: nil)
   end
 
+  # Maps camelCase keys emitted by #out_of_sync_fields to column names so the
+  # frontend can sync individual sections instead of overwriting every field.
+  SYNC_FIELD_MAP = {
+    'uncapLevel' => %i[uncap_level],
+    'transcendenceStep' => %i[transcendence_step]
+  }.freeze
+
+  ALL_SYNC_COLUMNS = SYNC_FIELD_MAP.values.flatten.uniq.freeze
+
   ##
   # Syncs customizations from the linked collection summon.
   #
+  # @param fields [Array<String>, nil] optional list of camelCase keys to sync
   # @return [Boolean] true if sync was performed, false if no collection link
-  def sync_from_collection!
+  def sync_from_collection!(fields: nil)
     return false unless collection_summon.present?
 
-    update!(
-      uncap_level: collection_summon.uncap_level,
-      transcendence_step: collection_summon.transcendence_step
-    )
+    columns = sync_columns_for(fields)
+    return true if columns.empty?
+
+    update!(columns.index_with { |col| collection_summon.public_send(col) })
     true
   end
 
   ##
   # Syncs customizations from this grid summon to the linked collection summon.
   #
+  # @param fields [Array<String>, nil] optional list of camelCase keys to sync
   # @return [Boolean] true if sync was performed, false if no collection link
-  def sync_to_collection!
+  def sync_to_collection!(fields: nil)
     return false unless collection_summon.present?
 
-    collection_summon.update!(
-      uncap_level: uncap_level,
-      transcendence_step: transcendence_step
-    )
+    columns = sync_columns_for(fields)
+    return true if columns.empty?
+
+    collection_summon.update!(columns.index_with { |col| public_send(col) })
     true
   end
 
@@ -140,6 +151,12 @@ class GridSummon < ApplicationRecord
   end
 
   private
+
+  def sync_columns_for(fields)
+    return ALL_SYNC_COLUMNS if fields.blank?
+
+    fields.flat_map { |key| SYNC_FIELD_MAP[key] || [] }.uniq
+  end
 
   def set_default_uncap_level
     self.uncap_level ||= 0

--- a/app/models/grid_weapon.rb
+++ b/app/models/grid_weapon.rb
@@ -192,25 +192,38 @@ class GridWeapon < ApplicationRecord
   #
   # @return [Boolean] true if any customization differs from collection
   def out_of_sync?
-    return false unless collection_weapon.present?
+    out_of_sync_fields.any?
+  end
 
-    uncap_level != collection_weapon.uncap_level ||
-      transcendence_step != collection_weapon.transcendence_step ||
-      element != collection_weapon.element ||
-      weapon_key1_id != collection_weapon.weapon_key1_id ||
-      weapon_key2_id != collection_weapon.weapon_key2_id ||
-      weapon_key3_id != collection_weapon.weapon_key3_id ||
-      weapon_key4_id != collection_weapon.weapon_key4_id ||
-      ax_modifier1_id != collection_weapon.ax_modifier1_id ||
-      ax_strength1 != collection_weapon.ax_strength1 ||
-      ax_modifier2_id != collection_weapon.ax_modifier2_id ||
-      ax_strength2 != collection_weapon.ax_strength2 ||
-      befoulment_modifier_id != collection_weapon.befoulment_modifier_id ||
-      befoulment_strength != collection_weapon.befoulment_strength ||
-      exorcism_level != collection_weapon.exorcism_level ||
-      awakening_id != collection_weapon.awakening_id ||
-      awakening_level != collection_weapon.awakening_level ||
-      bullets_out_of_sync?
+  ##
+  # Returns the list of fields that differ from the linked collection weapon.
+  # Uses camelCase keys for value fields (`uncapLevel`), `weaponKey{N}` for the
+  # 1-based weapon key slots, and dotted keys (`ax.0`/`ax.1`, `bullets.N` by
+  # position) for fields the UI renders as individual rows.
+  def out_of_sync_fields
+    return [] unless collection_weapon.present?
+
+    fields = []
+    fields << 'uncapLevel' if uncap_level != collection_weapon.uncap_level
+    fields << 'transcendenceStep' if transcendence_step != collection_weapon.transcendence_step
+    fields << 'element' if element != collection_weapon.element
+    fields << 'weaponKey1' if weapon_key1_id != collection_weapon.weapon_key1_id
+    fields << 'weaponKey2' if weapon_key2_id != collection_weapon.weapon_key2_id
+    fields << 'weaponKey3' if weapon_key3_id != collection_weapon.weapon_key3_id
+    fields << 'weaponKey4' if weapon_key4_id != collection_weapon.weapon_key4_id
+    if ax_modifier1_id != collection_weapon.ax_modifier1_id || ax_strength1 != collection_weapon.ax_strength1
+      fields << 'ax.0'
+    end
+    if ax_modifier2_id != collection_weapon.ax_modifier2_id || ax_strength2 != collection_weapon.ax_strength2
+      fields << 'ax.1'
+    end
+    fields << 'befoulmentModifier' if befoulment_modifier_id != collection_weapon.befoulment_modifier_id
+    fields << 'befoulmentStrength' if befoulment_strength != collection_weapon.befoulment_strength
+    fields << 'exorcismLevel' if exorcism_level != collection_weapon.exorcism_level
+    fields << 'awakeningId' if awakening_id != collection_weapon.awakening_id
+    fields << 'awakeningLevel' if awakening_level != collection_weapon.awakening_level
+    fields.concat(out_of_sync_bullet_positions.map { |position| "bullets.#{position}" })
+    fields
   end
 
   ##
@@ -354,12 +367,15 @@ class GridWeapon < ApplicationRecord
   # If the grid weapon's position is -1, sets the `mainhand` attribute to true.
   #
   # @return [void]
-  def bullets_out_of_sync?
-    return false unless collection_weapon.present?
+  def out_of_sync_bullet_positions
+    return [] unless collection_weapon.present?
 
-    grid_bullets = grid_weapon_bullets.sort_by(&:position).map { |b| [b.position, b.bullet_id] }
-    collection_bullets = collection_weapon.collection_weapon_bullets.sort_by(&:position).map { |b| [b.position, b.bullet_id] }
-    grid_bullets != collection_bullets
+    grid_by_pos = grid_weapon_bullets.index_by(&:position)
+    collection_by_pos = collection_weapon.collection_weapon_bullets.index_by(&:position)
+    positions = grid_by_pos.keys | collection_by_pos.keys
+    positions.sort.select do |position|
+      grid_by_pos[position]&.bullet_id != collection_by_pos[position]&.bullet_id
+    end
   end
 
   def assign_mainhand

--- a/app/models/grid_weapon.rb
+++ b/app/models/grid_weapon.rb
@@ -113,32 +113,43 @@ class GridWeapon < ApplicationRecord
   # Syncs customizations from the linked collection weapon.
   #
   # @return [Boolean] true if sync was performed, false if no collection link
-  def sync_from_collection!
+  # Maps camelCase keys emitted by #out_of_sync_fields to the underlying
+  # column names. Bullets live in a join table and use the special `bullets.N`
+  # keys, handled separately from this map.
+  SYNC_FIELD_MAP = {
+    'uncapLevel' => %i[uncap_level],
+    'transcendenceStep' => %i[transcendence_step],
+    'element' => %i[element],
+    'weaponKey1' => %i[weapon_key1_id],
+    'weaponKey2' => %i[weapon_key2_id],
+    'weaponKey3' => %i[weapon_key3_id],
+    'weaponKey4' => %i[weapon_key4_id],
+    'ax.0' => %i[ax_modifier1_id ax_strength1],
+    'ax.1' => %i[ax_modifier2_id ax_strength2],
+    'befoulmentModifier' => %i[befoulment_modifier_id],
+    'befoulmentStrength' => %i[befoulment_strength],
+    'exorcismLevel' => %i[exorcism_level],
+    'awakeningId' => %i[awakening_id],
+    'awakeningLevel' => %i[awakening_level]
+  }.freeze
+
+  ALL_SYNC_COLUMNS = SYNC_FIELD_MAP.values.flatten.uniq.freeze
+
+  def sync_from_collection!(fields: nil)
     return false unless collection_weapon.present?
 
-    update!(
-      uncap_level: collection_weapon.uncap_level,
-      transcendence_step: collection_weapon.transcendence_step,
-      element: collection_weapon.element,
-      weapon_key1_id: collection_weapon.weapon_key1_id,
-      weapon_key2_id: collection_weapon.weapon_key2_id,
-      weapon_key3_id: collection_weapon.weapon_key3_id,
-      weapon_key4_id: collection_weapon.weapon_key4_id,
-      ax_modifier1_id: collection_weapon.ax_modifier1_id,
-      ax_strength1: collection_weapon.ax_strength1,
-      ax_modifier2_id: collection_weapon.ax_modifier2_id,
-      ax_strength2: collection_weapon.ax_strength2,
-      befoulment_modifier_id: collection_weapon.befoulment_modifier_id,
-      befoulment_strength: collection_weapon.befoulment_strength,
-      exorcism_level: collection_weapon.exorcism_level,
-      awakening_id: collection_weapon.awakening_id,
-      awakening_level: collection_weapon.awakening_level
-    )
+    columns = sync_columns_for(fields)
+    bullet_positions = sync_bullet_positions_for(fields)
 
-    # Sync bullet loadout
-    grid_weapon_bullets.destroy_all
-    collection_weapon.collection_weapon_bullets.each do |cwb|
-      grid_weapon_bullets.create!(bullet_id: cwb.bullet_id, position: cwb.position)
+    update!(columns.index_with { |col| collection_weapon.public_send(col) }) if columns.any?
+
+    if bullet_positions == :all
+      grid_weapon_bullets.destroy_all
+      collection_weapon.collection_weapon_bullets.each do |cwb|
+        grid_weapon_bullets.create!(bullet_id: cwb.bullet_id, position: cwb.position)
+      end
+    elsif bullet_positions.is_a?(Array)
+      bullet_positions.each { |position| pull_bullet_position!(position) }
     end
 
     true
@@ -147,33 +158,23 @@ class GridWeapon < ApplicationRecord
   ##
   # Syncs customizations from this grid weapon to the linked collection weapon.
   #
+  # @param fields [Array<String>, nil] optional list of camelCase keys to sync
   # @return [Boolean] true if sync was performed, false if no collection link
-  def sync_to_collection!
+  def sync_to_collection!(fields: nil)
     return false unless collection_weapon.present?
 
-    collection_weapon.update!(
-      uncap_level: uncap_level,
-      transcendence_step: transcendence_step,
-      element: element,
-      weapon_key1_id: weapon_key1_id,
-      weapon_key2_id: weapon_key2_id,
-      weapon_key3_id: weapon_key3_id,
-      weapon_key4_id: weapon_key4_id,
-      ax_modifier1_id: ax_modifier1_id,
-      ax_strength1: ax_strength1,
-      ax_modifier2_id: ax_modifier2_id,
-      ax_strength2: ax_strength2,
-      befoulment_modifier_id: befoulment_modifier_id,
-      befoulment_strength: befoulment_strength,
-      exorcism_level: exorcism_level,
-      awakening_id: awakening_id,
-      awakening_level: awakening_level
-    )
+    columns = sync_columns_for(fields)
+    bullet_positions = sync_bullet_positions_for(fields)
 
-    # Sync bullet loadout
-    collection_weapon.collection_weapon_bullets.destroy_all
-    grid_weapon_bullets.each do |gwb|
-      collection_weapon.collection_weapon_bullets.create!(bullet_id: gwb.bullet_id, position: gwb.position)
+    collection_weapon.update!(columns.index_with { |col| public_send(col) }) if columns.any?
+
+    if bullet_positions == :all
+      collection_weapon.collection_weapon_bullets.destroy_all
+      grid_weapon_bullets.each do |gwb|
+        collection_weapon.collection_weapon_bullets.create!(bullet_id: gwb.bullet_id, position: gwb.position)
+      end
+    elsif bullet_positions.is_a?(Array)
+      bullet_positions.each { |position| push_bullet_position!(position) }
     end
 
     true
@@ -264,6 +265,53 @@ class GridWeapon < ApplicationRecord
   end
 
   private
+
+  def sync_columns_for(fields)
+    return ALL_SYNC_COLUMNS if fields.blank?
+
+    fields.flat_map { |key| SYNC_FIELD_MAP[key] || [] }.uniq
+  end
+
+  # Returns :all (every bullet position) when fields is blank, an Array of
+  # positions when the caller scoped to specific `bullets.N` keys, or [] when
+  # the caller targeted some other section and bullets should stay put.
+  def sync_bullet_positions_for(fields)
+    return :all if fields.blank?
+
+    fields.filter_map do |key|
+      next unless key.start_with?('bullets.')
+
+      Integer(key.split('.', 2).last, 10)
+    rescue ArgumentError, TypeError
+      nil
+    end
+  end
+
+  def pull_bullet_position!(position)
+    collection_bullet = collection_weapon.collection_weapon_bullets.find_by(position: position)
+    grid_bullet = grid_weapon_bullets.find_by(position: position)
+
+    if collection_bullet.nil?
+      grid_bullet&.destroy!
+    elsif grid_bullet.nil?
+      grid_weapon_bullets.create!(bullet_id: collection_bullet.bullet_id, position: position)
+    else
+      grid_bullet.update!(bullet_id: collection_bullet.bullet_id)
+    end
+  end
+
+  def push_bullet_position!(position)
+    grid_bullet = grid_weapon_bullets.find_by(position: position)
+    collection_bullet = collection_weapon.collection_weapon_bullets.find_by(position: position)
+
+    if grid_bullet.nil?
+      collection_bullet&.destroy!
+    elsif collection_bullet.nil?
+      collection_weapon.collection_weapon_bullets.create!(bullet_id: grid_bullet.bullet_id, position: position)
+    else
+      collection_bullet.update!(bullet_id: grid_bullet.bullet_id)
+    end
+  end
 
   ##
   # Validates the transcendence step of the weapon.

--- a/app/services/notes_sync.rb
+++ b/app/services/notes_sync.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+##
+# Keeps the Notes pane (description + substitutions) in lockstep across every
+# grid item in a party that shares the same canonical weapon/summon.
+#
+# A "sync group" is the set of GridWeapons (or GridSummons) in a single party
+# that point to the same Weapon (or Summon) and have +notes_synced+ true.
+# Toggling the flag on any one item propagates to every sibling; writes to a
+# synced item's description or substitutions fan out to siblings inside a
+# single transaction so the group can't drift.
+module NotesSync
+  module_function
+
+  ##
+  # Returns sibling grid items in the same party that share this item's
+  # canonical reference. Excludes the item itself.
+  #
+  # @param item [GridWeapon, GridSummon]
+  # @return [ActiveRecord::Relation<GridWeapon, GridSummon>]
+  def siblings(item)
+    case item
+    when GridWeapon
+      item.party.weapons.where(weapon_id: item.weapon_id).where.not(id: item.id)
+    when GridSummon
+      item.party.summons.where(summon_id: item.summon_id).where.not(id: item.id)
+    else
+      # GridCharacter and anything else aren't part of any sync group.
+      nil
+    end
+  end
+
+  ##
+  # True for grid item types that carry the notes_synced flag.
+  def syncable?(item)
+    item.is_a?(GridWeapon) || item.is_a?(GridSummon)
+  end
+
+  ##
+  # If the item is in a sync group, copy its description to every sibling.
+  # No-op when notes_synced is false.
+  def propagate_description!(item)
+    return false unless syncable?(item) && item.notes_synced?
+
+    siblings(item).update_all(description: item.description, updated_at: Time.current)
+    true
+  end
+
+  ##
+  # Replaces each sibling's substitutions with a mirror of this item's set.
+  # Same (position, substitute_grid) tuples; only the primary grid pointer
+  # differs. Rows that would make a sibling substitute itself are skipped
+  # (the Substitution model rejects that case anyway).
+  def propagate_substitutions!(item)
+    return false unless syncable?(item) && item.notes_synced?
+
+    grid_type = item.class.name
+    source_subs = item.substitutions.to_a
+
+    ActiveRecord::Base.transaction do
+      siblings(item).find_each do |sibling|
+        sibling.substitutions.destroy_all
+
+        source_subs.each do |sub|
+          next if sub.substitute_grid_id == sibling.id && sub.substitute_grid_type == grid_type
+
+          sibling.substitutions.create!(
+            substitute_grid_id: sub.substitute_grid_id,
+            substitute_grid_type: sub.substitute_grid_type,
+            position: sub.position
+          )
+        end
+      end
+    end
+    true
+  end
+
+  ##
+  # Flips notes_synced on this item AND every sibling, then immediately
+  # mirrors this item's description + substitutions across the group so the
+  # newly-joined siblings adopt the editing item's state.
+  def enable_sync!(item)
+    return false unless syncable?(item)
+
+    ActiveRecord::Base.transaction do
+      item.update_column(:notes_synced, true) unless item.notes_synced?
+      siblings(item).update_all(notes_synced: true, updated_at: Time.current)
+      propagate_description!(item)
+      propagate_substitutions!(item)
+    end
+    true
+  end
+
+  ##
+  # Turns the group off. Each item keeps its current description and
+  # substitutions as its own — we intentionally don't roll back so users
+  # don't lose their work mid-flow.
+  def disable_sync!(item)
+    return false unless syncable?(item)
+
+    ActiveRecord::Base.transaction do
+      item.update_column(:notes_synced, false) if item.notes_synced?
+      siblings(item).update_all(notes_synced: false, updated_at: Time.current)
+    end
+    true
+  end
+
+  ##
+  # Called after a new grid item is created. If any existing sibling is in a
+  # sync group, the new item auto-joins: it picks up the flag, description,
+  # and substitution set so the user doesn't have to re-toggle.
+  def adopt_for_new_item!(item)
+    return false unless syncable?(item)
+
+    leader = siblings(item).where(notes_synced: true).first
+    return false unless leader
+
+    ActiveRecord::Base.transaction do
+      item.update!(notes_synced: true, description: leader.description)
+
+      grid_type = item.class.name
+      leader.substitutions.each do |sub|
+        next if sub.substitute_grid_id == item.id && sub.substitute_grid_type == grid_type
+
+        item.substitutions.create!(
+          substitute_grid_id: sub.substitute_grid_id,
+          substitute_grid_type: sub.substitute_grid_type,
+          position: sub.position
+        )
+      end
+    end
+    true
+  end
+end

--- a/db/migrate/20260513000000_normalize_empty_rings_to_null.rb
+++ b/db/migrate/20260513000000_normalize_empty_rings_to_null.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Normalizes empty ring/earring JSONB columns to NULL on both grid_characters
+# and collection_characters.
+#
+# Historically these columns held a mix of representations for "unset":
+#   - NULL (correct)
+#   - {modifier: nil, strength: nil} (returned from apply_new_rings padding)
+#   - {modifier: 1, strength: 0} (placeholder leaked from the edit pane bug
+#     fixed in the frontend hensei-web#856)
+#   - {modifier: 0, strength: 0}
+#
+# After the blueprint consolidation that makes both grid and collection
+# characters expose the same positional `over_mastery` array, per-field sync
+# writes the raw column value across without normalizing — so we want the
+# column itself to consistently store NULL for empty slots.
+#
+# Rule: a ring/earring is considered empty when:
+#   - the column is already NULL, OR
+#   - modifier is missing / nil / 0, OR
+#   - strength is missing / nil / 0
+# These cases collapse to NULL.
+class NormalizeEmptyRingsToNull < ActiveRecord::Migration[8.0]
+  RING_COLUMNS = %i[ring1 ring2 ring3 ring4 earring].freeze
+
+  def up
+    [
+      ['grid_characters', GridCharacter],
+      ['collection_characters', CollectionCharacter]
+    ].each do |table, klass|
+      RING_COLUMNS.each do |column|
+        # Use a JSONB-aware predicate so we only rewrite rows whose value
+        # currently encodes an "empty" ring, leaving anything well-formed alone.
+        sql = <<~SQL.squish
+          UPDATE #{table}
+          SET #{column} = NULL
+          WHERE #{column} IS NOT NULL
+            AND (
+              #{column} ->> 'modifier' IS NULL
+              OR (#{column} ->> 'modifier')::int = 0
+              OR #{column} ->> 'strength' IS NULL
+              OR (#{column} ->> 'strength')::int = 0
+            )
+        SQL
+
+        rows = klass.connection.execute(sql).cmd_tuples
+        say "Normalized #{rows} rows on #{table}.#{column}", true
+      end
+    end
+  end
+
+  def down
+    # Irreversible: we lose the distinction between "explicitly cleared" and
+    # "never set" representations. Both map to NULL going forward.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20260514000000_add_notes_synced_to_grid_items.rb
+++ b/db/migrate/20260514000000_add_notes_synced_to_grid_items.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Adds a notes_synced flag to grid_weapons and grid_summons. When true, the
+# item participates in a "notes sync group" that mirrors its description and
+# substitutions across every grid item in the same party with the same
+# weapon_id / summon_id (i.e. duplicates of the same canonical item). The
+# fan-out logic lives in app/services/notes_sync.rb; this migration just
+# carries the flag. Existing rows start unsynced.
+class AddNotesSyncedToGridItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :grid_weapons, :notes_synced, :boolean, null: false, default: false
+    add_column :grid_summons, :notes_synced, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_13_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_14_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -587,6 +587,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_13_000000) do
     t.boolean "orphaned", default: false, null: false
     t.boolean "is_substitute", default: false, null: false
     t.jsonb "description"
+    t.boolean "notes_synced", default: false, null: false
     t.index ["collection_summon_id"], name: "index_grid_summons_on_collection_summon_id"
     t.index ["orphaned"], name: "index_grid_summons_on_orphaned"
     t.index ["party_id", "position", "summon_id"], name: "index_grid_summons_unique_substitute", unique: true, where: "is_substitute"
@@ -633,6 +634,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_13_000000) do
     t.integer "exorcism_level", default: 0
     t.boolean "is_substitute", default: false, null: false
     t.jsonb "description"
+    t.boolean "notes_synced", default: false, null: false
     t.index ["awakening_id"], name: "index_grid_weapons_on_awakening_id"
     t.index ["ax_modifier1_id"], name: "index_grid_weapons_on_ax_modifier1_id"
     t.index ["ax_modifier2_id"], name: "index_grid_weapons_on_ax_modifier2_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_12_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_13_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/spec/models/grid_characters_spec.rb
+++ b/spec/models/grid_characters_spec.rb
@@ -280,5 +280,53 @@ RSpec.describe GridCharacter, type: :model do
         end
       end
     end
+
+    describe '#out_of_sync_fields' do
+      context 'when collection_character is linked' do
+        before do
+          character.update!(transcendence: true)
+          @grid_char = create(:grid_character,
+                              valid_attributes.merge(collection_character: collection_character))
+          @grid_char.sync_from_collection!
+          @grid_char.reload
+        end
+
+        it 'returns [] when everything matches' do
+          expect(@grid_char.out_of_sync_fields).to eq([])
+        end
+
+        it 'reports a single value drift by camelCase key' do
+          @grid_char.update!(uncap_level: 4)
+          expect(@grid_char.out_of_sync_fields).to eq(['uncapLevel'])
+        end
+
+        it 'reports multiple drifts together' do
+          @grid_char.update!(uncap_level: 4, perpetuity: false)
+          expect(@grid_char.out_of_sync_fields).to include('uncapLevel', 'perpetuity')
+        end
+
+        it 'reports ring drift with dotted overMastery keys' do
+          # Skip validations: we only care about field drift detection here, not
+          # the over-mastery ratio rule.
+          @grid_char.update_columns(ring2: { 'modifier' => '2', 'strength' => 1 })
+          expect(@grid_char.reload.out_of_sync_fields).to eq(['overMastery.1'])
+        end
+
+        it 'reports earring drift as aetherialMastery' do
+          @grid_char.update_columns(earring: { 'modifier' => '3', 'strength' => 1 })
+          expect(@grid_char.reload.out_of_sync_fields).to eq(['aetherialMastery'])
+        end
+      end
+
+      context 'when no collection_character is linked' do
+        before do
+          @grid_char = create(:grid_character, valid_attributes)
+        end
+
+        it 'returns []' do
+          expect(@grid_char.out_of_sync_fields).to eq([])
+        end
+      end
+    end
   end
 end

--- a/spec/models/grid_characters_spec.rb
+++ b/spec/models/grid_characters_spec.rb
@@ -281,6 +281,45 @@ RSpec.describe GridCharacter, type: :model do
       end
     end
 
+    describe '#sync_from_collection! with fields' do
+      before do
+        character.update!(transcendence: true)
+        @grid_char = create(:grid_character,
+                            valid_attributes.merge(collection_character: collection_character))
+        # Start in sync, then drift simple value fields (no inter-field validators)
+        @grid_char.sync_from_collection!
+        @grid_char.update_columns(uncap_level: 3, perpetuity: false, awakening_level: 1)
+        @grid_char.reload
+      end
+
+      it 'only updates columns mapped from the supplied keys' do
+        @grid_char.sync_from_collection!(fields: ['uncapLevel'])
+        @grid_char.reload
+
+        expect(@grid_char.uncap_level).to eq(collection_character.uncap_level)
+        # Other drifted fields stay drifted
+        expect(@grid_char.perpetuity).to be false
+        expect(@grid_char.awakening_level).to eq(1)
+      end
+
+      it 'handles multiple keys in one call' do
+        @grid_char.sync_from_collection!(fields: %w[uncapLevel perpetuity])
+        @grid_char.reload
+
+        expect(@grid_char.uncap_level).to eq(collection_character.uncap_level)
+        expect(@grid_char.perpetuity).to eq(collection_character.perpetuity)
+        expect(@grid_char.awakening_level).to eq(1) # untouched
+      end
+
+      it 'is a no-op when no supplied key maps to a known field' do
+        @grid_char.sync_from_collection!(fields: ['bogus'])
+        @grid_char.reload
+
+        expect(@grid_char.uncap_level).to eq(3)
+        expect(@grid_char.perpetuity).to be false
+      end
+    end
+
     describe '#out_of_sync_fields' do
       context 'when collection_character is linked' do
         before do

--- a/spec/models/grid_summons_spec.rb
+++ b/spec/models/grid_summons_spec.rb
@@ -439,6 +439,39 @@ RSpec.describe GridSummon, type: :model do
         end
       end
     end
+
+    describe '#out_of_sync_fields' do
+      context 'when collection_summon is linked' do
+        let(:linked_grid_summon) do
+          summon.update!(transcendence: true, ulb: true, flb: true)
+          create(:grid_summon,
+                 party: party,
+                 summon: summon,
+                 position: 1,
+                 collection_summon: collection_summon,
+                 uncap_level: 3,
+                 transcendence_step: 0)
+        end
+
+        it 'reports drifted uncap_level as uncapLevel' do
+          expect(linked_grid_summon.out_of_sync_fields).to include('uncapLevel')
+        end
+
+        it 'returns [] after sync' do
+          linked_grid_summon.sync_from_collection!
+          expect(linked_grid_summon.out_of_sync_fields).to eq([])
+        end
+      end
+
+      context 'when no collection_summon is linked' do
+        it 'returns []' do
+          unlinked = build(:grid_summon, party: party, summon: summon, position: 1,
+                                         uncap_level: 3, transcendence_step: 0)
+          unlinked.save!
+          expect(unlinked.out_of_sync_fields).to eq([])
+        end
+      end
+    end
   end
 
   describe 'boost recomputation callback' do

--- a/spec/models/grid_weapon_spec.rb
+++ b/spec/models/grid_weapon_spec.rb
@@ -325,5 +325,34 @@ RSpec.describe GridWeapon, type: :model do
         end
       end
     end
+
+    describe '#out_of_sync_fields' do
+      context 'when collection_weapon is linked' do
+        let(:linked_grid_weapon) do
+          create(:grid_weapon,
+                 party: party,
+                 weapon: ec_weapon,
+                 position: 0,
+                 collection_weapon: collection_weapon,
+                 uncap_level: 3)
+        end
+
+        it 'reports drifted top-level fields with camelCase keys' do
+          # uncap_level differs (3 vs collection 5), element differs (default vs collection 2)
+          expect(linked_grid_weapon.out_of_sync_fields).to include('uncapLevel', 'element')
+        end
+
+        it 'returns [] after sync' do
+          linked_grid_weapon.sync_from_collection!
+          expect(linked_grid_weapon.out_of_sync_fields).to eq([])
+        end
+      end
+
+      context 'when no collection_weapon is linked' do
+        it 'returns []' do
+          expect(grid_weapon.out_of_sync_fields).to eq([])
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/collection_characters_spec.rb
+++ b/spec/requests/api/v1/collection_characters_spec.rb
@@ -317,7 +317,8 @@ RSpec.describe 'Collection Characters API', type: :request do
       json = response.parsed_body
       expect(json['uncap_level']).to eq(5)
       expect(json['transcendence_step']).to eq(3)
-      expect(json['ring1']['modifier']).to eq(1)
+      # ring1 is now serialized at over_mastery[0] in the unified shape.
+      expect(json['over_mastery'][0]['modifier']).to eq(1)
     end
 
     it 'returns not found for other user\'s character' do

--- a/spec/services/notes_sync_spec.rb
+++ b/spec/services/notes_sync_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NotesSync do
+  let(:party) { create(:party) }
+  let(:weapon_series) { create(:weapon_series, extra: false) }
+  let(:canonical_weapon) { create(:weapon, limit: false, weapon_series: weapon_series) }
+  let(:other_weapon) { create(:weapon, limit: false, weapon_series: weapon_series) }
+
+  let(:summon) { Summon.find_by!(granblue_id: '2040034000') }
+  let(:other_summon) { Summon.find_by!(granblue_id: '2040003000') }
+
+  let(:doc_a) { { 'type' => 'doc', 'content' => [{ 'type' => 'paragraph', 'content' => [{ 'type' => 'text', 'text' => 'A' }] }] } }
+  let(:doc_b) { { 'type' => 'doc', 'content' => [{ 'type' => 'paragraph', 'content' => [{ 'type' => 'text', 'text' => 'B' }] }] } }
+
+  describe '.siblings' do
+    it 'returns other grid weapons in the same party with the same canonical weapon' do
+      a = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 0)
+      b = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 1)
+      unrelated = create(:grid_weapon, party: party, weapon: other_weapon, position: 2)
+
+      result = described_class.siblings(a).to_a
+      expect(result).to contain_exactly(b)
+      expect(result).not_to include(unrelated)
+      expect(result).not_to include(a)
+    end
+
+    it 'returns nil for unsupported types (e.g. GridCharacter)' do
+      character = Character.find_by!(granblue_id: '3040087000')
+      grid_char = create(:grid_character, party: party, character: character, position: 0,
+                                          uncap_level: 3, transcendence_step: 0)
+      expect(described_class.siblings(grid_char)).to be_nil
+    end
+  end
+
+  describe '.enable_sync!' do
+    it 'flips the flag on every sibling and copies the source description' do
+      a = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 0, description: doc_a)
+      b = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 1, description: doc_b)
+
+      described_class.enable_sync!(a)
+
+      expect(a.reload.notes_synced).to be true
+      expect(b.reload.notes_synced).to be true
+      expect(b.description).to eq(doc_a)
+    end
+
+    it 'is a no-op for unsyncable items' do
+      character = Character.find_by!(granblue_id: '3040087000')
+      grid_char = create(:grid_character, party: party, character: character, position: 0,
+                                          uncap_level: 3, transcendence_step: 0)
+      expect(described_class.enable_sync!(grid_char)).to be false
+    end
+  end
+
+  describe '.disable_sync!' do
+    it 'turns the flag off on every sibling but leaves descriptions alone' do
+      a = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 0,
+                               description: doc_a, notes_synced: true)
+      b = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 1,
+                               description: doc_a, notes_synced: true)
+
+      described_class.disable_sync!(a)
+
+      expect(a.reload.notes_synced).to be false
+      expect(b.reload.notes_synced).to be false
+      expect(a.description).to eq(doc_a)
+      expect(b.description).to eq(doc_a)
+    end
+  end
+
+  describe '.propagate_description!' do
+    it 'mirrors the source description onto every sibling when synced' do
+      a = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 0,
+                               description: doc_a, notes_synced: true)
+      b = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 1,
+                               description: doc_b, notes_synced: true)
+
+      described_class.propagate_description!(a)
+
+      expect(b.reload.description).to eq(doc_a)
+    end
+
+    it 'is a no-op when the item is not synced' do
+      a = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 0,
+                               description: doc_a, notes_synced: false)
+      b = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 1,
+                               description: doc_b, notes_synced: false)
+
+      described_class.propagate_description!(a)
+
+      expect(b.reload.description).to eq(doc_b)
+    end
+  end
+
+  describe '.adopt_for_new_item!' do
+    it 'pulls the new item into an existing sync group' do
+      leader = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 0,
+                                    description: doc_a, notes_synced: true)
+      newcomer = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 1,
+                                      description: doc_b, notes_synced: false)
+
+      described_class.adopt_for_new_item!(newcomer)
+
+      expect(newcomer.reload.notes_synced).to be true
+      expect(newcomer.description).to eq(doc_a)
+      expect(leader.reload.description).to eq(doc_a)
+    end
+
+    it 'is a no-op when no sibling is already synced' do
+      a = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 0,
+                               description: doc_a, notes_synced: false)
+      newcomer = create(:grid_weapon, party: party, weapon: canonical_weapon, position: 1,
+                                      description: doc_b, notes_synced: false)
+
+      described_class.adopt_for_new_item!(newcomer)
+
+      expect(newcomer.reload.notes_synced).to be false
+      expect(newcomer.description).to eq(doc_b)
+      expect(a.reload.description).to eq(doc_a)
+    end
+  end
+
+  describe '.propagate_description! across summons' do
+    it 'mirrors descriptions across duplicate summons in the same party' do
+      summon.update!(transcendence: true, ulb: true, flb: true)
+      a = create(:grid_summon, party: party, summon: summon, position: 0, uncap_level: 3,
+                               description: doc_a, notes_synced: true)
+      b = create(:grid_summon, party: party, summon: summon, position: 1, uncap_level: 3,
+                               description: doc_b, notes_synced: true)
+      unrelated = create(:grid_summon, party: party, summon: other_summon, position: 2,
+                                       uncap_level: 3, description: doc_b)
+
+      described_class.propagate_description!(a)
+
+      expect(b.reload.description).to eq(doc_a)
+      expect(unrelated.reload.description).to eq(doc_b)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `#out_of_sync_fields` to GridCharacter / GridWeapon / GridSummon. Returns the camelCase field-key list that drifts from the linked collection item, with dotted positions for relational sets (`bullets.N`, `overMastery.N`, `ax.N`, `weaponKey1..4`).
- `out_of_sync?` now derives from the field list. `bullets_out_of_sync?` becomes `out_of_sync_bullet_positions` (per-position diff).
- Exposes the new field on all three grid blueprints, gated on the collection link being present.

The frontend uses this to mark exactly which sidebar sections/rows drifted and offer inline sync controls, instead of the single opaque "out of sync" boolean we ship today. The boolean stays in place during the rollout.

## Test plan
- [x] `bundle exec rspec spec/models/grid_characters_spec.rb spec/models/grid_weapon_spec.rb spec/models/grid_summons_spec.rb` — 110 examples, 0 failures
- [ ] Manual: load a party with a linked collection item, drift one or two fields, confirm `outOfSyncFields` shape in the party JSON