### PR TITLE
Scope grid conflict resolution to party

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Hensei is a Ruby on Rails API for managing Granblue Fantasy party configurations
 
 ## Prerequisites
 
-- Ruby 3.3.7
+- Ruby 3.4.4
 - Rails 8.0.1
 - PostgreSQL
 - AWS S3 Account (for image storage)
@@ -30,11 +30,11 @@ cd hensei-api
 
 ### 2. Install Ruby
 
-Ensure you have Ruby 3.3.7 installed. If using rbenv:
+Ensure you have Ruby 3.4.4 installed. If using rbenv:
 
 ```bash
-rbenv install 3.3.7
-rbenv local 3.3.7
+rbenv install 3.4.4
+rbenv local 3.4.4
 ```
 
 ### 3. Install Dependencies

--- a/app/controllers/api/v1/grid_characters_controller.rb
+++ b/app/controllers/api/v1/grid_characters_controller.rb
@@ -206,7 +206,7 @@ module Api
         incoming = find_by_any_id(Character, resolve_params[:incoming])
         render_not_found_response('character') and return unless incoming
 
-        conflicting = resolve_params[:conflicting].map { |id| GridCharacter.find_by(id: id) }.compact
+        conflicting = GridCharacter.where(id: resolve_params[:conflicting], party_id: @party.id)
         conflicting.each(&:destroy)
 
         if (existing = GridCharacter.find_by(party_id: @party.id, position: resolve_params[:position]))

--- a/app/controllers/api/v1/grid_weapons_controller.rb
+++ b/app/controllers/api/v1/grid_weapons_controller.rb
@@ -224,7 +224,7 @@ module Api
       def resolve
         incoming = find_by_any_id(Weapon, resolve_params[:incoming])
         conflicting_ids = resolve_params[:conflicting]
-        conflicting_weapons = GridWeapon.where(id: conflicting_ids)
+        conflicting_weapons = GridWeapon.where(id: conflicting_ids, party_id: @party.id)
 
         # Destroy each conflicting weapon
         conflicting_weapons.each(&:destroy)

--- a/spec/requests/api/v1/grid_characters_spec.rb
+++ b/spec/requests/api/v1/grid_characters_spec.rb
@@ -323,6 +323,25 @@ RSpec.describe 'GridCharacters API', type: :request do
       expect(json_response['grid_character']).to include('position' => 4)
       expect { conflicting_character.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it 'does not destroy conflicting character ids from another party' do
+      other_party = create(:party, user: create(:user))
+      other_conflicting_character = create(:grid_character,
+                                           party: other_party,
+                                           character: incoming_character,
+                                           position: 4,
+                                           uncap_level: 3)
+
+      resolve_params[:resolve][:conflicting] = [conflicting_character.id, other_conflicting_character.id]
+
+      expect do
+        post '/api/v1/grid_characters/resolve', params: resolve_params.to_json, headers: headers
+      end.to change(GridCharacter, :count).by(0)
+
+      expect(response).to have_http_status(:created)
+      expect { conflicting_character.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(other_conflicting_character.reload).to be_persisted
+    end
   end
 
   describe 'DELETE /api/v1/grid_characters (destroy action)' do

--- a/spec/requests/api/v1/grid_weapons_spec.rb
+++ b/spec/requests/api/v1/grid_weapons_spec.rb
@@ -277,6 +277,25 @@ RSpec.describe 'GridWeapons API', type: :request do
       expect(response.parsed_body['grid_weapon']).to include('uncap_level' => 4, 'position' => 5)
       expect { conflicting_weapon.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it 'does not destroy conflicting weapon ids from another party' do
+      other_party = create(:party, user: create(:user))
+      other_conflicting_weapon = create(:grid_weapon,
+                                        party: other_party,
+                                        weapon: weapon,
+                                        position: 5,
+                                        uncap_level: 3)
+
+      resolve_params[:resolve][:conflicting] = [conflicting_weapon.id, other_conflicting_weapon.id]
+
+      expect do
+        post '/api/v1/grid_weapons/resolve', params: resolve_params.to_json, headers: headers
+      end.to change(GridWeapon, :count).by(0)
+
+      expect(response).to have_http_status(:created)
+      expect { conflicting_weapon.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(other_conflicting_weapon.reload).to be_persisted
+    end
   end
 
   describe 'DELETE /api/v1/grid_weapons/:id (destroy action)' do


### PR DESCRIPTION
## Summary
- Scope grid weapon and character conflict resolution deletes to the authorized party
- Add cross-party regression coverage for conflict resolution endpoints
- Update README Ruby version from 3.3.7 to 3.4.4

## Tests
- bundle exec rspec spec/requests/api/v1/grid_weapons_spec.rb spec/requests/api/v1/grid_characters_spec.rb
- bundle exec rubocop --cache false app/controllers/api/v1/grid_weapons_controller.rb app/controllers/api/v1/grid_characters_controller.rb spec/requests/api/v1/grid_weapons_spec.rb spec/requests/api/v1/grid_characters_spec.rb