### PR TITLE
Reorganize image bucket (API write path + migration runbook/scripts)

### DIFF
--- a/bin/migrate-image-bucket-cleanup.sh
+++ b/bin/migrate-image-bucket-cleanup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# migrate-image-bucket-cleanup.sh — FINAL step of the image bucket reorganization.
+#
+# Deletes the old prefixes (now duplicated under the new structure) plus the orphans
+# that were never migrated. Run ONLY after the copy pass + both deploys have soaked
+# and you've confirmed no image 404s. This is destructive.
+#
+# See docs/follow-ups/image-bucket-reorg.md.
+#
+# Usage:
+#   BUCKET=s3://your-bucket bin/migrate-image-bucket-cleanup.sh           # dry run
+#   BUCKET=s3://your-bucket APPLY=1 bin/migrate-image-bucket-cleanup.sh   # actually delete
+set -euo pipefail
+
+BUCKET="${BUCKET:?Set BUCKET, e.g. BUCKET=s3://siero-img}"
+APPLY="${APPLY:-0}"
+
+run() {
+	if [[ "$APPLY" == "1" ]]; then
+		aws s3 "$@"
+	else
+		echo "DRY-RUN: aws s3 $*"
+	fi
+}
+
+# Old prefixes that were copied to new homes in the copy pass.
+OLD_PREFIXES=(
+	character-main character-grid character-square character-detail
+	weapon-main weapon-grid weapon-square weapon-base
+	summon-main summon-grid summon-square summon-detail summon-tall summon-wide
+	accessory-square accessory-grid artifact-square artifact-wide bullet-square
+	job-icons job-portraits job-wide job-zoom jobs
+	raid-thumbnail raids
+	ability-icons job-skills elements proficiencies rarity awakening mastery ax
+	fonts placeholders external media
+)
+
+# Orphans never migrated: weapon-raw (dup of weapon-base, unused) and raid-square
+# (aspirational, no source). The duplicate nested images/media/ is dropped too.
+ORPHAN_PREFIXES=(weapon-raw raid-square images/media)
+
+for p in "${OLD_PREFIXES[@]}" "${ORPHAN_PREFIXES[@]}"; do
+	echo "==> rm $p/"
+	run rm "$BUCKET/$p/" --recursive
+done
+
+# Loose marketing files now live under app/marketing/.
+for f in about-hero.jpg about-hero2.jpg background_a.jpg port-breeze.jpg relief.png .DS_Store; do
+	echo "==> rm $f"
+	run rm "$BUCKET/$f"
+done
+
+echo
+[[ "$APPLY" == "1" ]] || echo "(this was a DRY RUN — re-run with APPLY=1 to delete)"

--- a/bin/migrate-image-bucket-cleanup.sh
+++ b/bin/migrate-image-bucket-cleanup.sh
@@ -24,14 +24,15 @@ run() {
 	fi
 }
 
-# Old prefixes that were copied to new homes in the copy pass.
+# Old prefixes that were copied to new homes in the copy pass. Safe to recursively
+# delete because none nests under a new group prefix.
 OLD_PREFIXES=(
 	character-main character-grid character-square character-detail
 	weapon-main weapon-grid weapon-square weapon-base
 	summon-main summon-grid summon-square summon-detail summon-tall summon-wide
 	accessory-square accessory-grid artifact-square artifact-wide bullet-square
-	job-icons job-portraits job-wide job-zoom jobs
-	raid-thumbnail raids
+	job-icons job-portraits job-wide job-zoom
+	raid-thumbnail
 	ability-icons job-skills elements proficiencies rarity awakening mastery ax
 	fonts placeholders external media
 )
@@ -43,6 +44,15 @@ ORPHAN_PREFIXES=(weapon-raw raid-square images/media)
 for p in "${OLD_PREFIXES[@]}" "${ORPHAN_PREFIXES[@]}"; do
 	echo "==> rm $p/"
 	run rm "$BUCKET/$p/" --recursive
+done
+
+# `jobs/` and `raids/` are special: the OLD assets sit directly under the prefix
+# (e.g. jobs/100101.jpg), but the NEW structure ALSO nests under them (jobs/full/,
+# jobs/icon/, raids/thumbnail/, …). Delete ONLY the old direct children — `--exclude
+# "*/*"` keeps anything in a subdirectory — so the migrated content survives.
+for p in jobs raids; do
+	echo "==> rm $p/ (direct children only; preserving $p/<new-subdirs>/)"
+	run rm "$BUCKET/$p/" --recursive --exclude "*/*"
 done
 
 # Loose marketing files now live under app/marketing/.

--- a/bin/migrate-image-bucket.sh
+++ b/bin/migrate-image-bucket.sh
@@ -3,8 +3,9 @@
 # migrate-image-bucket.sh — STEP 1 of the image bucket reorganization.
 #
 # Copies every old prefix to its new home (additive; old keys stay live so nothing
-# 404s mid-migration). Run this BEFORE deploying hensei-web / hensei-api. After a
-# soak, run migrate-image-bucket-cleanup.sh to delete the old prefixes + orphans.
+# 404s mid-migration). Run this BEFORE promoting staging -> main (the deploy that
+# serves new-path code). Merging the PRs into staging is safe without it (staging
+# isn't deployed). After a prod soak, run migrate-image-bucket-cleanup.sh.
 #
 # See docs/follow-ups/image-bucket-reorg.md.
 #

--- a/bin/migrate-image-bucket.sh
+++ b/bin/migrate-image-bucket.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# migrate-image-bucket.sh — STEP 1 of the image bucket reorganization.
+#
+# Copies every old prefix to its new home (additive; old keys stay live so nothing
+# 404s mid-migration). Run this BEFORE deploying hensei-web / hensei-api. After a
+# soak, run migrate-image-bucket-cleanup.sh to delete the old prefixes + orphans.
+#
+# See docs/follow-ups/image-bucket-reorg.md.
+#
+# Usage:
+#   BUCKET=s3://your-bucket bin/migrate-image-bucket.sh           # dry run (prints only)
+#   BUCKET=s3://your-bucket APPLY=1 bin/migrate-image-bucket.sh   # actually copy
+#
+# previews/ profile/ updates/ guidebooks/ labels/ weapon-keys/ favicon.png and all
+# editor-uploaded icons (grid_character_roles/, images/difficulties/) are intentionally
+# left in place.
+set -euo pipefail
+
+BUCKET="${BUCKET:?Set BUCKET, e.g. BUCKET=s3://siero-img}"
+APPLY="${APPLY:-0}"
+
+run() {
+	if [[ "$APPLY" == "1" ]]; then
+		aws s3 "$@"
+	else
+		echo "DRY-RUN: aws s3 $*"
+	fi
+}
+
+# old:new prefix pairs (no trailing slash). weapon-raw and raid-square are NOT here —
+# they are orphans removed in the cleanup pass, not migrated.
+MAP=(
+	"character-main:characters/main" "character-grid:characters/grid"
+	"character-square:characters/square" "character-detail:characters/detail"
+	"weapon-main:weapons/main" "weapon-grid:weapons/grid" "weapon-square:weapons/square"
+	"weapon-base:weapons/base"
+	"summon-main:summons/main" "summon-grid:summons/grid" "summon-square:summons/square"
+	"summon-detail:summons/detail" "summon-tall:summons/tall" "summon-wide:summons/wide"
+	"accessory-square:accessories/square" "accessory-grid:accessories/grid"
+	"artifact-square:artifacts/square" "artifact-wide:artifacts/wide"
+	"bullet-square:bullets/square"
+	"job-icons:jobs/icon" "job-portraits:jobs/portrait" "job-wide:jobs/wide"
+	"job-zoom:jobs/zoom" "jobs:jobs/full"
+	"raid-thumbnail:raids/thumbnail" "raids:raids/full"
+	"ability-icons:icons/abilities" "job-skills:icons/job-skills"
+	"elements:icons/elements" "proficiencies:icons/proficiencies" "rarity:icons/rarity"
+	"awakening:icons/awakening" "mastery:icons/mastery" "ax:icons/ax-skills"
+	"fonts:app/fonts" "placeholders:app/placeholders" "external:app/external" "media:app/media"
+)
+
+for pair in "${MAP[@]}"; do
+	old="${pair%%:*}"
+	new="${pair##*:}"
+	echo "==> $old/ -> $new/"
+	run cp "$BUCKET/$old/" "$BUCKET/$new/" --recursive
+done
+
+# Loose marketing files at the bucket root.
+for f in about-hero.jpg about-hero2.jpg background_a.jpg port-breeze.jpg relief.png; do
+	echo "==> $f -> app/marketing/$f"
+	run cp "$BUCKET/$f" "$BUCKET/app/marketing/$f"
+done
+
+echo
+echo "Copy pass complete. Next: deploy both repos, soak, then run migrate-image-bucket-cleanup.sh."
+[[ "$APPLY" == "1" ]] || echo "(this was a DRY RUN — re-run with APPLY=1 to copy)"

--- a/docs/follow-ups/image-bucket-reorg.md
+++ b/docs/follow-ups/image-bucket-reorg.md
@@ -21,13 +21,13 @@ path) **and** the S3 bucket simultaneously.
 
 ```
 characters/{main,grid,square,detail}/        # was character-{main,grid,square,detail}
-weapons/{main,grid,square,base,raw}/          # was weapon-{main,grid,square,base,raw}
+weapons/{main,grid,square,base}/              # was weapon-{main,grid,square,base}; weapon-raw REMOVED (orphan)
 summons/{main,grid,square,detail,tall,wide}/  # was summon-{…}
 accessories/{square,grid}/                    # was accessory-{square,grid}
 artifacts/{square,wide}/                       # was artifact-{square,wide}
 bullets/square/                                # was bullet-square
 jobs/{icon,portrait,wide,zoom,full}/           # was job-icons, job-portraits, job-wide, job-zoom, jobs
-raids/{icon,thumbnail,lobby,background,full}/  # was raid-{icon,thumbnail,lobby,background}, raids
+raids/{icon,thumbnail,lobby,background,full}/  # was raid-{icon,thumbnail,lobby,background}, raids; raid-square DROPPED
 guidebooks/                                    # unchanged
 
 icons/abilities/        # was ability-icons
@@ -38,7 +38,7 @@ icons/rarity/           # was rarity
 icons/awakening/        # was awakening
 icons/mastery/          # was mastery
 icons/ax-skills/        # was ax              (rename: clarify cryptic "ax")
-icons/weapon-keys/      # was weapon-keys
+weapon-keys/            # unchanged (stays top-level)
 labels/{element,proficiency,race,gender}/     # unchanged (already grouped)
 
 app/fonts/              # was fonts
@@ -50,29 +50,27 @@ app/marketing/          # was loose root files: about-hero.jpg, about-hero2.jpg,
 favicon.png             # stays at root (served as site favicon)
 
 previews/               # UNCHANGED (og:image; externally cached)
-profile/                # UNCHANGED for now — see open question
-updates/                # UNCHANGED for now — see open question
+profile/                # UNCHANGED
+updates/                # UNCHANGED
 ```
 
-## Open questions (confirm before executing)
+## Decisions (confirmed)
 
-1. **`profile/`** (84 files) — `getProfileIcon()` builds `profile/{slug}`. Doc-comment says
-   "site-brand icons (gamewith/kamigame)" but those live in `external/`, and the dir has 84
-   files. Leave as `profile/` (safe) or fold somewhere? **Default: leave.**
-2. **`updates/`** (60 files) — changelog images. Move to `app/updates/` or leave? **Default: leave.**
-3. **`raid-square/`** (1 file) — looks vestigial; `getRaidImage` builds icon/thumbnail/lobby/
-   background, not square. Drop it or map to `raids/square/`? **Default: drop (verify the 1 file).**
-4. **`weapon-base` vs `weapon-raw`** — keep both names under `weapons/` (`base`, `raw`) or
-   rename for clarity? **Default: keep `base`/`raw`.**
-5. **`weapon-keys`** → `icons/weapon-keys` (grouped as an icon set) vs keep top-level. **Default: icons/weapon-keys.**
+1. **`profile/`** — keep as-is.
+2. **`updates/`** — keep as-is.
+3. **`raid-square/`** — **drop.** Aspirational; no source for the images. (Single stray file.)
+4. **`weapon-raw/`** — **remove entirely.** Duplicate of `weapon-base` (same image); orphan with
+   no producer (API) and no consumer (app), so removal is a pure S3 delete — no code changes.
+   `weapon-base` is the live one → `weapons/base`.
+5. **`weapon-keys/`** — keep top-level (not moved under `icons/`).
 
 ## Read-path inventory (hensei-svelte)
 
 | File | What to change |
 |---|---|
-| `src/lib/utils/images.ts` | The hub. `getImageDirectory`, placeholders, accessory/artifact/bullet/awakening/weapon-key/ax/mastery/elements/labels/profile/guidebook/raid builders → new prefixes. **Do NOT change** `GAME_CDN_BASE`, `RAID_*_CDN`. |
+| `src/lib/utils/images.ts` | The hub. `getImageDirectory`, placeholders, accessory/artifact/bullet/awakening/ax/mastery/elements/labels/guidebook/raid builders → new prefixes. `weapon-keys`, `profile`, `guidebooks` stay top-level. **Do NOT change** `GAME_CDN_BASE`, `RAID_*_CDN`. |
 | `src/lib/utils/jobUtils.ts` | `job-icons`, `job-portraits`, `job-wide`, `job-zoom` → `jobs/{icon,portrait,wide,zoom}`. |
-| `src/lib/utils/modifiers.ts` | `weapon-keys` → `icons/weapon-keys`; `awakening` → `icons/awakening`. |
+| `src/lib/utils/modifiers.ts` | `awakening` → `icons/awakening` (weapon-keys stays top-level — unchanged). |
 | `src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts` | `character-square`/`{type}-square` → `characters/square` etc.; `ability-icons` → `icons/abilities`. |
 | `src/lib/features/database/weapons/AwakeningModal.svelte` | inline `awakening/` → `icons/awakening/` (or route through `getAwakeningImage`). |
 | Tests | `images.test.ts`, `jobUtils.test.ts`, `modifiers.test.ts`, mention `helpers.test.ts`/`normalize.test.ts` — update asserted paths. |
@@ -110,7 +108,7 @@ MAP=(
   "character-main:characters/main" "character-grid:characters/grid"
   "character-square:characters/square" "character-detail:characters/detail"
   "weapon-main:weapons/main" "weapon-grid:weapons/grid" "weapon-square:weapons/square"
-  "weapon-base:weapons/base" "weapon-raw:weapons/raw"
+  "weapon-base:weapons/base"   # weapon-raw intentionally omitted (removed, not migrated)
   "summon-main:summons/main" "summon-grid:summons/grid" "summon-square:summons/square"
   "summon-detail:summons/detail" "summon-tall:summons/tall" "summon-wide:summons/wide"
   "accessory-square:accessories/square" "accessory-grid:accessories/grid"
@@ -122,9 +120,9 @@ MAP=(
   "ability-icons:icons/abilities" "job-skills:icons/job-skills"
   "elements:icons/elements" "proficiencies:icons/proficiencies" "rarity:icons/rarity"
   "awakening:icons/awakening" "mastery:icons/mastery" "ax:icons/ax-skills"
-  "weapon-keys:icons/weapon-keys"
   "fonts:app/fonts" "placeholders:app/placeholders" "external:app/external" "media:app/media"
 )
+# Unchanged (NOT migrated): weapon-keys/ profile/ updates/ guidebooks/ labels/ previews/ favicon.png
 for pair in "${MAP[@]}"; do
   old="${pair%%:*}"; new="${pair##*:}"
   echo "==> $old/ -> $new/"
@@ -138,6 +136,8 @@ echo "Copy complete. Deploy repos, soak, then run the --delete pass."
 ```
 
 A second script (post-soak) does `aws s3 rm "$BUCKET/$old/" --recursive` per old prefix.
+The same delete pass also removes the orphans that were never migrated:
+`weapon-raw/`, `raid-square/`, the duplicate nested `images/media/`, and stray `.DS_Store`.
 
 ## Cutover order (zero-downtime)
 
@@ -148,4 +148,3 @@ A second script (post-soak) does `aws s3 rm "$BUCKET/$old/" --recursive` per old
 4. Soak (e.g. 1–2 weeks); watch for image 404s.
 5. Run delete script → remove old prefixes. Also remove the duplicate `media/extension.mp4`
    nested copy and stray `.DS_Store`.
-```

--- a/docs/follow-ups/image-bucket-reorg.md
+++ b/docs/follow-ups/image-bucket-reorg.md
@@ -1,0 +1,151 @@
+# Image bucket reorganization
+
+Status: **proposed** — mapping below must be confirmed before execution, because the
+new prefixes are baked into two repos (`hensei-svelte` read path, `hensei-api` write
+path) **and** the S3 bucket simultaneously.
+
+## Principles
+
+- The local `static/images/` folder is **git-ignored** — a disposable dev mirror. The
+  **S3 bucket is the source of truth.**
+- All read URLs are built in `hensei-svelte/src/lib/utils/images.ts` (+ a few strays).
+  All writes come from `hensei-api` downloaders/services.
+- **`previews/` is NOT touched.** It is managed render output used as `og:image`; those
+  URLs are cached by external sites/Discord, so re-keying would break shared links.
+- **Game-CDN URLs are NOT touched** (`prd-game-a*.akamaized.net …`). Only our own bucket
+  prefixes move.
+- Cutover is **copy-first** (additive), so nothing 404s mid-migration and rollback is just
+  a code revert. Old prefixes are deleted only after a soak.
+
+## Target structure
+
+```
+characters/{main,grid,square,detail}/        # was character-{main,grid,square,detail}
+weapons/{main,grid,square,base,raw}/          # was weapon-{main,grid,square,base,raw}
+summons/{main,grid,square,detail,tall,wide}/  # was summon-{…}
+accessories/{square,grid}/                    # was accessory-{square,grid}
+artifacts/{square,wide}/                       # was artifact-{square,wide}
+bullets/square/                                # was bullet-square
+jobs/{icon,portrait,wide,zoom,full}/           # was job-icons, job-portraits, job-wide, job-zoom, jobs
+raids/{icon,thumbnail,lobby,background,full}/  # was raid-{icon,thumbnail,lobby,background}, raids
+guidebooks/                                    # unchanged
+
+icons/abilities/        # was ability-icons
+icons/job-skills/       # was job-skills
+icons/elements/         # was elements
+icons/proficiencies/    # was proficiencies
+icons/rarity/           # was rarity
+icons/awakening/        # was awakening
+icons/mastery/          # was mastery
+icons/ax-skills/        # was ax              (rename: clarify cryptic "ax")
+icons/weapon-keys/      # was weapon-keys
+labels/{element,proficiency,race,gender}/     # unchanged (already grouped)
+
+app/fonts/              # was fonts
+app/placeholders/       # was placeholders
+app/external/           # was external (site logos)
+app/media/              # was media (+ dedupe: drop nested images/media/)
+app/marketing/          # was loose root files: about-hero.jpg, about-hero2.jpg,
+                        #   background_a.jpg, port-breeze.jpg, relief.png
+favicon.png             # stays at root (served as site favicon)
+
+previews/               # UNCHANGED (og:image; externally cached)
+profile/                # UNCHANGED for now — see open question
+updates/                # UNCHANGED for now — see open question
+```
+
+## Open questions (confirm before executing)
+
+1. **`profile/`** (84 files) — `getProfileIcon()` builds `profile/{slug}`. Doc-comment says
+   "site-brand icons (gamewith/kamigame)" but those live in `external/`, and the dir has 84
+   files. Leave as `profile/` (safe) or fold somewhere? **Default: leave.**
+2. **`updates/`** (60 files) — changelog images. Move to `app/updates/` or leave? **Default: leave.**
+3. **`raid-square/`** (1 file) — looks vestigial; `getRaidImage` builds icon/thumbnail/lobby/
+   background, not square. Drop it or map to `raids/square/`? **Default: drop (verify the 1 file).**
+4. **`weapon-base` vs `weapon-raw`** — keep both names under `weapons/` (`base`, `raw`) or
+   rename for clarity? **Default: keep `base`/`raw`.**
+5. **`weapon-keys`** → `icons/weapon-keys` (grouped as an icon set) vs keep top-level. **Default: icons/weapon-keys.**
+
+## Read-path inventory (hensei-svelte)
+
+| File | What to change |
+|---|---|
+| `src/lib/utils/images.ts` | The hub. `getImageDirectory`, placeholders, accessory/artifact/bullet/awakening/weapon-key/ax/mastery/elements/labels/profile/guidebook/raid builders → new prefixes. **Do NOT change** `GAME_CDN_BASE`, `RAID_*_CDN`. |
+| `src/lib/utils/jobUtils.ts` | `job-icons`, `job-portraits`, `job-wide`, `job-zoom` → `jobs/{icon,portrait,wide,zoom}`. |
+| `src/lib/utils/modifiers.ts` | `weapon-keys` → `icons/weapon-keys`; `awakening` → `icons/awakening`. |
+| `src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts` | `character-square`/`{type}-square` → `characters/square` etc.; `ability-icons` → `icons/abilities`. |
+| `src/lib/features/database/weapons/AwakeningModal.svelte` | inline `awakening/` → `icons/awakening/` (or route through `getAwakeningImage`). |
+| Tests | `images.test.ts`, `jobUtils.test.ts`, `modifiers.test.ts`, mention `helpers.test.ts`/`normalize.test.ts` — update asserted paths. |
+
+**Strategy:** centralize all bucket dir names in one `BUCKET` map in `images.ts`; route the
+strays (jobUtils, modifiers, mentions/helpers, AwakeningModal) through it so the structure
+lives in exactly one place going forward.
+
+`renderRegistry.ts`/`renderCache.ts` use the `previews/` prefix — **unchanged.**
+
+## Write-path inventory (hensei-api)
+
+Downloaders/services that upload to bucket prefixes (mirror the read structure):
+
+- `lib/granblue/downloaders/base_downloader.rb` (+ `character_`, `weapon_`, `summon_`,
+  `artifact_`, `bullet_`, `job_`, `job_accessory_`, `raid_`, `ability_icon_` downloaders)
+- `app/services/{character,weapon,summon,artifact,bullet,raid}_image_download_service.rb`
+- `app/services/icon_storage.rb`, `app/services/aws_service.rb`
+- `lib/tasks/ability_icons.rake`
+- `app/jobs/download_*_images_job.rb`
+
+Game-CDN **source** URLs stay; only the **destination** S3 prefix changes. Update specs.
+
+## Migration script (copy-first)
+
+```bash
+#!/usr/bin/env bash
+# migrate-image-bucket.sh — copy old prefixes to new (additive, idempotent).
+# Run BEFORE deploying the repos. previews/ is intentionally excluded.
+set -euo pipefail
+BUCKET="s3://YOUR_BUCKET"
+
+# old:new pairs
+MAP=(
+  "character-main:characters/main" "character-grid:characters/grid"
+  "character-square:characters/square" "character-detail:characters/detail"
+  "weapon-main:weapons/main" "weapon-grid:weapons/grid" "weapon-square:weapons/square"
+  "weapon-base:weapons/base" "weapon-raw:weapons/raw"
+  "summon-main:summons/main" "summon-grid:summons/grid" "summon-square:summons/square"
+  "summon-detail:summons/detail" "summon-tall:summons/tall" "summon-wide:summons/wide"
+  "accessory-square:accessories/square" "accessory-grid:accessories/grid"
+  "artifact-square:artifacts/square" "artifact-wide:artifacts/wide"
+  "bullet-square:bullets/square"
+  "job-icons:jobs/icon" "job-portraits:jobs/portrait" "job-wide:jobs/wide"
+  "job-zoom:jobs/zoom" "jobs:jobs/full"
+  "raid-thumbnail:raids/thumbnail" "raids:raids/full"
+  "ability-icons:icons/abilities" "job-skills:icons/job-skills"
+  "elements:icons/elements" "proficiencies:icons/proficiencies" "rarity:icons/rarity"
+  "awakening:icons/awakening" "mastery:icons/mastery" "ax:icons/ax-skills"
+  "weapon-keys:icons/weapon-keys"
+  "fonts:app/fonts" "placeholders:app/placeholders" "external:app/external" "media:app/media"
+)
+for pair in "${MAP[@]}"; do
+  old="${pair%%:*}"; new="${pair##*:}"
+  echo "==> $old/ -> $new/"
+  aws s3 cp "$BUCKET/$old/" "$BUCKET/$new/" --recursive
+done
+# loose marketing files
+for f in about-hero.jpg about-hero2.jpg background_a.jpg port-breeze.jpg relief.png; do
+  aws s3 cp "$BUCKET/$f" "$BUCKET/app/marketing/$f"
+done
+echo "Copy complete. Deploy repos, soak, then run the --delete pass."
+```
+
+A second script (post-soak) does `aws s3 rm "$BUCKET/$old/" --recursive` per old prefix.
+
+## Cutover order (zero-downtime)
+
+1. Confirm mapping (this doc).
+2. Run copy script → old + new prefixes both exist in S3.
+3. Merge + deploy `hensei-api` (downloaders write to new prefixes) and `hensei-svelte`
+   (reads from new prefixes). Both old and new work, so order doesn't matter.
+4. Soak (e.g. 1–2 weeks); watch for image 404s.
+5. Run delete script → remove old prefixes. Also remove the duplicate `media/extension.mp4`
+   nested copy and stray `.DS_Store`.
+```

--- a/docs/follow-ups/image-bucket-reorg.md
+++ b/docs/follow-ups/image-bucket-reorg.md
@@ -147,10 +147,19 @@ The same delete pass also removes the orphans that were never migrated:
 
 ## Cutover order (zero-downtime)
 
+Deploy topology: `staging` is an integration branch and is **not deployed**; CI/CD deploys
+from `main`. Staging and prod read images from the same bucket (`siero-img`), but since
+staging isn't served, the only deploy that reads new-path code is the one from `main`. So
+the copy gates on the **staging → main** promotion, not on merging into staging.
+
 1. Confirm mapping (this doc).
-2. Run copy script → old + new prefixes both exist in S3.
-3. Merge + deploy `hensei-api` (downloaders write to new prefixes) and `hensei-svelte`
-   (reads from new prefixes). Both old and new work, so order doesn't matter.
-4. Soak (e.g. 1–2 weeks); watch for image 404s.
-5. Run delete script → remove old prefixes. Also remove the duplicate `media/extension.mp4`
-   nested copy and stray `.DS_Store`.
+2. Merge both PRs into `staging` — safe (integration only, no deploy).
+3. Run the **copy** pass (`bin/migrate-image-bucket.sh APPLY=1`) → old + new prefixes both
+   exist. Additive; changes nothing live. Required before the `main` deploy.
+4. Promote `staging → main`. CI/CD deploys: the API writes to new prefixes and the web reads
+   from them — and the keys now exist. Old keys remain as a rollback safety net.
+5. Soak (e.g. 1–2 weeks); watch for image 404s. Rollback = revert the deploy (old keys still
+   present), no bucket changes needed.
+6. Run the **delete** pass (`bin/migrate-image-bucket-cleanup.sh APPLY=1`) → remove old
+   prefixes + orphans (`weapon-raw/`, `raid-square/`, duplicate nested `images/media/`,
+   `.DS_Store`). Destructive — only after prod has soaked.

--- a/docs/follow-ups/image-bucket-reorg.md
+++ b/docs/follow-ups/image-bucket-reorg.md
@@ -64,6 +64,12 @@ updates/                # UNCHANGED
    `weapon-base` is the live one → `weapons/base`.
 5. **`weapon-keys/`** — keep top-level (not moved under `icons/`).
 
+**Editor-uploaded icons are unaffected.** Grid-character-role icons (`grid_character_roles/`)
+and difficulty images (`images/difficulties/`, incl. `_drafts/`) are written by `IconStorage`
+with their own prefixes and stored as `icon_key`/`image_key` on records, then rendered via the
+generic `buildEntityIconUrl`. None of these prefixes are in the migration MAP, so stored keys
+keep resolving — no data migration needed for them.
+
 ## Read-path inventory (hensei-svelte)
 
 | File | What to change |

--- a/lib/granblue/downloaders/ability_icon_downloader.rb
+++ b/lib/granblue/downloaders/ability_icon_downloader.rb
@@ -50,7 +50,7 @@ module Granblue
 
       # Stem is the storage key; no size subdirectory.
       def build_s3_key(_size, filename)
-        "#{object_type}/#{filename}"
+        "icons/abilities/#{filename}"
       end
 
       def download_path(_size)

--- a/lib/granblue/downloaders/base_downloader.rb
+++ b/lib/granblue/downloaders/base_downloader.rb
@@ -206,12 +206,20 @@ module Granblue
         "#{Rails.root}/download/#{object_type}-#{size}"
       end
 
+      # S3 prefix for this object type. Defaults to the pluralized object_type
+      # (character -> characters); override where pluralization differs (e.g. accessory).
+      # See the bucket layout in hensei-api/docs/follow-ups/image-bucket-reorg.md.
+      # @return [String] S3 prefix (no trailing slash)
+      def bucket_directory
+        "#{object_type}s"
+      end
+
       # Build S3 key for an image
       # @param size [String] Image size variant
       # @param filename [String] Image filename
       # @return [String] Complete S3 key
       def build_s3_key(size, filename)
-        "#{object_type}-#{size}/#{filename}"
+        "#{bucket_directory}/#{size}/#{filename}"
       end
 
       # Log informational message if verbose

--- a/lib/granblue/downloaders/job_accessory_downloader.rb
+++ b/lib/granblue/downloaders/job_accessory_downloader.rb
@@ -55,6 +55,12 @@ module Granblue
         'accessory'
       end
 
+      # "accessory" does not pluralize as "accessorys"; use the correct bucket prefix.
+      # @return [String] S3 prefix
+      def bucket_directory
+        'accessories'
+      end
+
       # Gets base URL for job accessory assets.
       # This is set dynamically in #download based on accessory_type.
       # @return [String] Base URL for accessory images

--- a/lib/granblue/downloaders/job_skill_downloader.rb
+++ b/lib/granblue/downloaders/job_skill_downloader.rb
@@ -74,7 +74,7 @@ module Granblue
       # @param filename [String] Image filename
       # @return [String] Complete S3 key
       def build_s3_key(size, filename)
-        "#{object_type}/#{filename}"
+        "icons/job-skills/#{filename}"
       end
 
       # Override download path to not append size

--- a/spec/lib/granblue/downloaders/base_downloader_spec.rb
+++ b/spec/lib/granblue/downloaders/base_downloader_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe Granblue::Downloaders::BaseDownloader do
   describe '#build_s3_key' do
     let(:downloader) { test_downloader_class.new('12345', test_mode: true) }
 
-    it 'constructs S3 key from object_type, size, and filename' do
+    it 'constructs S3 key from bucket_directory, size, and filename' do
       key = downloader.send(:build_s3_key, 'main', '12345.jpg')
-      expect(key).to eq('test_object-main/12345.jpg')
+      expect(key).to eq('test_objects/main/12345.jpg')
     end
   end
 


### PR DESCRIPTION
Part of the image bucket reorganization. **Pairs with hensei-web PR #878 (read path).**

✅ **Safe to merge into `staging`** — staging is an integration branch and isn't deployed, so nothing reads the bucket with new-path code yet.
⚠️ **Before promoting `staging → main`** (the CI/CD deploy), run the copy pass `BUCKET=s3://… APPLY=1 bin/migrate-image-bucket.sh` — additive, old keys stay live. The destructive **delete** pass runs only after prod has soaked. Full sequence in the runbook's "Cutover order".

## What's here
- **Runbook:** `docs/follow-ups/image-bucket-reorg.md` — full old→new mapping, both-repo inventory, cutover order, decisions, "editor-uploaded icons unaffected".
- **Runnable migration scripts** (dry-run by default; `APPLY=1` to execute):
  - `bin/migrate-image-bucket.sh` — copy pass (`previews/` and editor icons excluded).
  - `bin/migrate-image-bucket-cleanup.sh` — delete pass (old prefixes + orphans `weapon-raw/`, `raid-square/`, dup `images/media/`, `.DS_Store`; handles the `jobs/`/`raids/` nesting safely).
- **Downloaders repointed** (`lib/granblue/downloaders/*`): base S3 key → `{bucket_directory}/{size}/` (pluralized `object_type`); `accessory`→`accessories/`; ability/job-skill icons → `icons/abilities` / `icons/job-skills`. Game-CDN *source* URLs and local `download/` staging dirs unchanged.

## New structure (abridged)
`characters/ weapons/ summons/ accessories/ artifacts/ bullets/`, `jobs/{icon,portrait,wide,zoom,full}`, `raids/{…,full}`, `icons/{abilities,job-skills,elements,proficiencies,rarity,awakening,mastery,ax-skills}`, `app/{fonts,placeholders,external,media,marketing}`. Unchanged: `previews/ profile/ updates/ guidebooks/ labels/ weapon-keys/`.

## Testing
Downloader + image-service specs pass (350 examples); rubocop clean.