### PR TITLE
fix difficulty N+1 in party list

### DIFF
--- a/app/controllers/concerns/party_querying_concern.rb
+++ b/app/controllers/concerns/party_querying_concern.rb
@@ -10,6 +10,7 @@ module PartyQueryingConcern
     Party.includes(
       { raid: :group },
       :job,
+      :difficulty,
       { user: { active_crew_membership: :crew } },
       { characters: [:character, :awakening] },
       { weapons: [:weapon, :awakening] },


### PR DESCRIPTION
The `:list` blueprint renders the `difficulty` field (`party.difficulty`), but `build_preview_base_query` wasn't eager-loading it — so every party in the list fired its own `SELECT` on `difficulties`.

Added `:difficulty` to the preview includes. Covers `parties#index`, `parties#favorites`, and `user_parties` since they share the query. `DifficultyBlueprint`'s `:nested` view only renders scalar columns, so no secondary N+1.