### PR TITLE
fix: ActionController::Parameters in DraftWorkspace sanitize

### DIFF
--- a/app/services/party_difficulty/draft_workspace.rb
+++ b/app/services/party_difficulty/draft_workspace.rb
@@ -240,6 +240,7 @@ module PartyDifficulty
 
     def sanitize_attributes(target_type, attrs)
       allowed = EDITABLE_COLUMNS[target_type] || []
+      attrs = attrs.to_unsafe_h if attrs.respond_to?(:to_unsafe_h)
       (attrs || {}).each_with_object({}) do |(key, value), out|
         out[key.to_s] = value if allowed.include?(key.to_s)
       end

--- a/spec/services/party_difficulty/draft_workspace_spec.rb
+++ b/spec/services/party_difficulty/draft_workspace_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe PartyDifficulty::DraftWorkspace do
       reloaded = described_class.for(user)
       expect(reloaded.merged_rules.map(&:id)).not_to include(rule.id)
     end
+
+    it 'accepts ActionController::Parameters from controllers' do
+      params = ActionController::Parameters.new(name: 'Hard', sort_order: 5).permit(:name, :sort_order)
+
+      draft = workspace.stage!(
+        target_type: 'Difficulty', target_id: nil,
+        operation: 'create', attributes: params
+      )
+
+      expect(draft.attributes_payload).to eq('name' => 'Hard', 'sort_order' => 5)
+    end
   end
 
   describe '#diff' do


### PR DESCRIPTION
## Summary

Editing a Difficulty tier (or rule/component) in the admin Database editor 500'd with:

> undefined method 'each_with_object' for an instance of ActionController::Parameters

`DifficultiesController#update`, `DifficultyRulesController`, and `DifficultyComponentsController` pass permitted `ActionController::Parameters` into `DraftWorkspace#stage!`, which forwards to `sanitize_attributes`. Parameters doesn't include `Enumerable`, so `each_with_object` is undefined.

Fix is in the service layer (single point) so any future caller is covered: coerce via `to_unsafe_h` when the input responds to it. `DifficultyDraftsController` already converted upstream, so its path is unaffected.

## Test plan

- [x] `bundle exec rspec spec/services/party_difficulty/draft_workspace_spec.rb` — 11/11 pass, including new regression that calls `stage!` with `ActionController::Parameters`.
- [ ] Manual: edit a tier in the Database editor → save returns 200 with draft envelope.