### PR TITLE
users#search: match display_name

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -67,7 +67,8 @@ module Api
         query = params[:query].to_s.strip
         return render json: { users: [] } if query.length < 2
 
-        users = User.where('lower(username) LIKE ?', "#{query.downcase}%")
+        q = "#{query.downcase}%"
+        users = User.where('LOWER(username) LIKE :q OR LOWER(display_name) LIKE :q', q: q)
                      .where.not(id: current_user.id)
                      .includes(active_crew_membership: :crew)
                      .limit(10)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -67,11 +67,13 @@ module Api
         query = params[:query].to_s.strip
         return render json: { users: [] } if query.length < 2
 
-        q = "#{query.downcase}%"
-        users = User.where('LOWER(username) LIKE :q OR LOWER(display_name) LIKE :q', q: q)
-                     .where.not(id: current_user.id)
-                     .includes(active_crew_membership: :crew)
-                     .limit(10)
+        escaped = query.downcase.gsub(/[\\%_]/) { |c| "\\#{c}" }
+        q = "#{escaped}%"
+        users = User
+                .where("LOWER(username) LIKE :q ESCAPE '\\' OR LOWER(display_name) LIKE :q ESCAPE '\\'", q: q)
+                .where.not(id: current_user.id)
+                .includes(active_crew_membership: :crew)
+                .limit(10)
         render json: { users: UserBlueprint.render_as_hash(users, view: :minimal) }
       end
 

--- a/db/migrate/20260514120000_add_lower_display_name_index_to_users.rb
+++ b/db/migrate/20260514120000_add_lower_display_name_index_to_users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddLowerDisplayNameIndexToUsers < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :users, 'LOWER(display_name) text_pattern_ops',
+              name: 'index_users_on_lower_display_name',
+              algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260514120100_swap_users_lower_username_index_to_pattern_ops.rb
+++ b/db/migrate/20260514120100_swap_users_lower_username_index_to_pattern_ops.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class SwapUsersLowerUsernameIndexToPatternOps < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    add_index :users, 'LOWER(username) text_pattern_ops',
+              name: 'index_users_on_lower_username_pattern',
+              unique: true,
+              algorithm: :concurrently
+    remove_index :users, name: 'index_users_on_lower_username', algorithm: :concurrently
+    execute 'ALTER INDEX index_users_on_lower_username_pattern RENAME TO index_users_on_lower_username'
+  end
+
+  def down
+    add_index :users, 'LOWER(username)',
+              name: 'index_users_on_lower_username_pattern',
+              unique: true,
+              algorithm: :concurrently
+    remove_index :users, name: 'index_users_on_lower_username', algorithm: :concurrently
+    execute 'ALTER INDEX index_users_on_lower_username_pattern RENAME TO index_users_on_lower_username'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_14_105320) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_14_120100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -1175,7 +1175,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_14_105320) do
     t.string "last_extension_version"
     t.datetime "last_extension_version_at"
     t.string "description", limit: 140
-    t.index "lower((username)::text)", name: "index_users_on_lower_username", unique: true
+    t.index "lower((display_name)::text) text_pattern_ops", name: "index_users_on_lower_display_name"
+    t.index "lower((username)::text) text_pattern_ops", name: "index_users_on_lower_username", unique: true
     t.index ["collection_privacy"], name: "index_users_on_collection_privacy"
   end
 

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -150,6 +150,52 @@ RSpec.describe 'Api::V1::Users', type: :request do
     end
   end
 
+  describe 'GET /api/v1/users/search' do
+    it 'returns users matched by username prefix' do
+      create(:user, username: 'jedmund', display_name: 'Justin')
+      get '/api/v1/users/search', params: { query: 'jed' }, headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      usernames = response.parsed_body['users'].map { |u| u['username'] }
+      expect(usernames).to include('jedmund')
+    end
+
+    it 'returns users matched by display_name prefix' do
+      create(:user, username: 'someguy', display_name: 'Konami')
+      get '/api/v1/users/search', params: { query: 'kona' }, headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      usernames = response.parsed_body['users'].map { |u| u['username'] }
+      expect(usernames).to include('someguy')
+    end
+
+    it 'is case-insensitive on both columns' do
+      create(:user, username: 'Sandalphon', display_name: 'Cocytus')
+      get '/api/v1/users/search', params: { query: 'COC' }, headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      usernames = response.parsed_body['users'].map { |u| u['username'] }
+      expect(usernames).to include('Sandalphon')
+    end
+
+    it 'excludes the current user from results' do
+      user.update!(username: 'jedmund', display_name: 'Justin')
+      get '/api/v1/users/search', params: { query: 'jed' }, headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      usernames = response.parsed_body['users'].map { |u| u['username'] }
+      expect(usernames).not_to include('jedmund')
+    end
+
+    it 'returns an empty array for queries shorter than 2 characters' do
+      create(:user, username: 'jedmund')
+      get '/api/v1/users/search', params: { query: 'j' }, headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['users']).to eq([])
+    end
+  end
+
   describe 'POST /api/v1/check/email' do
     it 'checks email availability' do
       post '/api/v1/check/email', params: { email: 'available@example.com' }.to_json,


### PR DESCRIPTION
## Summary
- `/api/v1/users/search` now matches `LOWER(display_name) LIKE 'query%'` in addition to `LOWER(username)`. Self-exclusion and the 10-result cap stay.
- Adds request specs covering username match, display_name match, case-insensitivity, self-exclusion, and the <2-char short-circuit.

## Test plan
- [ ] `bundle exec rspec spec/requests/api/v1/users_spec.rb -e "GET /api/v1/users/search"`