### PR TITLE
Load amazing_print in all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,13 +84,16 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'stackprof'
 
+# Loaded in all environments: the granblue parsers call `ap` in debug/error
+# branches that run via rake tasks and Sidekiq jobs in production.
+gem 'amazing_print'
+
 group :doc do
   gem 'apipie-rails'
   gem 'sdoc'
 end
 
 group :development, :test do
-  gem 'amazing_print'
   gem 'dotenv-rails'
   gem 'prosopite'
   gem 'pry'


### PR DESCRIPTION
## Problem

The granblue parsers (`weapon_parser`, `summon_parser`, `character_parser`, `base_parser`, `wiki`) call `ap` (amazing_print) in their debug and error branches. Those branches run in **production** via:

- rake tasks — `granblue:parse_weapon_skills`, `granblue:parse_character_skills`, `build_status_catalog`, etc., all of which pass `debug: true`
- Sidekiq jobs that invoke the parsers

But `amazing_print` was scoped to `group :development, :test`, so under `RAILS_ENV=production` Bundler never loads it and `ap` is undefined → `NoMethodError`.

## How it surfaced

Running `granblue:parse_weapon_skills` against production during the staging promotion. The in-loop debug `ap` (before the persist call) raised on every weapon, got swallowed by the per-iteration `rescue StandardError` — so **nothing persisted** — and the task then aborted on the post-loop summary `ap`:

```
NoMethodError: undefined method 'ap' for class Granblue::Parsers::WeaponParser
  weapon_parser.rb:539:in 'persist_all_skills'
```

## Fix

Move `gem 'amazing_print'` out of `group :development, :test` to the default group so `ap` resolves in every environment. Gemfile-only change — Bundler doesn't record groups in `Gemfile.lock`, so the lock is unchanged.

## Notes

- Proper follow-up (not in this PR): the parsers should use `Rails.logger`/`puts` for operational output rather than a pretty-printer, and the ungated `ap e` calls in rescue branches should be cleaned up. This change is the minimal unblock for the in-progress deploy.