### PR TITLE
MC ability Full Auto toggles, 0-indexed slots, and MC-only teams in Gallery

### DIFF
--- a/app/blueprints/api/v1/party_blueprint.rb
+++ b/app/blueprints/api/v1/party_blueprint.rb
@@ -235,6 +235,10 @@ module Api
           }
         end
 
+        field :full_auto_skills do |party|
+          party.full_auto_skills
+        end
+
         field :guidebooks, cache: true do |party|
           {
             '1' => party.guidebook1 ? GuidebookBlueprint.render_as_hash(party.guidebook1) : nil,

--- a/app/controllers/api/v1/grid_characters_controller.rb
+++ b/app/controllers/api/v1/grid_characters_controller.rb
@@ -610,7 +610,7 @@ module Api
           awakening: %i[id level],
           rings: %i[modifier strength],
           earring: %i[modifier strength],
-          full_auto_skills: %w[1 2 3 4]
+          full_auto_skills: %w[0 1 2 3]
         ).then { |p| permit_description(p, params[:character]) }
       end
 

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -20,8 +20,9 @@ module Api
       # Maximum number of weapons allowed in a party
       MAX_WEAPONS = 13
 
-      # Default minimum number of characters required for filtering
-      DEFAULT_MIN_CHARACTERS = 3
+      # Default minimum number of characters required for filtering.
+      # 0 so MC-only teams (no characters) appear in the Gallery by default.
+      DEFAULT_MIN_CHARACTERS = 0
 
       # Default minimum number of summons required for filtering
       DEFAULT_MIN_SUMMONS = 2

--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -432,6 +432,7 @@ module Api
           :collection_source_user_id, :full_auto, :auto_guard, :auto_summon, :charge_attack, :solo, :clear_time, :button_count,
           :turn_count, :chain_count, :summon_count, :ultimate_mastery, :ultimate_mastery_level,
           :video_url, :guidebook1_id, :guidebook2_id, :guidebook3_id,
+          full_auto_skills: %w[0 1 2 3],
           characters_attributes: [:id, :party_id, :character_id, :position, :uncap_level,
                                   :transcendence_step, :perpetuity, :awakening_id, :awakening_level,
                                   { ring1: %i[modifier strength], ring2: %i[modifier strength], ring3: %i[modifier strength], ring4: %i[modifier strength],

--- a/app/helpers/party_constants.rb
+++ b/app/helpers/party_constants.rb
@@ -5,7 +5,8 @@
 #
 module PartyConstants
   COLLECTION_PER_PAGE = 15
-  DEFAULT_MIN_CHARACTERS = 3
+  # 0 so MC-only teams (no characters) appear in the Gallery by default.
+  DEFAULT_MIN_CHARACTERS = 0
   DEFAULT_MIN_SUMMONS = 2
   DEFAULT_MIN_WEAPONS = 5
   MAX_CHARACTERS = 5

--- a/app/models/grid_character.rb
+++ b/app/models/grid_character.rb
@@ -332,9 +332,9 @@ class GridCharacter < ApplicationRecord
     errors.add(:roles, "may have at most #{ROLE_CAP}")
   end
 
-  # full_auto_skills maps an ability slot ("1".."4") to whether it is used in
+  # full_auto_skills maps an ability slot ("0".."3") to whether it is used in
   # Full Auto. Reject unknown slots or non-boolean values.
-  FULL_AUTO_SLOTS = %w[1 2 3 4].freeze
+  FULL_AUTO_SLOTS = %w[0 1 2 3].freeze
   FULL_AUTO_VALUES = [true, false].freeze
 
   def validate_full_auto_skills

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -231,6 +231,7 @@ class Party < ApplicationRecord
   # ActiveRecord Validations
   validate :skills_are_unique
   validate :guidebooks_are_unique
+  validate :validate_full_auto_skills
 
   validates :name,
             profanity: { languages: [:en, :ja], tier: :moderate, message: 'contains inappropriate language' },
@@ -500,6 +501,29 @@ class Party < ApplicationRecord
     validate_uniqueness_of_associations([guidebook1, guidebook2, guidebook3],
                                         %i[guidebook1 guidebook2 guidebook3],
                                         :guidebooks)
+  end
+
+  # full_auto_skills maps an MC ability slot ("0".."3") to whether it is used in
+  # Full Auto. Reject unknown slots or non-boolean values.
+  FULL_AUTO_SLOTS = %w[0 1 2 3].freeze
+  FULL_AUTO_VALUES = [true, false].freeze
+
+  ##
+  # Validates the per-slot MC Full Auto toggles.
+  #
+  # @return [void]
+  def validate_full_auto_skills
+    return if full_auto_skills.blank?
+
+    unless full_auto_skills.is_a?(Hash)
+      errors.add(:full_auto_skills, 'must be an object')
+      return
+    end
+
+    full_auto_skills.each do |slot, value|
+      errors.add(:full_auto_skills, "invalid slot #{slot}") unless FULL_AUTO_SLOTS.include?(slot.to_s)
+      errors.add(:full_auto_skills, "invalid value for slot #{slot}") unless FULL_AUTO_VALUES.include?(value)
+    end
   end
 
   #########################

--- a/app/services/party_query_builder.rb
+++ b/app/services/party_query_builder.rb
@@ -369,7 +369,8 @@ class PartyQueryBuilder
   end
 
   def default_characters_count
-    @options[:default_characters_count] || 3
+    # Defaults to 0 so MC-only teams (no characters) appear in the Gallery.
+    @options[:default_characters_count] || 0
   end
 
   def default_summons_count

--- a/db/data/20260618000001_remap_grid_character_full_auto_skill_slots.rb
+++ b/db/data/20260618000001_remap_grid_character_full_auto_skill_slots.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Unify GridCharacter#full_auto_skills slot keys to the 0-indexed convention
+# shared with the MC abilities (Party#full_auto_skills). Existing rows were keyed
+# "1".."4"; shift them down to "0".."3", preserving order and values.
+class RemapGridCharacterFullAutoSkillSlots < ActiveRecord::Migration[8.0]
+  SHIFT = { '1' => '0', '2' => '1', '3' => '2', '4' => '3' }.freeze
+
+  def up
+    remap_with(SHIFT)
+  end
+
+  def down
+    remap_with(SHIFT.invert)
+  end
+
+  private
+
+  def remap_with(mapping)
+    count = 0
+    GridCharacter.where.not(full_auto_skills: {}).find_each do |gc|
+      remapped = gc.full_auto_skills.transform_keys { |k| mapping.fetch(k.to_s, k.to_s) }
+      gc.update_column(:full_auto_skills, remapped)
+      count += 1
+    end
+    puts "Remapped full_auto_skills slots on #{count} grid_characters"
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20260320010000)
+DataMigrate::Data.define(version: 20260618000001)

--- a/db/migrate/20260618000000_add_full_auto_skills_to_parties.rb
+++ b/db/migrate/20260618000000_add_full_auto_skills_to_parties.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Per-slot Full Auto toggles for a party's MC (main character) abilities.
+# Keyed by slot number "0".."3" → boolean (whether that ability is used in
+# Full Auto). An absent slot defaults to ON. Mirrors GridCharacter#full_auto_skills.
+class AddFullAutoSkillsToParties < ActiveRecord::Migration[8.0]
+  def change
+    add_column :parties, :full_auto_skills, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_17_010000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_18_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -876,6 +876,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_17_010000) do
     t.jsonb "difficulty_breakdown"
     t.datetime "difficulty_computed_at"
     t.integer "difficulty_ruleset_version"
+    t.jsonb "full_auto_skills", default: {}, null: false
     t.index ["accessory_id"], name: "index_parties_on_accessory_id"
     t.index ["boost_mod", "boost_side"], name: "index_parties_on_boost_mod_and_boost_side"
     t.index ["collection_source_user_id"], name: "index_parties_on_collection_source_user_id"

--- a/spec/requests/api/v1/grid_characters_spec.rb
+++ b/spec/requests/api/v1/grid_characters_spec.rb
@@ -89,14 +89,14 @@ RSpec.describe 'GridCharacters API', type: :request do
         update_params = {
           character: {
             id: grid_character.id, party_id: party.id, character_id: incoming_character.id,
-            position: 2, full_auto_skills: { '2' => false, '3' => true }
+            position: 2, full_auto_skills: { '1' => false, '2' => true }
           }
         }
 
         put "/api/v1/grid_characters/#{grid_character.id}", params: update_params.to_json, headers: headers
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body['grid_character']['full_auto_skills']).to eq('2' => false, '3' => true)
+        expect(response.parsed_body['grid_character']['full_auto_skills']).to eq('1' => false, '2' => true)
       end
 
       it 'rejects full_auto_skills with a non-boolean value' do
@@ -104,13 +104,28 @@ RSpec.describe 'GridCharacters API', type: :request do
         update_params = {
           character: {
             id: grid_character.id, party_id: party.id, character_id: incoming_character.id,
-            position: 2, full_auto_skills: { '1' => 'maybe' }
+            position: 2, full_auto_skills: { '0' => 'maybe' }
           }
         }
 
         put "/api/v1/grid_characters/#{grid_character.id}", params: update_params.to_json, headers: headers
 
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'filters out-of-range full_auto_skills slots' do
+        grid_character = create(:grid_character, party: party, character: incoming_character, position: 2)
+        update_params = {
+          character: {
+            id: grid_character.id, party_id: party.id, character_id: incoming_character.id,
+            position: 2, full_auto_skills: { '3' => true, '4' => false }
+          }
+        }
+
+        put "/api/v1/grid_characters/#{grid_character.id}", params: update_params.to_json, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(grid_character.reload.full_auto_skills).to eq('3' => true)
       end
 
       it 'allows the owner to update the uncap level and transcendence step' do

--- a/spec/requests/api/v1/parties_spec.rb
+++ b/spec/requests/api/v1/parties_spec.rb
@@ -264,6 +264,33 @@ RSpec.describe 'Parties API', type: :request do
       expect(response).to have_http_status(:unauthorized)
       expect(party.reload.name).to eq('Old Name')
     end
+
+    it 'persists and serializes per-slot MC full_auto_skills' do
+      update_params = { party: { full_auto_skills: { '0' => false, '2' => true } } }
+
+      put "/api/v1/parties/#{party.id}", params: update_params.to_json, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['party']['full_auto_skills']).to eq('0' => false, '2' => true)
+      expect(party.reload.full_auto_skills).to eq('0' => false, '2' => true)
+    end
+
+    it 'rejects MC full_auto_skills with a non-boolean value' do
+      update_params = { party: { full_auto_skills: { '0' => 'maybe' } } }
+
+      put "/api/v1/parties/#{party.id}", params: update_params.to_json, headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'filters out-of-range MC full_auto_skills slots' do
+      update_params = { party: { full_auto_skills: { '3' => true, '4' => false } } }
+
+      put "/api/v1/parties/#{party.id}", params: update_params.to_json, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(party.reload.full_auto_skills).to eq('3' => true)
+    end
   end
 
   describe 'DELETE /api/v1/parties/:id' do

--- a/spec/requests/api/v1/parties_spec.rb
+++ b/spec/requests/api/v1/parties_spec.rb
@@ -548,6 +548,9 @@ RSpec.describe 'Parties API', type: :request do
       let!(:bad_party) do
         create(:party, user: user, weapons_count: 2, characters_count: 2, summons_count: 1, visibility: 1)
       end
+      let!(:mc_only_party) do
+        create(:party, user: user, weapons_count: 5, characters_count: 0, summons_count: 2, visibility: 1)
+      end
 
       it 'returns only parties meeting the default thresholds' do
         get '/api/v1/parties', headers: headers
@@ -556,6 +559,14 @@ RSpec.describe 'Parties API', type: :request do
         party_ids = response.parsed_body['results'].map { |p| p['id'] }
         expect(party_ids).to include(good_party.id)
         expect(party_ids).not_to include(bad_party.id)
+      end
+
+      it 'includes MC-only teams with no characters' do
+        get '/api/v1/parties', headers: headers
+        expect(response).to have_http_status(:ok)
+
+        party_ids = response.parsed_body['results'].map { |p| p['id'] }
+        expect(party_ids).to include(mc_only_party.id)
       end
     end
   end

--- a/spec/services/party_query_builder_spec.rb
+++ b/spec/services/party_query_builder_spec.rb
@@ -271,6 +271,7 @@ RSpec.describe PartyQueryBuilder, type: :model do
   describe 'count filters' do
     let!(:stacked_party) { create(:party, weapons_count: 10, characters_count: 5, summons_count: 4, visibility: 1) }
     let!(:light_party) { create(:party, weapons_count: 1, characters_count: 1, summons_count: 1, visibility: 1) }
+    let!(:mc_only_party) { create(:party, weapons_count: 5, characters_count: 0, summons_count: 2, visibility: 1) }
 
     context 'with apply_defaults option' do
       let(:options) { { apply_defaults: true } }
@@ -279,6 +280,11 @@ RSpec.describe PartyQueryBuilder, type: :model do
         results = subject.build
         expect(results).to include(stacked_party)
         expect(results).not_to include(light_party)
+      end
+
+      it 'includes MC-only teams with no characters' do
+        results = subject.build
+        expect(results).to include(mc_only_party)
       end
     end
 


### PR DESCRIPTION
## Summary

Adds Full Auto On/Off control for MC (main character) abilities, unifies the character Full Auto slot convention to be 0-indexed, and relaxes the Gallery quality filter so MC-only teams show up by default.

## Changes

### MC ability Full Auto toggles
Characters already support per-ability Full Auto toggles via `GridCharacter#full_auto_skills`. This brings the same capability to the four MC ability slots:
- New JSONB `parties.full_auto_skills` column, keyed by slot `"0".."3"` → boolean. An absent slot defaults to ON.
- Model validation rejects unknown slots and non-boolean values.
- Accepted on the normal party update (`PUT /api/v1/parties/:id`) via strong params.
- Serialized in the `job_metadata` view alongside `job_skills`.

### Unify character slots to 0-3
- Re-indexes `GridCharacter#full_auto_skills` keys from `"1".."4"` to `"0".."3"` so characters and MC abilities share one 0-indexed convention.
- Includes a data migration that shifts existing keys (`1->0 .. 4->3`), preserving order and values.

### Show MC-only teams in the Gallery by default
- Lowers the default character-count threshold in the Gallery quality filter from 3 to 0, so MC-only teams (no characters) that still meet the weapon (5) and summon (2) minimums surface by default.
- Updates the now-stale `DEFAULT_MIN_CHARACTERS` constants to match the actual default.

## Testing
- `bundle exec rspec spec/requests/api/v1/parties_spec.rb spec/requests/api/v1/grid_characters_spec.rb spec/services/party_query_builder_spec.rb` — all green.
- RuboCop clean on all changed files.

## Notes
- `hensei-web` consumes these slot keys and needs a matching `"1".."4"` -> `"0".."3"` update for character Full Auto, and should expose the new MC `full_auto_skills` field. That work is out of scope here and should ship alongside this PR to avoid a mismatch.
- The weapon (5) and summon (2) Gallery minimums are unchanged; only the character minimum was relaxed.
