### PR TITLE
users#info: optional check_collection returns collection_accessible flag

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -60,12 +60,13 @@ module Api
       end
 
       def info
-        if ActiveModel::Type::Boolean.new.cast(params[:check_collection]) &&
-           !@user.collection_viewable_by?(current_user)
-          return render_forbidden_response('This collection is private')
+        payload = UserBlueprint.render_as_hash(@user, view: :minimal)
+
+        if ActiveModel::Type::Boolean.new.cast(params[:check_collection])
+          payload[:collection_accessible] = @user.collection_viewable_by?(current_user)
         end
 
-        render json: UserBlueprint.render(@user, view: :minimal)
+        render json: payload
       end
 
       def search

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -60,6 +60,11 @@ module Api
       end
 
       def info
+        if ActiveModel::Type::Boolean.new.cast(params[:check_collection]) &&
+           !@user.collection_viewable_by?(current_user)
+          return render_forbidden_response('This collection is private')
+        end
+
         render json: UserBlueprint.render(@user, view: :minimal)
       end
 

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -54,36 +54,41 @@ RSpec.describe 'Api::V1::Users', type: :request do
     context 'with check_collection=true' do
       let(:private_user) { create(:user, collection_privacy: :private_collection) }
 
-      it 'returns 403 for a private collection when viewed by a stranger' do
+      it 'returns collection_accessible=false for a private collection viewed by a stranger' do
         get "/api/v1/users/info/#{private_user.username}", params: { check_collection: 'true' }
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['collection_accessible']).to eq(false)
       end
 
-      it 'returns 403 for a private collection when viewed unauthenticated' do
+      it 'returns collection_accessible=false unauthenticated' do
         get "/api/v1/users/info/#{private_user.username}?check_collection=true"
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['collection_accessible']).to eq(false)
       end
 
-      it 'allows the owner to view their own private collection' do
+      it 'returns collection_accessible=true for the owner' do
         owner_token = Doorkeeper::AccessToken.create!(
           resource_owner_id: private_user.id, expires_in: 30.days, scopes: 'public'
         )
         get "/api/v1/users/info/#{private_user.username}?check_collection=true",
             headers: { 'Authorization' => "Bearer #{owner_token.token}" }
         expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['collection_accessible']).to eq(true)
       end
 
-      it 'allows public collections without authentication' do
+      it 'returns collection_accessible=true for a public collection unauthenticated' do
         public_user = create(:user, collection_privacy: :everyone)
         get "/api/v1/users/info/#{public_user.username}?check_collection=true"
         expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['collection_accessible']).to eq(true)
       end
     end
 
-    it 'ignores the collection privacy without check_collection' do
+    it 'omits collection_accessible without check_collection' do
       private_user = create(:user, collection_privacy: :private_collection)
       get "/api/v1/users/info/#{private_user.username}"
       expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).not_to have_key('collection_accessible')
     end
   end
 

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -50,6 +50,41 @@ RSpec.describe 'Api::V1::Users', type: :request do
       expect(json['id']).to eq(user.id)
       expect(json['username']).to eq(user.username)
     end
+
+    context 'with check_collection=true' do
+      let(:private_user) { create(:user, collection_privacy: :private_collection) }
+
+      it 'returns 403 for a private collection when viewed by a stranger' do
+        get "/api/v1/users/info/#{private_user.username}", params: { check_collection: 'true' }
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'returns 403 for a private collection when viewed unauthenticated' do
+        get "/api/v1/users/info/#{private_user.username}?check_collection=true"
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'allows the owner to view their own private collection' do
+        owner_token = Doorkeeper::AccessToken.create!(
+          resource_owner_id: private_user.id, expires_in: 30.days, scopes: 'public'
+        )
+        get "/api/v1/users/info/#{private_user.username}?check_collection=true",
+            headers: { 'Authorization' => "Bearer #{owner_token.token}" }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows public collections without authentication' do
+        public_user = create(:user, collection_privacy: :everyone)
+        get "/api/v1/users/info/#{public_user.username}?check_collection=true"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    it 'ignores the collection privacy without check_collection' do
+      private_user = create(:user, collection_privacy: :private_collection)
+      get "/api/v1/users/info/#{private_user.username}"
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe 'GET /api/v1/users/:id' do


### PR DESCRIPTION
## Summary

- Adds optional \`check_collection\` query param to \`GET /users/info/:id\`. When truthy, the response includes a \`collection_accessible\` boolean computed from \`User#collection_viewable_by?(current_user)\` (honoring the everyone / crew_only / private_collection enum).
- Behavior unchanged when the param is absent — existing callers (e.g. crew roster) keep getting the plain payload.
- Used by the frontend's \`(profile)\` layout so collection routes can render an inline "this collection is private" message while keeping the profile header mounted and the other tabs navigable.

## Test plan

- [x] \`rspec spec/requests/api/v1/users_spec.rb\` — new specs cover the four cases (private + stranger / unauth / owner, public + unauth) and assert the baseline doesn't include the field.