### PR TITLE
remove color from difficulty tiers

### DIFF
--- a/app/blueprints/api/v1/difficulty_blueprint.rb
+++ b/app/blueprints/api/v1/difficulty_blueprint.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class DifficultyBlueprint < ApiBlueprint
-      fields :name, :slug, :description, :min_score, :max_score, :sort_order, :color
+      fields :name, :slug, :description, :min_score, :max_score, :sort_order
 
       # Host-relative URL (i.e. <prefix>/<key>?v=<timestamp>), not a literal S3
       # key. Versioned with updated_at so the URL changes on every upload,
@@ -30,7 +30,7 @@ module Api
       end
 
       view :nested do
-        fields :name, :slug, :color, :sort_order
+        fields :name, :slug, :sort_order
       end
 
       view :list do

--- a/app/controllers/api/v1/difficulties_controller.rb
+++ b/app/controllers/api/v1/difficulties_controller.rb
@@ -59,7 +59,7 @@ module Api
       end
 
       def difficulty_params
-        params.require(:difficulty).permit(:name, :slug, :description, :min_score, :max_score, :sort_order, :color)
+        params.require(:difficulty).permit(:name, :slug, :description, :min_score, :max_score, :sort_order)
       end
 
       def with_drafts?

--- a/app/services/party_difficulty/draft_workspace.rb
+++ b/app/services/party_difficulty/draft_workspace.rb
@@ -22,13 +22,13 @@ module PartyDifficulty
   # background score sweep) keep reading the canonical tables.
   class DraftWorkspace
     EDITABLE_COLUMNS = {
-      'Difficulty' => %w[name slug description min_score max_score sort_order color].freeze,
+      'Difficulty' => %w[name slug description min_score max_score sort_order].freeze,
       'DifficultyRule' => %w[name description component rule_type params weight active].freeze,
       'DifficultyComponent' => %w[weight enabled min_count_to_score target_max].freeze
     }.freeze
 
     SUMMARY_COLUMNS = {
-      'Difficulty' => %w[name slug min_score max_score sort_order color],
+      'Difficulty' => %w[name slug min_score max_score sort_order],
       'DifficultyRule' => %w[name component rule_type weight active],
       'DifficultyComponent' => %w[name weight enabled min_count_to_score target_max]
     }.freeze

--- a/db/migrate/20260514105320_remove_color_from_difficulties.rb
+++ b/db/migrate/20260514105320_remove_color_from_difficulties.rb
@@ -1,0 +1,5 @@
+class RemoveColorFromDifficulties < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :difficulties, :color, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_14_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_14_105320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -388,7 +388,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_14_000000) do
     t.decimal "min_score", precision: 5, scale: 2, default: "0.0", null: false
     t.decimal "max_score", precision: 5, scale: 2, default: "100.0", null: false
     t.integer "sort_order", default: 0, null: false
-    t.string "color"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "image_key"


### PR DESCRIPTION
Drops the `color` string column from `difficulties` and removes it from `DifficultyBlueprint` (root + `:nested` view), `difficulty_params` strong params, and `DraftWorkspace::EDITABLE_COLUMNS` / `SUMMARY_COLUMNS`. Tier appearance is handled by `image_key` now, so `color` is dead weight.