### PR TITLE
difficulty drafts: batch target load + allow multi-tier coverage edits

### DIFF
--- a/app/controllers/api/v1/difficulty_drafts_controller.rb
+++ b/app/controllers/api/v1/difficulty_drafts_controller.rb
@@ -87,6 +87,11 @@ module Api
           target_type: e.target_type,
           target_id: e.target_id
         }, status: :conflict
+      rescue PartyDifficulty::CoverageError => e
+        render json: {
+          error: 'invalid_coverage',
+          messages: e.messages
+        }, status: :unprocessable_entity
       end
 
       private

--- a/app/models/difficulty.rb
+++ b/app/models/difficulty.rb
@@ -26,6 +26,63 @@ class Difficulty < ApplicationRecord
     DifficultyBlueprint
   end
 
+  # The set of all tiers must tile [0, 100] with no overlaps and no gaps wider
+  # than one score quantum (Calculator#composite_score rounds to 2 decimals, so
+  # adjacent tiers may sit at .99 / .00 with a 0.01 difference). For multi-tier
+  # edits (e.g. splitting one tier in two), batch the changes through
+  # PartyDifficulty::DraftWorkspace so the intermediate state isn't persisted.
+  TIER_QUANTUM = 0.01
+
+  # Returns aggregate error messages for a proposed tier set. The set is any
+  # collection of objects responding to `name` / `min_score` / `max_score`.
+  # Tiers with blank or inverted bounds are surfaced as errors so callers like
+  # PartyDifficulty::DraftWorkspace#commit! can reject them up front instead
+  # of letting per-row save raise ActiveRecord::RecordInvalid mid-apply.
+  def self.coverage_errors_for(tiers)
+    errors = []
+    valid = []
+    tiers.each do |t|
+      label = t.try(:name).presence || t.try(:slug).presence || t.try(:id) || 'unnamed'
+      if t.min_score.blank? || t.max_score.blank?
+        errors << "tier #{label} is missing min_score or max_score"
+      elsif t.max_score <= t.min_score
+        errors << "tier #{label} has max_score not greater than min_score"
+      else
+        valid << t
+      end
+    end
+
+    return errors + ['tier coverage is empty'] if valid.empty?
+
+    proposed = valid.sort_by { |t| t.min_score.to_f }
+    errors << 'tier coverage must start at 0.00' if proposed.first.min_score.to_f.abs > TIER_QUANTUM
+    errors << 'tier coverage must end at 100.00' if (100.0 - proposed.last.max_score.to_f).abs > TIER_QUANTUM
+
+    proposed.each_cons(2) do |prev_tier, next_tier|
+      gap = next_tier.min_score.to_f - prev_tier.max_score.to_f
+      if gap.negative?
+        errors << "tier overlaps an existing tier near #{prev_tier.max_score}"
+      elsif gap > TIER_QUANTUM + 1e-6
+        errors << "tier leaves a coverage gap between #{prev_tier.max_score} and #{next_tier.min_score}"
+      end
+    end
+
+    errors
+  end
+
+  # Yields with the per-row tier coverage validation suppressed. Use only when
+  # the caller will validate the aggregate post-write state itself — for
+  # example PartyDifficulty::DraftWorkspace#commit!, which pre-validates the
+  # merged canonical+drafts set and then applies multiple tier updates in
+  # sequence whose intermediate states are intentionally inconsistent.
+  def self.with_coverage_validation_skipped
+    prev = Thread.current[:difficulty_skip_coverage_validation]
+    Thread.current[:difficulty_skip_coverage_validation] = true
+    yield
+  ensure
+    Thread.current[:difficulty_skip_coverage_validation] = prev
+  end
+
   private
 
   def max_score_greater_than_min_score
@@ -34,36 +91,12 @@ class Difficulty < ApplicationRecord
     errors.add(:max_score, 'must be greater than min_score') if max_score <= min_score
   end
 
-  # The set of all tiers must tile [0, 100] with no overlaps and no gaps wider
-  # than one score quantum (Calculator#composite_score rounds to 2 decimals, so
-  # adjacent tiers may sit at .99 / .00 with a 0.01 difference). For multi-tier
-  # edits (e.g. splitting one tier in two), batch the changes through
-  # PartyDifficulty::DraftWorkspace so the intermediate state isn't persisted.
-  TIER_QUANTUM = 0.01
-
   def tier_coverage_complete
+    return if Thread.current[:difficulty_skip_coverage_validation]
     return if min_score.blank? || max_score.blank? || max_score <= min_score
 
-    proposed = (Difficulty.where.not(id: id).to_a + [self]).sort_by { |t| t.min_score.to_f }
-
-    if proposed.first.min_score.to_f.abs > TIER_QUANTUM
-      errors.add(:base, 'tier coverage must start at 0.00')
-      return
-    end
-    if (100.0 - proposed.last.max_score.to_f).abs > TIER_QUANTUM
-      errors.add(:base, 'tier coverage must end at 100.00')
-      return
-    end
-
-    proposed.each_cons(2).find do |prev_tier, next_tier|
-      gap = next_tier.min_score.to_f - prev_tier.max_score.to_f
-      if gap.negative?
-        errors.add(:base, "tier overlaps an existing tier near #{prev_tier.max_score}")
-      elsif gap > TIER_QUANTUM + 1e-6
-        errors.add(:base, "tier leaves a coverage gap between #{prev_tier.max_score} and #{next_tier.min_score}")
-      end
-      errors[:base].any?
-    end
+    proposed = Difficulty.where.not(id: id).to_a + [self]
+    self.class.coverage_errors_for(proposed).each { |msg| errors.add(:base, msg) }
   end
 
   def bump_ruleset_version

--- a/app/services/party_difficulty/draft_workspace.rb
+++ b/app/services/party_difficulty/draft_workspace.rb
@@ -15,6 +15,18 @@ module PartyDifficulty
     end
   end
 
+  # Raised by DraftWorkspace#commit! when the merged canonical+drafts tier set
+  # would leave [0, 100] partially uncovered or overlapping. The controller
+  # turns this into a 422 with the full list of aggregate messages.
+  class CoverageError < StandardError
+    attr_reader :messages
+
+    def initialize(messages)
+      @messages = Array(messages)
+      super(@messages.join('; '))
+    end
+  end
+
   ##
   # Per-editor staging layer for difficulty rules / tiers / components.
   # Editors mutate state here via the controllers, hit Preview to validate,
@@ -81,11 +93,19 @@ module PartyDifficulty
     def commit!(note: nil)
       ApplicationRecord.transaction do
         snapshot = diff
+        # Multi-tier boundary edits can't tile [0, 100] mid-save, so validate
+        # the aggregate post-commit set up front and suppress the per-row
+        # coverage check while we apply.
+        coverage_messages = Difficulty.coverage_errors_for(merged_tiers)
+        raise CoverageError, coverage_messages if coverage_messages.any?
+
         # Each apply! triggers the per-record after_save :bump_ruleset_version
         # callback on Difficulty / DifficultyRule / DifficultyComponent, so the
         # version increases by N. The log records the final post-apply version;
         # we don't add an extra explicit bump here.
-        @drafts.each { |draft| apply!(draft) }
+        Difficulty.with_coverage_validation_skipped do
+          @drafts.each { |draft| apply!(draft) }
+        end
         log = DifficultyChangeLog.create!(
           user: @user,
           note: note.presence,
@@ -256,6 +276,9 @@ module PartyDifficulty
       updates = []
       destroys = []
 
+      target_ids = drafts.filter_map { |d| d.target_id unless d.operation == 'create' }.uniq
+      targets_by_id = target_ids.any? ? target_type.constantize.where(id: target_ids).index_by(&:id) : {}
+
       drafts.each do |draft|
         case draft.operation
         when 'create'
@@ -264,7 +287,7 @@ module PartyDifficulty
             attributes: sanitize_attributes(target_type, draft.attributes_payload)
           }
         when 'update'
-          target = draft.target
+          target = targets_by_id[draft.target_id]
           if target.nil?
             updates << stale_entry(draft)
             next
@@ -281,7 +304,7 @@ module PartyDifficulty
             stale: stale_against?(target, draft)
           }
         when 'destroy'
-          target = draft.target
+          target = targets_by_id[draft.target_id]
           if target.nil?
             destroys << stale_entry(draft)
             next

--- a/spec/services/party_difficulty/draft_workspace_spec.rb
+++ b/spec/services/party_difficulty/draft_workspace_spec.rb
@@ -78,6 +78,33 @@ RSpec.describe PartyDifficulty::DraftWorkspace do
       change = diff[:rules][:updates].first
       expect(change[:changes]['weight']).to include(new: 7.5)
     end
+
+    it 'batch-loads targets per section instead of one query per draft' do
+      extra_rules = Array.new(3) do |i|
+        DifficultyRule.create!(
+          name: "Spec rule #{i}", component: 'weapon', rule_type: 'weapon_uncap_at_least',
+          weight: 1.0, active: true,
+          params: { 'min_uncap_level' => 1, 'min_count' => 1 }
+        )
+      end
+      [rule, *extra_rules].each_with_index do |r, i|
+        workspace.stage!(target_type: 'DifficultyRule', target_id: r.id, operation: 'update', attributes: { weight: i + 10.0 })
+      end
+
+      reloaded = described_class.for(user)
+      rule_loads = 0
+      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |_, _, _, _, payload|
+        next if payload[:name] == 'SCHEMA' || payload[:cached]
+        rule_loads += 1 if payload[:sql].include?('FROM "difficulty_rules"')
+      end
+      begin
+        reloaded.diff
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(rule_loads).to eq(1)
+    end
   end
 
   describe '#commit!' do
@@ -92,6 +119,86 @@ RSpec.describe PartyDifficulty::DraftWorkspace do
       expect(log.note).to eq('spec')
       expect(log.ruleset_version_after).to be > starting_version
       expect(DifficultyDraft.for_user(user).count).to eq(0)
+    end
+
+    context 'with multi-tier score boundary edits' do
+      # Seed a 4-tier layout that already tiles [0, 100] so we can stage edits
+      # against it. Seeding requires bypassing the per-row coverage check
+      # because no insertion order is individually valid against an empty DB.
+      let!(:tiers) do
+        Difficulty.delete_all
+        Difficulty.with_coverage_validation_skipped do
+          [
+            Difficulty.create!(name: 'Beginner', slug: 'beginner', min_score: 0.0, max_score: 24.99, sort_order: 0),
+            Difficulty.create!(name: 'Intermediate', slug: 'intermediate', min_score: 25.0, max_score: 49.99, sort_order: 1),
+            Difficulty.create!(name: 'Advanced', slug: 'advanced', min_score: 50.0, max_score: 84.99, sort_order: 2),
+            Difficulty.create!(name: 'Whale', slug: 'whale', min_score: 85.0, max_score: 100.0, sort_order: 3)
+          ]
+        end
+      end
+
+      it 'commits a valid multi-tier rebalance whose intermediate states would individually fail' do
+        intermediate = tiers[1]
+        advanced = tiers[2]
+        workspace.stage!(target_type: 'Difficulty', target_id: intermediate.id, operation: 'update',
+                         attributes: { max_score: 59.99 })
+        workspace.stage!(target_type: 'Difficulty', target_id: advanced.id, operation: 'update',
+                         attributes: { min_score: 60.0 })
+
+        described_class.for(user).commit!(note: 'rebalance')
+
+        expect(intermediate.reload.max_score.to_f).to eq(59.99)
+        expect(advanced.reload.min_score.to_f).to eq(60.0)
+      end
+
+      it 'raises CoverageError and rolls back when the final tier set has a real gap' do
+        intermediate = tiers[1]
+        workspace.stage!(target_type: 'Difficulty', target_id: intermediate.id, operation: 'update',
+                         attributes: { max_score: 40.0 })
+
+        expect do
+          described_class.for(user).commit!(note: 'broken')
+        end.to raise_error(PartyDifficulty::CoverageError, /coverage gap/)
+
+        expect(intermediate.reload.max_score.to_f).to eq(49.99)
+      end
+
+      it 'raises CoverageError when a staged draft inverts a tier bounds (max <= min)' do
+        intermediate = tiers[1]
+        workspace.stage!(target_type: 'Difficulty', target_id: intermediate.id, operation: 'update',
+                         attributes: { min_score: 60.0, max_score: 50.0 })
+
+        expect do
+          described_class.for(user).commit!(note: 'inverted')
+        end.to raise_error(PartyDifficulty::CoverageError, /max_score not greater than min_score/)
+
+        expect(intermediate.reload.min_score.to_f).to eq(25.0)
+        expect(intermediate.reload.max_score.to_f).to eq(49.99)
+      end
+    end
+  end
+
+  describe 'Difficulty.with_coverage_validation_skipped' do
+    let(:bad_tier) do
+      Difficulty.new(name: 'Bad', slug: 'bad', min_score: 0.0, max_score: 5.0, sort_order: 50)
+    end
+
+    it 'suppresses the per-row coverage check inside the block' do
+      Difficulty.with_coverage_validation_skipped do
+        expect(bad_tier).to be_valid
+      end
+    end
+
+    it 'restores per-row coverage validation after the block exits' do
+      Difficulty.with_coverage_validation_skipped { :noop }
+      expect(bad_tier).not_to be_valid
+      expect(bad_tier.errors[:base].join).to include('coverage')
+    end
+
+    it 'restores the flag even if the block raises' do
+      expect { Difficulty.with_coverage_validation_skipped { raise 'boom' } }.to raise_error('boom')
+      expect(Thread.current[:difficulty_skip_coverage_validation]).to be_falsey
+      expect(bad_tier).not_to be_valid
     end
   end
 


### PR DESCRIPTION
## Summary

- `DraftWorkspace#section_diff` batch-loads canonical targets per section instead of issuing one `find_by` per draft (fixes the N+1 detector hit on `difficulty_drafts#diff`).
- `DraftWorkspace#commit!` now pre-validates the merged post-commit tier set via a new `Difficulty.coverage_errors_for` and skips per-row coverage validation during the apply loop, so a valid multi-tier rebalance (e.g. shifting Intermediate to 25–59.99 and Advanced to 60–84.99 in one go) no longer trips the transient gap check.
- Coverage failures surface as a new `PartyDifficulty::CoverageError` → 422 in the controller, with aggregate messages including blank/inverted bounds.

## Test plan

- [x] `bundle exec rspec spec/services/party_difficulty/draft_workspace_spec.rb` (18 examples)
- [x] `bundle exec rubocop` on touched files
- [ ] Manual: stage four-tier layout (Beginner 0–24.99, Intermediate 25–59.99, Advanced 60–84.99, Whale 85–100) and commit