### PR TITLE
Migrate weapon-skill-icons → icons/weapon-skills

### DIFF
--- a/bin/migrate-image-bucket-cleanup.sh
+++ b/bin/migrate-image-bucket-cleanup.sh
@@ -33,7 +33,7 @@ OLD_PREFIXES=(
 	accessory-square accessory-grid artifact-square artifact-wide bullet-square
 	job-icons job-portraits job-wide job-zoom
 	raid-thumbnail
-	ability-icons job-skills elements proficiencies rarity awakening mastery ax
+	ability-icons job-skills weapon-skill-icons elements proficiencies rarity awakening mastery ax
 	fonts placeholders external media
 )
 

--- a/bin/migrate-image-bucket.sh
+++ b/bin/migrate-image-bucket.sh
@@ -45,6 +45,7 @@ MAP=(
 	"job-zoom:jobs/zoom" "jobs:jobs/full"
 	"raid-thumbnail:raids/thumbnail" "raids:raids/full"
 	"ability-icons:icons/abilities" "job-skills:icons/job-skills"
+	"weapon-skill-icons:icons/weapon-skills"
 	"elements:icons/elements" "proficiencies:icons/proficiencies" "rarity:icons/rarity"
 	"awakening:icons/awakening" "mastery:icons/mastery" "ax:icons/ax-skills"
 	"fonts:app/fonts" "placeholders:app/placeholders" "external:app/external" "media:app/media"

--- a/docs/follow-ups/image-bucket-reorg.md
+++ b/docs/follow-ups/image-bucket-reorg.md
@@ -32,6 +32,7 @@ guidebooks/                                    # unchanged
 
 icons/abilities/        # was ability-icons
 icons/job-skills/       # was job-skills
+icons/weapon-skills/    # was weapon-skill-icons
 icons/elements/         # was elements
 icons/proficiencies/    # was proficiencies
 icons/rarity/           # was rarity
@@ -124,6 +125,7 @@ MAP=(
   "job-zoom:jobs/zoom" "jobs:jobs/full"
   "raid-thumbnail:raids/thumbnail" "raids:raids/full"
   "ability-icons:icons/abilities" "job-skills:icons/job-skills"
+  "weapon-skill-icons:icons/weapon-skills"
   "elements:icons/elements" "proficiencies:icons/proficiencies" "rarity:icons/rarity"
   "awakening:icons/awakening" "mastery:icons/mastery" "ax:icons/ax-skills"
   "fonts:app/fonts" "placeholders:app/placeholders" "external:app/external" "media:app/media"


### PR DESCRIPTION
New weapon-skill icons were uploaded to S3 under `weapon-skill-icons/` after the bucket reorg was written. This adds that prefix to the migration so it lands in the canonical `icons/` namespace, alongside `icons/abilities` and `icons/job-skills`.

- `bin/migrate-image-bucket.sh` — copy MAP: `weapon-skill-icons → icons/weapon-skills`.
- `bin/migrate-image-bucket-cleanup.sh` — old prefix `weapon-skill-icons` removed in the delete pass.
- `docs/follow-ups/image-bucket-reorg.md` — target structure + inline MAP updated.

No code references `weapon-skill-icons` in this repo (nothing writes it), so the scripts are the only change needed here. The read-path for weapon skills lives in the in-progress `feature/weapon-skills` work and should point at `icons/weapon-skills` there.

(The local-mirror script `scripts/migrate-local-images.sh` in hensei-web is updated to match on its open PR #879.)