### PR TITLE
add support summons (data model + import API)

### DIFF
--- a/app/blueprints/api/v1/summon_blueprint.rb
+++ b/app/blueprints/api/v1/summon_blueprint.rb
@@ -10,7 +10,7 @@ module Api
         }
       end
 
-      fields :granblue_id, :element, :rarity, :max_level, :subaura, :limit, :promotions
+      fields :granblue_id, :element, :rarity, :max_level, :subaura, :limit, :support_eligible, :promotions
 
       field :promotion_names do |s|
         s.promotion_names
@@ -39,13 +39,13 @@ module Api
 
       view :preview do
         excludes :name, :element, :rarity, :max_level, :promotions,
-                 :promotion_names, :series, :uncap
+                 :promotion_names, :series, :uncap, :support_eligible
       end
 
       # Minimal view for party list cards — just enough for image rendering
       view :list do
         excludes :name, :element, :rarity, :max_level, :promotions,
-                 :promotion_names, :series, :uncap, :subaura, :limit
+                 :promotion_names, :series, :uncap, :subaura, :limit, :support_eligible
       end
 
       view :stats do

--- a/app/blueprints/api/v1/support_summon_blueprint.rb
+++ b/app/blueprints/api/v1/support_summon_blueprint.rb
@@ -3,7 +3,7 @@ module Api
     class SupportSummonBlueprint < ApiBlueprint
       identifier :id
 
-      fields :section, :position, :created_at, :updated_at
+      fields :section, :position, :required, :created_at, :updated_at
 
       association :collection_summon, blueprint: CollectionSummonBlueprint
 

--- a/app/blueprints/api/v1/support_summon_blueprint.rb
+++ b/app/blueprints/api/v1/support_summon_blueprint.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1
+    class SupportSummonBlueprint < ApiBlueprint
+      identifier :id
+
+      fields :section, :position, :created_at, :updated_at
+
+      association :collection_summon, blueprint: CollectionSummonBlueprint
+
+      view :full do
+        association :collection_summon, blueprint: CollectionSummonBlueprint, view: :full
+      end
+    end
+  end
+end

--- a/app/blueprints/api/v1/user_blueprint.rb
+++ b/app/blueprints/api/v1/user_blueprint.rb
@@ -15,7 +15,7 @@ module Api
       end
 
       view :minimal do
-        fields :username, :display_name, :description, :language, :private, :gender, :theme, :role, :granblue_id, :show_gamertag, :wiki_profile, :youtube, :simple_portraits, :default_rep_view, :timezone
+        fields :username, :display_name, :description, :language, :private, :gender, :theme, :role, :granblue_id, :show_gamertag, :wiki_profile, :youtube, :simple_portraits, :default_rep_view, :timezone, :support_summons_public
         # Return collection_privacy as integer (enum returns string by default)
         field :collection_privacy do |user|
           User.collection_privacies[user.collection_privacy]

--- a/app/controllers/api/v1/collection_summons_controller.rb
+++ b/app/controllers/api/v1/collection_summons_controller.rb
@@ -19,6 +19,9 @@ module Api
           @summons = @summons.where(element: array_param(:element)) if params[:element]
           @summons = @summons.where(rarity: array_param(:rarity)) if params[:rarity]
           @summons = @summons.where(summon_series_id: array_param(:series)) if params[:series]
+          if ActiveModel::Type::Boolean.new.cast(params[:support_eligible])
+            @summons = @summons.where(support_eligible: true)
+          end
           if params[:search].present?
             q = "%#{ActiveRecord::Base.sanitize_sql_like(params[:search])}%"
             @summons = @summons.where("name_en ILIKE :q OR name_jp ILIKE :q", q: q)
@@ -46,6 +49,9 @@ module Api
         @collection_summons = @collection_summons.by_rarity(array_param(:rarity)) if params[:rarity]
         @collection_summons = @collection_summons.by_series(array_param(:series)) if params[:series]
         @collection_summons = @collection_summons.by_name(params[:search]) if params[:search].present?
+        if ActiveModel::Type::Boolean.new.cast(params[:support_eligible])
+          @collection_summons = @collection_summons.support_eligible
+        end
 
         @collection_summons = @collection_summons.sorted_by(params[:sort], current_user&.language || 'en')
 

--- a/app/controllers/api/v1/support_summons_controller.rb
+++ b/app/controllers/api/v1/support_summons_controller.rb
@@ -91,7 +91,7 @@ module Api
       end
 
       def support_summon_params
-        params.require(:support_summon).permit(:collection_summon_id, :section, :position)
+        params.require(:support_summon).permit(:collection_summon_id, :section, :position, :required)
       end
 
       def import_params

--- a/app/controllers/api/v1/support_summons_controller.rb
+++ b/app/controllers/api/v1/support_summons_controller.rb
@@ -1,0 +1,102 @@
+module Api
+  module V1
+    class SupportSummonsController < ApiController
+      before_action :set_target_user, only: %i[index]
+      before_action :check_support_summons_access, only: %i[index]
+      before_action :restrict_access, only: %i[create update destroy import]
+      before_action :set_support_summon_for_write, only: %i[update destroy]
+
+      def index
+        @support_summons = @target_user.support_summons
+                                       .includes(collection_summon: { summon: :summon_series })
+                                       .ordered
+
+        render json: Api::V1::SupportSummonBlueprint.render(
+          @support_summons,
+          root: :support_summons
+        )
+      end
+
+      def create
+        @support_summon = current_user.support_summons.build(support_summon_params)
+
+        if @support_summon.save
+          render json: Api::V1::SupportSummonBlueprint.render(@support_summon, view: :full),
+                 status: :created
+        else
+          render_validation_error_response(@support_summon)
+        end
+      end
+
+      def update
+        if @support_summon.update(support_summon_params)
+          render json: Api::V1::SupportSummonBlueprint.render(@support_summon, view: :full)
+        else
+          render_validation_error_response(@support_summon)
+        end
+      end
+
+      def destroy
+        @support_summon.destroy
+        head :no_content
+      end
+
+      # POST /api/v1/support_summons/import
+      # Imports a user's profile Support Summon set from the Chrome extension's
+      # parsed HTML payload. Translates GBF section indices to our internal
+      # enum, auto-creates missing CollectionSummons using the level-derived
+      # uncap/transcendence, and atomically replaces the user's existing slots.
+      def import
+        items = import_params[:support_summons] || []
+        service = SupportSummonImportService.new(current_user, items.map(&:to_unsafe_h))
+        result = service.import
+
+        if result.success?
+          render json: Api::V1::SupportSummonBlueprint.render(
+            result.created,
+            root: :support_summons,
+            meta: { created: result.created.size }
+          ), status: :ok
+        else
+          render json: { errors: result.errors }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      # `user_id` accepts either the UUID primary key or a (case-insensitive)
+      # username so the route is consistent with other user-keyed endpoints.
+      def set_target_user
+        identifier = params[:user_id].to_s
+        @target_user = User.find_by('lower(username) = ?', identifier.downcase) ||
+                       User.find_by(id: identifier)
+        return if @target_user
+
+        render json: { error: 'User not found' }, status: :not_found
+      end
+
+      def check_support_summons_access
+        return if @target_user.nil?
+
+        return if @target_user.support_summons_viewable_by?(current_user)
+
+        render json: { error: 'You do not have permission to view these support summons' },
+               status: :forbidden
+      end
+
+      def set_support_summon_for_write
+        @support_summon = current_user.support_summons.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: 'Support summon not found' }, status: :not_found
+      end
+
+      def support_summon_params
+        params.require(:support_summon).permit(:collection_summon_id, :section, :position)
+      end
+
+      def import_params
+        params.permit(support_summons: [:gbf_section, :position, :granblue_id, :level])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -61,9 +61,14 @@ module Api
 
       def info
         payload = UserBlueprint.render_as_hash(@user, view: :minimal)
+        cast_bool = ActiveModel::Type::Boolean.new
 
-        if ActiveModel::Type::Boolean.new.cast(params[:check_collection])
+        if cast_bool.cast(params[:check_collection])
           payload[:collection_accessible] = @user.collection_viewable_by?(current_user)
+        end
+
+        if cast_bool.cast(params[:check_support_summons])
+          payload[:support_summons_accessible] = @user.support_summons_viewable_by?(current_user)
         end
 
         render json: payload

--- a/app/models/collection_summon.rb
+++ b/app/models/collection_summon.rb
@@ -16,6 +16,7 @@ class CollectionSummon < ApplicationRecord
   scope :by_element, ->(element) { joins(:summon).where(summons: { element: element }) }
   scope :by_rarity, ->(rarity) { joins(:summon).where(summons: { rarity: rarity }) }
   scope :by_series, ->(series_id) { joins(:summon).where(summons: { summon_series_id: series_id }) }
+  scope :support_eligible, -> { joins(:summon).where(summons: { support_eligible: true }) }
   scope :transcended, -> { where('transcendence_step > 0') }
   scope :max_uncapped, -> { where(uncap_level: 5) }
   scope :by_name, ->(query) {
@@ -33,6 +34,18 @@ class CollectionSummon < ApplicationRecord
       joins(:summon).order('summons.element ASC')
     when 'element_desc'
       joins(:summon).order('summons.element DESC')
+    when 'uncap_desc'
+      # uncap_level desc, then transcendable summons rank above non-transcendable
+      # at the same uncap level (e.g. a transcendence-capable uncap 5 beats a
+      # non-transcendable uncap 5), then transcendence_step desc as the final
+      # tie-breaker.
+      joins(:summon).order(uncap_level: :desc)
+                    .order(Arel.sql('summons.transcendence DESC'))
+                    .order(transcendence_step: :desc)
+    when 'uncap_asc'
+      joins(:summon).order(uncap_level: :asc)
+                    .order(Arel.sql('summons.transcendence ASC'))
+                    .order(transcendence_step: :asc)
     else
       order(created_at: :desc)
     end

--- a/app/models/collection_summon.rb
+++ b/app/models/collection_summon.rb
@@ -3,6 +3,7 @@ class CollectionSummon < ApplicationRecord
   belongs_to :summon
 
   has_many :grid_summons, dependent: :nullify
+  has_many :support_summons, dependent: :destroy
 
   before_destroy :orphan_grid_items
 

--- a/app/models/concerns/granblue_enums.rb
+++ b/app/models/concerns/granblue_enums.rb
@@ -9,10 +9,15 @@ module GranblueEnums
   # Internal: 0=Null, 1=Wind, 2=Fire, 3=Water, 4=Earth, 5=Dark, 6=Light
   # GBF:      0=Null, 1=Fire, 2=Water, 3=Earth, 4=Wind, 5=Light, 6=Dark
   INTERNAL_TO_GBF_ELEMENT = { 0 => 0, 1 => 4, 2 => 1, 3 => 2, 4 => 3, 5 => 6, 6 => 5 }.freeze
+  GBF_TO_INTERNAL_ELEMENT = INTERNAL_TO_GBF_ELEMENT.invert.freeze
 
   included do
     def self.to_granblue_element(internal_element)
       INTERNAL_TO_GBF_ELEMENT[internal_element] || internal_element
+    end
+
+    def self.to_internal_element(gbf_element)
+      GBF_TO_INTERNAL_ELEMENT[gbf_element] || gbf_element
     end
   end
   GENDERS = { Unknown: 0, Male: 1, Female: 2, "Male/Female": 3 }.freeze

--- a/app/models/support_summon.rb
+++ b/app/models/support_summon.rb
@@ -1,0 +1,39 @@
+class SupportSummon < ApplicationRecord
+  belongs_to :user
+  belongs_to :collection_summon
+
+  has_one :summon, through: :collection_summon
+
+  enum :section, { wind: 1, fire: 2, water: 3, earth: 4, dark: 5, light: 6, misc: 7 }
+
+  validates :section, presence: true
+  validates :position, presence: true
+  validates :position, uniqueness: { scope: [:user_id, :section] }
+  validate :position_within_section_bounds
+  validate :collection_summon_belongs_to_user
+
+  scope :ordered, -> { order(:section, :position) }
+  scope :by_section, ->(section) { where(section: section) }
+
+  def blueprint
+    Api::V1::SupportSummonBlueprint
+  end
+
+  private
+
+  def position_within_section_bounds
+    return if position.nil? || section.nil?
+
+    max = misc? ? 3 : 2
+    return if position.between?(0, max)
+
+    errors.add(:position, "must be between 0 and #{max} for #{section} section")
+  end
+
+  def collection_summon_belongs_to_user
+    return if collection_summon.nil? || user_id.nil?
+    return if collection_summon.user_id == user_id
+
+    errors.add(:collection_summon, 'must belong to the same user')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :collection_summons, dependent: :destroy
   has_many :collection_job_accessories, dependent: :destroy
   has_many :collection_artifacts, dependent: :destroy
+  has_many :support_summons, dependent: :destroy
 
   # Crew associations
   has_many :crew_memberships, dependent: :destroy
@@ -127,6 +128,14 @@ class User < ApplicationRecord
     else
       false
     end
+  end
+
+  # Check if support summons are viewable by another user.
+  # Owners can always view their own; otherwise gated by a single public/private toggle.
+  def support_summons_viewable_by?(viewer)
+    return true if self == viewer
+
+    support_summons_public
   end
 
   # Check if user is in same crew as another user

--- a/app/services/support_summon_import_service.rb
+++ b/app/services/support_summon_import_service.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+##
+# Service for importing a user's profile Support Summon configuration
+# (the 22 slots displayed on their GBF profile: 3 per element + 4 misc).
+#
+# Accepts the raw payload extracted by the Chrome extension's HTML parser:
+#
+#   [
+#     { gbf_section: 1, position: 0, granblue_id: "2040094000", level: 250 },
+#     { gbf_section: 0, position: 0, granblue_id: "2040158000", level: 100 },
+#     ...
+#   ]
+#
+# - `gbf_section` uses Granblue's element ordering (0=Misc/Null, 1=Fire, 2=Water,
+#   3=Earth, 4=Wind, 5=Light, 6=Dark) and is translated to our internal
+#   SupportSummon section enum.
+# - `level` is the in-game level scraped from the profile HTML. Used only when
+#   auto-creating a missing CollectionSummon — existing rows are not touched, on
+#   the assumption the user's collection import is more authoritative.
+#
+# Replacement is atomic: all existing SupportSummon rows are destroyed and the
+# new set is inserted inside a single transaction. Any validation failure rolls
+# the whole import back.
+#
+class SupportSummonImportService
+  Result = Struct.new(:success?, :created, :errors, keyword_init: true)
+
+  # GBF section index → SupportSummon enum symbol.
+  # 0 is GBF's Null/None bucket, which we use for the Misc section.
+  SECTION_MAP = {
+    0 => :misc,
+    1 => :fire,
+    2 => :water,
+    3 => :earth,
+    4 => :wind,
+    5 => :light,
+    6 => :dark
+  }.freeze
+
+  def initialize(user, items)
+    @user = user
+    @items = items.is_a?(Array) ? items : []
+    @created = []
+    @errors = []
+  end
+
+  ##
+  # Derives `[uncap_level, transcendence_step]` from an in-game summon level.
+  # GBF doesn't expose the raw uncap fields on the profile page, but level
+  # uniquely determines them.
+  def self.derive_uncap(level)
+    level = level.to_i
+    return [0, 0] if level <= 40
+    return [1, 0] if level <= 60
+    return [2, 0] if level <= 80
+    return [3, 0] if level <= 100
+    return [4, 0] if level <= 150
+    return [5, 0] if level <= 200
+
+    # 201–250: uncap 6, transcendence_step 1–5 in 10-level buckets
+    transcendence = ((level - 200) / 10.0).ceil.clamp(1, 5)
+    [6, transcendence]
+  end
+
+  def import
+    ActiveRecord::Base.transaction do
+      @user.support_summons.destroy_all
+
+      @items.each_with_index do |item, index|
+        import_item(item, index)
+      end
+
+      raise ActiveRecord::Rollback if @errors.any?
+    end
+
+    Result.new(success?: @errors.empty?, created: @created, errors: @errors)
+  end
+
+  private
+
+  def import_item(item, index)
+    granblue_id = item['granblue_id'].to_s
+    gbf_section = item['gbf_section']
+    position = item['position']
+    level = item['level']
+
+    section = SECTION_MAP[gbf_section.to_i]
+    if section.nil?
+      @errors << { index: index, granblue_id: granblue_id, error: "Unknown GBF section #{gbf_section.inspect}" }
+      return
+    end
+
+    summon = find_summon(granblue_id)
+    unless summon
+      @errors << { index: index, granblue_id: granblue_id, error: 'Summon not found' }
+      return
+    end
+
+    collection_summon = find_or_create_collection_summon(summon, level)
+    return if collection_summon.nil? # error already pushed
+
+    row = @user.support_summons.build(
+      collection_summon: collection_summon,
+      section: section,
+      position: position
+    )
+
+    if row.save
+      @created << row
+    else
+      @errors << {
+        index: index,
+        granblue_id: granblue_id,
+        error: row.errors.full_messages.join(', ')
+      }
+    end
+  end
+
+  def find_summon(granblue_id)
+    Summon.find_by(granblue_id: granblue_id) ||
+      Summon.find_by(granblue_id: SummonIdMapping.resolve(granblue_id))
+  end
+
+  # Users can only set summons they own in-game, so a missing CollectionSummon
+  # row means the user just hasn't run a collection import recently. Create one
+  # with the level-derived uncap/transcendence so the support summon resolves.
+  # Existing rows are not modified — collection import is the authoritative
+  # source for uncap state.
+  def find_or_create_collection_summon(summon, level)
+    existing = @user.collection_summons.find_by(summon_id: summon.id)
+    return existing if existing
+
+    uncap_level, transcendence_step = self.class.derive_uncap(level)
+    # If the summon doesn't support transcendence, clamp transcendence_step to 0
+    # so we don't trip the validate_transcendence_requirements validation.
+    transcendence_step = 0 unless summon.transcendence
+
+    cs = @user.collection_summons.build(
+      summon: summon,
+      uncap_level: uncap_level,
+      transcendence_step: transcendence_step
+    )
+
+    unless cs.save
+      @errors << {
+        granblue_id: summon.granblue_id,
+        error: "Could not create collection summon: #{cs.errors.full_messages.join(', ')}"
+      }
+      return nil
+    end
+
+    cs
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -382,6 +382,8 @@ Rails.application.routes.draw do
         resources :summons, only: [:index, :show], controller: '/api/v1/collection_summons'
         resources :artifacts, only: [:index, :show], controller: '/api/v1/collection_artifacts'
       end
+
+      resources :support_summons, only: [:index], controller: '/api/v1/support_summons'
     end
 
     # Writing to collections - requires auth, operates on current_user
@@ -423,6 +425,13 @@ Rails.application.routes.draw do
           post :import
           post :preview_sync
         end
+      end
+    end
+
+    # Writing support summons - requires auth, operates on current_user
+    resources :support_summons, only: [:create, :update, :destroy] do
+      collection do
+        post :import
       end
     end
   end

--- a/db/migrate/20260515000000_create_support_summons.rb
+++ b/db/migrate/20260515000000_create_support_summons.rb
@@ -1,0 +1,14 @@
+class CreateSupportSummons < ActiveRecord::Migration[8.0]
+  def change
+    create_table :support_summons, id: :uuid do |t|
+      t.references :user, type: :uuid, null: false, foreign_key: true
+      t.references :collection_summon, type: :uuid, null: false, foreign_key: true
+      t.integer :section, null: false
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+
+    add_index :support_summons, [:user_id, :section, :position], unique: true
+  end
+end

--- a/db/migrate/20260515000001_add_support_summons_public_to_users.rb
+++ b/db/migrate/20260515000001_add_support_summons_public_to_users.rb
@@ -1,0 +1,5 @@
+class AddSupportSummonsPublicToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :support_summons_public, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20260515000002_add_support_eligible_to_summons.rb
+++ b/db/migrate/20260515000002_add_support_eligible_to_summons.rb
@@ -1,0 +1,5 @@
+class AddSupportEligibleToSummons < ActiveRecord::Migration[8.0]
+  def change
+    add_column :summons, :support_eligible, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20260515000003_add_required_to_support_summons.rb
+++ b/db/migrate/20260515000003_add_required_to_support_summons.rb
@@ -1,0 +1,5 @@
+class AddRequiredToSupportSummons < ActiveRecord::Migration[8.0]
+  def change
+    add_column :support_summons, :required, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_14_120100) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_15_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_15_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_15_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -1107,6 +1107,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_15_000001) do
     t.boolean "subaura", default: false, null: false
     t.boolean "limit", default: false, null: false
     t.boolean "transcendence", default: false, null: false
+    t.boolean "support_eligible", default: true, null: false
     t.integer "max_atk_xlb"
     t.integer "max_hp_xlb"
     t.integer "summon_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_15_000002) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_15_000003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -1107,7 +1107,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_15_000002) do
     t.boolean "subaura", default: false, null: false
     t.boolean "limit", default: false, null: false
     t.boolean "transcendence", default: false, null: false
-    t.boolean "support_eligible", default: true, null: false
     t.integer "max_atk_xlb"
     t.integer "max_hp_xlb"
     t.integer "summon_id"
@@ -1127,6 +1126,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_15_000002) do
     t.integer "promotions", default: [], null: false, array: true
     t.uuid "summon_series_id"
     t.virtual "latest_date", type: :date, as: "GREATEST(release_date, flb_date, ulb_date, transcendence_date)", stored: true
+    t.boolean "support_eligible", default: true, null: false
     t.index ["granblue_id"], name: "index_summons_on_granblue_id"
     t.index ["latest_date", "id"], name: "index_summons_on_latest_date", order: { latest_date: :desc }
     t.index ["name_en"], name: "index_summons_on_name_en", opclass: :gin_trgm_ops, using: :gin
@@ -1141,6 +1141,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_15_000002) do
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "required", default: false, null: false
     t.index ["collection_summon_id"], name: "index_support_summons_on_collection_summon_id"
     t.index ["user_id", "section", "position"], name: "index_support_summons_on_user_id_and_section_and_position", unique: true
     t.index ["user_id"], name: "index_support_summons_on_user_id"

--- a/spec/factories/support_summons.rb
+++ b/spec/factories/support_summons.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :support_summon do
+    user
+    collection_summon { association :collection_summon, user: user }
+    section { :fire }
+    position { 0 }
+  end
+end

--- a/spec/models/collection_summon_spec.rb
+++ b/spec/models/collection_summon_spec.rb
@@ -94,6 +94,46 @@ RSpec.describe CollectionSummon, type: :model do
         expect(CollectionSummon.max_uncapped).not_to include(partial_uncapped)
       end
     end
+
+    describe '.sorted_by uncap' do
+      let!(:transcendable_summon) { create(:summon, :transcendable) }
+      let!(:plain_summon) { create(:summon) }
+      let!(:low_uncap) { create(:collection_summon, uncap_level: 2) }
+      let!(:mid_uncap) { create(:collection_summon, uncap_level: 4) }
+      let!(:max_uncap_plain) do
+        create(:collection_summon, summon: plain_summon, uncap_level: 5, transcendence_step: 0)
+      end
+      let!(:max_uncap_transcendable_no_step) do
+        create(:collection_summon, summon: transcendable_summon, uncap_level: 5, transcendence_step: 0)
+      end
+      let!(:max_uncap_transc) do
+        create(:collection_summon, summon: transcendable_summon, uncap_level: 5, transcendence_step: 5)
+      end
+
+      it 'uncap_desc ranks transcendable above non-transcendable at the same uncap level' do
+        scoped_ids = [
+          max_uncap_transc.id,
+          max_uncap_transcendable_no_step.id,
+          max_uncap_plain.id,
+          mid_uncap.id,
+          low_uncap.id
+        ]
+        ordered = CollectionSummon.sorted_by('uncap_desc').where(id: scoped_ids).pluck(:id)
+        expect(ordered).to eq(scoped_ids)
+      end
+
+      it 'uncap_asc orders by uncap_level asc' do
+        scoped_ids = [
+          low_uncap.id,
+          mid_uncap.id,
+          max_uncap_plain.id,
+          max_uncap_transcendable_no_step.id,
+          max_uncap_transc.id
+        ]
+        ordered = CollectionSummon.sorted_by('uncap_asc').where(id: scoped_ids).pluck(:id)
+        expect(ordered).to eq(scoped_ids)
+      end
+    end
   end
 
   describe 'factory traits' do

--- a/spec/models/support_summon_spec.rb
+++ b/spec/models/support_summon_spec.rb
@@ -1,0 +1,154 @@
+require 'rails_helper'
+
+RSpec.describe SupportSummon, type: :model do
+  describe 'associations' do
+    it { should belong_to(:user) }
+    it { should belong_to(:collection_summon) }
+    it { should have_one(:summon).through(:collection_summon) }
+  end
+
+  describe 'enums' do
+    it 'defines the seven sections' do
+      expect(SupportSummon.sections.keys).to match_array(%w[wind fire water earth dark light misc])
+    end
+
+    it 'maps section integers to mirror the ELEMENTS enum plus misc' do
+      expect(SupportSummon.sections).to eq(
+        'wind' => 1, 'fire' => 2, 'water' => 3, 'earth' => 4, 'dark' => 5, 'light' => 6, 'misc' => 7
+      )
+    end
+  end
+
+  describe 'validations' do
+    let(:user) { create(:user) }
+
+    describe 'position bounds per section' do
+      %w[wind fire water earth dark light].each do |section|
+        context "#{section} section" do
+          it 'accepts positions 0, 1, 2' do
+            (0..2).each do |position|
+              row = build(:support_summon, user: user, section: section, position: position)
+              expect(row).to be_valid, "expected #{section}/#{position} to be valid"
+            end
+          end
+
+          it 'rejects position 3' do
+            row = build(:support_summon, user: user, section: section, position: 3)
+            expect(row).not_to be_valid
+            expect(row.errors[:position]).to be_present
+          end
+
+          it 'rejects negative positions' do
+            row = build(:support_summon, user: user, section: section, position: -1)
+            expect(row).not_to be_valid
+          end
+        end
+      end
+
+      context 'misc section' do
+        it 'accepts positions 0, 1, 2, 3' do
+          (0..3).each do |position|
+            row = build(:support_summon, user: user, section: :misc, position: position)
+            expect(row).to be_valid, "expected misc/#{position} to be valid"
+          end
+        end
+
+        it 'rejects position 4' do
+          row = build(:support_summon, user: user, section: :misc, position: 4)
+          expect(row).not_to be_valid
+          expect(row.errors[:position]).to be_present
+        end
+      end
+    end
+
+    describe 'uniqueness of (user, section, position)' do
+      it 'is rejected at the model layer' do
+        create(:support_summon, user: user, section: :fire, position: 0)
+        duplicate = build(:support_summon, user: user, section: :fire, position: 0)
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:position]).to include('has already been taken')
+      end
+
+      it 'allows the same position across different sections for one user' do
+        create(:support_summon, user: user, section: :fire, position: 0)
+        other = build(:support_summon, user: user, section: :water, position: 0)
+        expect(other).to be_valid
+      end
+
+      it 'allows two different users to share the same slot' do
+        other_user = create(:user)
+        create(:support_summon, user: user, section: :fire, position: 0)
+        other = build(:support_summon, user: other_user,
+                                       collection_summon: create(:collection_summon, user: other_user),
+                                       section: :fire,
+                                       position: 0)
+        expect(other).to be_valid
+      end
+    end
+
+    describe 'collection_summon ownership' do
+      it 'rejects a collection_summon owned by a different user' do
+        other_user = create(:user)
+        foreign_cs = create(:collection_summon, user: other_user)
+        row = build(:support_summon, user: user, collection_summon: foreign_cs)
+        expect(row).not_to be_valid
+        expect(row.errors[:collection_summon]).to include('must belong to the same user')
+      end
+    end
+
+    describe 'element / section independence' do
+      it 'allows a Wind summon in the Fire section (strategic off-element placement)' do
+        wind_summon = create(:summon, element: 1) # Wind
+        wind_cs = create(:collection_summon, user: user, summon: wind_summon)
+        row = build(:support_summon, user: user, collection_summon: wind_cs, section: :fire, position: 0)
+        expect(row).to be_valid
+      end
+
+      it 'allows any element in the misc section' do
+        light_summon = create(:summon, element: 6)
+        light_cs = create(:collection_summon, user: user, summon: light_summon)
+        row = build(:support_summon, user: user, collection_summon: light_cs, section: :misc, position: 3)
+        expect(row).to be_valid
+      end
+    end
+  end
+
+  describe 'cascade deletes' do
+    let(:user) { create(:user) }
+
+    it 'is removed when its CollectionSummon is destroyed' do
+      cs = create(:collection_summon, user: user)
+      support = create(:support_summon, user: user, collection_summon: cs)
+      expect { cs.destroy }.to change(SupportSummon, :count).by(-1)
+      expect(SupportSummon.find_by(id: support.id)).to be_nil
+    end
+
+    it 'is removed when its User is destroyed' do
+      create(:support_summon, user: user)
+      expect { user.destroy }.to change(SupportSummon, :count).by(-1)
+    end
+  end
+
+  describe 'scopes' do
+    let(:user) { create(:user) }
+
+    describe '.ordered' do
+      it 'orders by section ascending, then position ascending' do
+        misc0 = create(:support_summon, user: user, section: :misc, position: 0)
+        fire2 = create(:support_summon, user: user, section: :fire, position: 2)
+        fire0 = create(:support_summon, user: user, section: :fire, position: 0)
+        wind1 = create(:support_summon, user: user, section: :wind, position: 1)
+
+        expect(user.support_summons.ordered).to eq([wind1, fire0, fire2, misc0])
+      end
+    end
+
+    describe '.by_section' do
+      it 'returns only rows in the given section' do
+        fire = create(:support_summon, user: user, section: :fire, position: 0)
+        create(:support_summon, user: user, section: :water, position: 0)
+        expect(SupportSummon.by_section(:fire)).to contain_exactly(fire)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/collection_summons_spec.rb
+++ b/spec/requests/api/v1/collection_summons_spec.rb
@@ -73,6 +73,30 @@ RSpec.describe 'Collection Summons API', type: :request do
       get "/api/v1/users/#{private_user.id}/collection/summons"
       expect(response).to have_http_status(:forbidden)
     end
+
+    describe 'support_eligible filter' do
+      let(:eligible_summon) { create(:summon, support_eligible: true) }
+      let(:ineligible_summon) { create(:summon, support_eligible: false) }
+      let!(:eligible_cs) { create(:collection_summon, user: user, summon: eligible_summon) }
+      let!(:ineligible_cs) { create(:collection_summon, user: user, summon: ineligible_summon) }
+
+      it 'returns only support-eligible summons when filter is true' do
+        get "/api/v1/users/#{user.id}/collection/summons",
+            params: { support_eligible: 'true' },
+            headers: headers
+
+        expect(response).to have_http_status(:ok)
+        ids = response.parsed_body['summons'].map { |s| s['id'] }
+        expect(ids).to include(eligible_cs.id)
+        expect(ids).not_to include(ineligible_cs.id)
+      end
+
+      it 'ignores the filter when unset' do
+        get "/api/v1/users/#{user.id}/collection/summons", headers: headers
+        ids = response.parsed_body['summons'].map { |s| s['id'] }
+        expect(ids).to include(eligible_cs.id, ineligible_cs.id)
+      end
+    end
   end
 
   describe 'GET /api/v1/users/:user_id/collection/summons?unowned=true' do

--- a/spec/requests/api/v1/support_summons_spec.rb
+++ b/spec/requests/api/v1/support_summons_spec.rb
@@ -1,0 +1,212 @@
+require 'rails_helper'
+
+RSpec.describe 'Support Summons API', type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:access_token) do
+    Doorkeeper::AccessToken.create!(resource_owner_id: user.id, expires_in: 30.days, scopes: 'public')
+  end
+  let(:other_access_token) do
+    Doorkeeper::AccessToken.create!(resource_owner_id: other_user.id, expires_in: 30.days, scopes: 'public')
+  end
+  let(:headers) do
+    { 'Authorization' => "Bearer #{access_token.token}", 'Content-Type' => 'application/json' }
+  end
+  let(:other_headers) do
+    { 'Authorization' => "Bearer #{other_access_token.token}", 'Content-Type' => 'application/json' }
+  end
+
+  let(:collection_summon) { create(:collection_summon, user: user) }
+
+  describe 'GET /api/v1/users/:user_id/support_summons' do
+    let!(:fire0) { create(:support_summon, user: user, section: :fire, position: 0) }
+    let!(:misc2) { create(:support_summon, user: user, section: :misc, position: 2) }
+
+    it 'returns the user\'s support summons ordered by section then position when public' do
+      get "/api/v1/users/#{user.id}/support_summons"
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      ids = json['support_summons'].map { |s| s['id'] }
+      expect(ids).to eq([fire0.id, misc2.id])
+    end
+
+    it 'serializes section as a string and position as an integer' do
+      get "/api/v1/users/#{user.id}/support_summons"
+      json = response.parsed_body
+      first = json['support_summons'].first
+      expect(first['section']).to eq('fire')
+      expect(first['position']).to eq(0)
+      expect(first['collection_summon']).to be_present
+    end
+
+    it 'returns 403 to other users when support_summons_public is false' do
+      user.update!(support_summons_public: false)
+
+      get "/api/v1/users/#{user.id}/support_summons", headers: other_headers
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns 403 to unauthenticated callers when support_summons_public is false' do
+      user.update!(support_summons_public: false)
+
+      get "/api/v1/users/#{user.id}/support_summons"
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'lets the owner view their own support summons even when private' do
+      user.update!(support_summons_public: false)
+
+      get "/api/v1/users/#{user.id}/support_summons", headers: headers
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 404 for an unknown user' do
+      get "/api/v1/users/#{SecureRandom.uuid}/support_summons"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'accepts a username in addition to a UUID' do
+      get "/api/v1/users/#{user.username}/support_summons"
+      expect(response).to have_http_status(:ok)
+      ids = response.parsed_body['support_summons'].map { |s| s['id'] }
+      expect(ids).to eq([fire0.id, misc2.id])
+    end
+
+    it 'matches usernames case-insensitively' do
+      get "/api/v1/users/#{user.username.upcase}/support_summons"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST /api/v1/support_summons' do
+    it 'creates a support summon for the current user' do
+      cs = create(:collection_summon, user: user)
+
+      expect {
+        post '/api/v1/support_summons',
+             params: { support_summon: { collection_summon_id: cs.id, section: 'water', position: 1 } }.to_json,
+             headers: headers
+      }.to change(SupportSummon, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      json = response.parsed_body
+      expect(json['section']).to eq('water')
+      expect(json['position']).to eq(1)
+    end
+
+    it 'requires authentication' do
+      cs = create(:collection_summon, user: user)
+      post '/api/v1/support_summons',
+           params: { support_summon: { collection_summon_id: cs.id, section: 'water', position: 0 } }.to_json,
+           headers: { 'Content-Type' => 'application/json' }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'rejects a collection_summon owned by a different user' do
+      foreign_cs = create(:collection_summon, user: other_user)
+
+      post '/api/v1/support_summons',
+           params: { support_summon: { collection_summon_id: foreign_cs.id, section: 'fire', position: 0 } }.to_json,
+           headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'rejects an out-of-range position' do
+      cs = create(:collection_summon, user: user)
+      post '/api/v1/support_summons',
+           params: { support_summon: { collection_summon_id: cs.id, section: 'fire', position: 3 } }.to_json,
+           headers: headers
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe 'PATCH /api/v1/support_summons/:id' do
+    let!(:row) { create(:support_summon, user: user, section: :fire, position: 0) }
+
+    it 'updates the slot' do
+      patch "/api/v1/support_summons/#{row.id}",
+            params: { support_summon: { position: 2 } }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(row.reload.position).to eq(2)
+    end
+
+    it 'returns not found when targeting another user\'s row' do
+      foreign = create(:support_summon, user: other_user, section: :fire, position: 0)
+      patch "/api/v1/support_summons/#{foreign.id}",
+            params: { support_summon: { position: 2 } }.to_json,
+            headers: headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'DELETE /api/v1/support_summons/:id' do
+    let!(:row) { create(:support_summon, user: user) }
+
+    it 'deletes the slot' do
+      expect {
+        delete "/api/v1/support_summons/#{row.id}", headers: headers
+      }.to change(SupportSummon, :count).by(-1)
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+
+  describe 'POST /api/v1/support_summons/import' do
+    let!(:fire_summon) { create(:summon, element: 2) }
+    let!(:water_summon) { create(:summon, element: 3) }
+
+    it 'imports the parsed extension payload and atomically replaces existing slots' do
+      existing_cs = create(:collection_summon, user: user, summon: water_summon)
+      stale = create(:support_summon, user: user, collection_summon: existing_cs, section: :water, position: 2)
+
+      payload = {
+        support_summons: [
+          { gbf_section: 1, position: 0, granblue_id: fire_summon.granblue_id, level: 250 },
+          { gbf_section: 0, position: 3, granblue_id: water_summon.granblue_id, level: 100 }
+        ]
+      }
+
+      post '/api/v1/support_summons/import', params: payload.to_json, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(SupportSummon.find_by(id: stale.id)).to be_nil
+      sections = user.support_summons.ordered.pluck(:section)
+      expect(sections).to eq(%w[fire misc])
+    end
+
+    it 'auto-creates a CollectionSummon when the user does not yet own the imported summon' do
+      expect(user.collection_summons.where(summon: fire_summon)).to be_empty
+
+      post '/api/v1/support_summons/import',
+           params: { support_summons: [
+             { gbf_section: 1, position: 0, granblue_id: fire_summon.granblue_id, level: 100 }
+           ] }.to_json,
+           headers: headers
+
+      expect(response).to have_http_status(:ok)
+      cs = user.collection_summons.find_by(summon: fire_summon)
+      expect(cs.uncap_level).to eq(3)
+    end
+
+    it 'returns 422 with row errors when the payload contains a bad section' do
+      post '/api/v1/support_summons/import',
+           params: { support_summons: [
+             { gbf_section: 99, position: 0, granblue_id: fire_summon.granblue_id, level: 100 }
+           ] }.to_json,
+           headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['errors'].first['error']).to include('Unknown GBF section')
+    end
+
+    it 'requires authentication' do
+      post '/api/v1/support_summons/import',
+           params: { support_summons: [] }.to_json,
+           headers: { 'Content-Type' => 'application/json' }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -90,6 +90,40 @@ RSpec.describe 'Api::V1::Users', type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).not_to have_key('collection_accessible')
     end
+
+    context 'with check_support_summons=true' do
+      it 'returns support_summons_accessible=false when private and viewed by a stranger' do
+        owner = create(:user, support_summons_public: false)
+        get "/api/v1/users/info/#{owner.username}?check_support_summons=true"
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['support_summons_accessible']).to eq(false)
+      end
+
+      it 'returns support_summons_accessible=true for the owner' do
+        owner = create(:user, support_summons_public: false)
+        token = Doorkeeper::AccessToken.create!(
+          resource_owner_id: owner.id, expires_in: 30.days, scopes: 'public'
+        )
+        get "/api/v1/users/info/#{owner.username}?check_support_summons=true",
+            headers: { 'Authorization' => "Bearer #{token.token}" }
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['support_summons_accessible']).to eq(true)
+      end
+
+      it 'returns support_summons_accessible=true when public' do
+        owner = create(:user, support_summons_public: true)
+        get "/api/v1/users/info/#{owner.username}?check_support_summons=true"
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['support_summons_accessible']).to eq(true)
+      end
+    end
+
+    it 'omits support_summons_accessible without check_support_summons' do
+      owner = create(:user, support_summons_public: false)
+      get "/api/v1/users/info/#{owner.username}"
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).not_to have_key('support_summons_accessible')
+    end
   end
 
   describe 'GET /api/v1/users/:id' do

--- a/spec/services/support_summon_import_service_spec.rb
+++ b/spec/services/support_summon_import_service_spec.rb
@@ -1,0 +1,168 @@
+require 'rails_helper'
+
+RSpec.describe SupportSummonImportService do
+  describe '.derive_uncap' do
+    {
+      1 => [0, 0],
+      40 => [0, 0],
+      41 => [1, 0],
+      60 => [1, 0],
+      61 => [2, 0],
+      80 => [2, 0],
+      81 => [3, 0],
+      100 => [3, 0],
+      101 => [4, 0],
+      150 => [4, 0],
+      151 => [5, 0],
+      200 => [5, 0],
+      201 => [6, 1],
+      210 => [6, 1],
+      211 => [6, 2],
+      220 => [6, 2],
+      221 => [6, 3],
+      230 => [6, 3],
+      231 => [6, 4],
+      240 => [6, 4],
+      241 => [6, 5],
+      250 => [6, 5]
+    }.each do |level, (uncap, transcendence)|
+      it "returns [#{uncap}, #{transcendence}] for level #{level}" do
+        expect(described_class.derive_uncap(level)).to eq([uncap, transcendence])
+      end
+    end
+  end
+
+  describe '#import' do
+    let(:user) { create(:user) }
+    let(:fire_summon) { create(:summon, element: 2) } # internal 2=Fire
+    let(:water_summon) { create(:summon, element: 3) }
+    let(:misc_summon) { create(:summon, element: 0) }
+
+    it 'translates GBF section indices to internal section enums' do
+      service = described_class.new(user, [
+        { 'gbf_section' => 1, 'position' => 0, 'granblue_id' => fire_summon.granblue_id, 'level' => 250 },
+        { 'gbf_section' => 2, 'position' => 0, 'granblue_id' => water_summon.granblue_id, 'level' => 200 },
+        { 'gbf_section' => 0, 'position' => 0, 'granblue_id' => misc_summon.granblue_id, 'level' => 100 }
+      ])
+
+      result = service.import
+
+      expect(result.success?).to be(true)
+      sections = user.support_summons.ordered.map(&:section)
+      expect(sections).to eq(%w[fire water misc])
+    end
+
+    it 'maps all 7 GBF section indices correctly' do
+      summons = (0..6).map { create(:summon, element: 0) }
+      items = (0..6).map do |gbf_section|
+        { 'gbf_section' => gbf_section, 'position' => 0, 'granblue_id' => summons[gbf_section].granblue_id, 'level' => 100 }
+      end
+
+      result = described_class.new(user, items).import
+
+      expect(result.success?).to be(true)
+      expect(user.support_summons.pluck(:section).sort).to eq(%w[dark earth fire light misc water wind].sort)
+    end
+
+    it 'auto-creates a CollectionSummon when the user does not own the summon yet' do
+      expect(user.collection_summons.count).to eq(0)
+
+      result = described_class.new(user, [
+        { 'gbf_section' => 1, 'position' => 0, 'granblue_id' => fire_summon.granblue_id, 'level' => 100 }
+      ]).import
+
+      expect(result.success?).to be(true)
+      expect(user.collection_summons.count).to eq(1)
+      cs = user.collection_summons.first
+      expect(cs.summon).to eq(fire_summon)
+      expect(cs.uncap_level).to eq(3) # level 100 → uncap 3
+      expect(cs.transcendence_step).to eq(0)
+    end
+
+    it 'sets transcendence on an auto-created CollectionSummon when level is in the transcendence range' do
+      transcendable = create(:summon, :transcendable)
+
+      described_class.new(user, [
+        { 'gbf_section' => 1, 'position' => 0, 'granblue_id' => transcendable.granblue_id, 'level' => 235 }
+      ]).import
+
+      cs = user.collection_summons.find_by(summon_id: transcendable.id)
+      expect(cs.uncap_level).to eq(6)
+      expect(cs.transcendence_step).to eq(4) # 231-240 → transcendence 4
+    end
+
+    it 'clamps transcendence_step to 0 for non-transcendable summons regardless of level' do
+      # Level claims transcendence, but the summon doesn't support it.
+      non_trans = create(:summon, transcendence: false)
+
+      result = described_class.new(user, [
+        { 'gbf_section' => 1, 'position' => 0, 'granblue_id' => non_trans.granblue_id, 'level' => 250 }
+      ]).import
+
+      expect(result.success?).to be(true)
+      cs = user.collection_summons.find_by(summon_id: non_trans.id)
+      expect(cs.transcendence_step).to eq(0)
+    end
+
+    it 'does not modify an existing CollectionSummon when one is already present' do
+      existing = create(:collection_summon, user: user, summon: fire_summon, uncap_level: 5, transcendence_step: 0)
+
+      described_class.new(user, [
+        { 'gbf_section' => 1, 'position' => 0, 'granblue_id' => fire_summon.granblue_id, 'level' => 100 }
+      ]).import
+
+      existing.reload
+      expect(existing.uncap_level).to eq(5)
+      expect(existing.transcendence_step).to eq(0)
+      # No duplicate CollectionSummon row was created either.
+      expect(user.collection_summons.where(summon: fire_summon).count).to eq(1)
+    end
+
+    it 'atomically wipes existing support summons before inserting new ones' do
+      existing_cs = create(:collection_summon, user: user, summon: water_summon)
+      old_support = create(:support_summon, user: user, collection_summon: existing_cs, section: :water, position: 2)
+
+      result = described_class.new(user, [
+        { 'gbf_section' => 1, 'position' => 0, 'granblue_id' => fire_summon.granblue_id, 'level' => 100 }
+      ]).import
+
+      expect(result.success?).to be(true)
+      expect(SupportSummon.find_by(id: old_support.id)).to be_nil
+      expect(user.support_summons.map(&:section)).to eq(['fire'])
+    end
+
+    it 'rolls back the entire transaction when any row fails' do
+      existing_cs = create(:collection_summon, user: user, summon: water_summon)
+      old_support = create(:support_summon, user: user, collection_summon: existing_cs, section: :water, position: 0)
+
+      result = described_class.new(user, [
+        { 'gbf_section' => 1, 'position' => 0, 'granblue_id' => fire_summon.granblue_id, 'level' => 100 },
+        { 'gbf_section' => 99, 'position' => 0, 'granblue_id' => water_summon.granblue_id, 'level' => 100 } # bad section
+      ]).import
+
+      expect(result.success?).to be(false)
+      expect(result.errors.first[:error]).to include('Unknown GBF section')
+      # Old slot still present; nothing from the failed import persisted.
+      expect(SupportSummon.find_by(id: old_support.id)).to eq(old_support)
+    end
+
+    it 'reports an error when a granblue_id does not match any summon' do
+      result = described_class.new(user, [
+        { 'gbf_section' => 1, 'position' => 0, 'granblue_id' => 'not-a-real-id', 'level' => 100 }
+      ]).import
+
+      expect(result.success?).to be(false)
+      expect(result.errors.first[:error]).to eq('Summon not found')
+    end
+
+    it 'accepts an empty payload as a clear-all operation' do
+      existing_cs = create(:collection_summon, user: user, summon: fire_summon)
+      create(:support_summon, user: user, collection_summon: existing_cs, section: :fire, position: 0)
+
+      result = described_class.new(user, []).import
+
+      expect(result.success?).to be(true)
+      expect(user.support_summons).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- New `SupportSummon` model + table: links a user's `CollectionSummon` to a `(section, position)` slot. Storage is independent of `Summon#element` so off-element placements (in-game strategic picks) work. Cascade-deletes from `CollectionSummon` so a slot can't outlive its underlying owned summon.
- Single privacy toggle on `User` — `support_summons_public` (default `true`); exposed on the user blueprint alongside `collection_privacy`.
- API surface: `GET /users/:user_id/support_summons` (privacy-gated), `POST /support_summons` + `PATCH/DELETE /support_summons/:id` for single-slot edits, and `POST /support_summons/import` for the Chrome-extension flow.
- `SupportSummonImportService` translates GBF section indices to our internal enum, looks up summons by `granblue_id` (Arcarum-forged aware via `SummonIdMapping`), and auto-creates `CollectionSummon` rows for unowned summons using level-derived `uncap_level` / `transcendence_step`. Existing `CollectionSummon`s are not modified — the regular collection import stays authoritative for uncap state.
- Atomic replacement: any row failure rolls the whole import back; old slots survive.
- `GranblueEnums::GBF_TO_INTERNAL_ELEMENT` and `to_internal_element` helper added so the tech-debt mapping has a single canonical inverse.

## Test plan

- [ ] `bundle exec rails db:migrate` applies the two new migrations cleanly.
- [ ] `bundle exec rspec spec/models/support_summon_spec.rb spec/services/support_summon_import_service_spec.rb spec/requests/api/v1/support_summons_spec.rb` — 84 examples, green locally.
- [ ] `bundle exec rspec spec/models/user_spec.rb spec/models/collection_summon_spec.rb` — no regressions from the new associations.
- [ ] Manual: POST `/api/v1/support_summons/import` with a sample extension payload (paired hensei-extractor PR) and confirm slots populate and missing CollectionSummons auto-create with the right uncap.