### PR TITLE
Fix rubocop offenses on staging

### DIFF
--- a/app/models/grid_weapon.rb
+++ b/app/models/grid_weapon.rb
@@ -421,8 +421,8 @@ class GridWeapon < ApplicationRecord
     grid_by_pos = grid_weapon_bullets.index_by(&:position)
     collection_by_pos = collection_weapon.collection_weapon_bullets.index_by(&:position)
     positions = grid_by_pos.keys | collection_by_pos.keys
-    positions.sort.select do |position|
-      grid_by_pos[position]&.bullet_id != collection_by_pos[position]&.bullet_id
+    positions.sort.reject do |position|
+      grid_by_pos[position]&.bullet_id == collection_by_pos[position]&.bullet_id
     end
   end
 

--- a/app/services/notes_sync.rb
+++ b/app/services/notes_sync.rb
@@ -19,14 +19,12 @@ module NotesSync
   # @param item [GridWeapon, GridSummon]
   # @return [ActiveRecord::Relation<GridWeapon, GridSummon>]
   def siblings(item)
+    # GridCharacter and anything else aren't part of any sync group (returns nil).
     case item
     when GridWeapon
       item.party.weapons.where(weapon_id: item.weapon_id).where.not(id: item.id)
     when GridSummon
       item.party.summons.where(summon_id: item.summon_id).where.not(id: item.id)
-    else
-      # GridCharacter and anything else aren't part of any sync group.
-      nil
     end
   end
 

--- a/lib/granblue/parsers/jp_wiki_skill_parser.rb
+++ b/lib/granblue/parsers/jp_wiki_skill_parser.rb
@@ -118,7 +118,7 @@ module Granblue
       end
 
       def skill_image_id(images)
-        images.map { |alt| alt[/\A(\d+_\d+)\.png\z/, 1] }.compact.first
+        images.filter_map { |alt| alt[/\A(\d+_\d+)\.png\z/, 1] }.first
       end
 
       def level_value(text)

--- a/spec/models/party_spec.rb
+++ b/spec/models/party_spec.rb
@@ -102,7 +102,6 @@ RSpec.describe Party, type: :model do
         expect(party.errors[:visibility]).to include(/is not a number/)
       end
     end
-
   end
 
   describe '#is_remix' do

--- a/spec/requests/api/v1/parties_spec.rb
+++ b/spec/requests/api/v1/parties_spec.rb
@@ -555,5 +555,4 @@ RSpec.describe 'Parties API', type: :request do
       expect(results.first).to include('shortcode' => party.shortcode)
     end
   end
-
 end


### PR DESCRIPTION
Clears the 5 rubocop offenses failing staging CI:
- `grid_weapon.rb` — `reject` instead of inverting `select` (InverseMethods)
- `notes_sync.rb` — drop redundant `else nil` (EmptyElse), comment relocated
- `jp_wiki_skill_parser.rb` — `filter_map` instead of `map { }.compact` (MapCompact)
- `party_spec.rb` / `parties_spec.rb` — trailing blank line in block body (EmptyLinesAroundBlockBody)

`bundle exec rubocop`: 624 files, 0 offenses. Behavior-preserving.