### PR TITLE
Fix ambiguous name_en on unowned character listing

### DIFF
--- a/app/controllers/api/v1/collection_characters_controller.rb
+++ b/app/controllers/api/v1/collection_characters_controller.rb
@@ -30,7 +30,7 @@ module Api
           @characters = @characters.by_series(array_param(:series)) if params[:series]
           if params[:search].present?
             q = "%#{ActiveRecord::Base.sanitize_sql_like(params[:search])}%"
-            @characters = @characters.where("name_en ILIKE :q OR name_jp ILIKE :q", q: q)
+            @characters = @characters.where("characters.name_en ILIKE :q OR characters.name_jp ILIKE :q", q: q)
           end
 
           lang = current_user&.language || 'en'
@@ -280,9 +280,9 @@ module Api
         name_col = locale == 'ja' ? 'name_jp' : 'name_en'
         case sort_key
         when 'name_asc'
-          scope.order(Arel.sql("#{name_col} ASC NULLS LAST"))
+          scope.order(Arel.sql("characters.#{name_col} ASC NULLS LAST"))
         when 'name_desc'
-          scope.order(Arel.sql("#{name_col} DESC NULLS LAST"))
+          scope.order(Arel.sql("characters.#{name_col} DESC NULLS LAST"))
         when 'element_asc'
           scope.order(element: :asc)
         when 'element_desc'

--- a/spec/requests/api/v1/collection_characters_spec.rb
+++ b/spec/requests/api/v1/collection_characters_spec.rb
@@ -188,6 +188,36 @@ RSpec.describe 'Collection Characters API', type: :request do
       expect(returned_ids).not_to include(other_char.id)
     end
 
+    it 'sorts by name while filtering by series in unowned mode' do
+      grand_series = create(:character_series, :grand)
+      grand_char = create(:character)
+      create(:character_series_membership, character: grand_char, character_series: grand_series)
+
+      # Both name sort and the series join reference name_en/name_jp; without
+      # qualifying the column this 500s with PG::AmbiguousColumn.
+      get "/api/v1/users/#{user.id}/collection/characters",
+          params: { unowned: true, series: grand_series.id, sort: 'name_asc' }, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      returned_ids = json['characters'].map { |c| c['id'] }
+      expect(returned_ids).to include(grand_char.id)
+    end
+
+    it 'searches by name while filtering by series in unowned mode' do
+      grand_series = create(:character_series, :grand)
+      matching_char = create(:character, name_en: 'Zeta Unique Name')
+      create(:character_series_membership, character: matching_char, character_series: grand_series)
+
+      get "/api/v1/users/#{user.id}/collection/characters",
+          params: { unowned: true, series: grand_series.id, search: 'Unique' }, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      returned_ids = json['characters'].map { |c| c['id'] }
+      expect(returned_ids).to include(matching_char.id)
+    end
+
     it 'does not return a character the user owns when requesting unowned' do
       owned_char = create(:character)
       create(:collection_character, user: user, character: owned_char)


### PR DESCRIPTION
## What

Viewing "characters I'm missing" (`?unowned=true`) 500s with `PG::AmbiguousColumn: column reference "name_en" is ambiguous` when a series filter is in play.

## Why

The unowned branch builds raw SQL with bare `name_en`/`name_jp`. Adding the `series` filter makes `by_series` join `character_series`, which *also* has `name_en`/`name_jp` — so the `DISTINCT` + `ORDER BY` query can't tell which table's column is meant.

## Fix

Qualify the search filter and name-sort columns with `characters.*`, same as the owned path already does in `CollectionCharacter`. Other sorts use hash-style `order(...)` which Rails auto-qualifies, so they were fine.

## Tests

Added two regression specs: `unowned + series + sort=name_asc` and `unowned + series + search`. Both fail without the fix, pass with it. Full file green (28 examples).