### PR TITLE
make sentry useful + quiet

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -6,6 +6,9 @@ module Api
       ##### Doorkeeper
       include Doorkeeper::Rails::Helpers
 
+      ##### Error reporting
+      include SentryReportable
+
       ##### Constants
       COLLECTION_PER_PAGE = 15
       SEARCH_PER_PAGE = 10
@@ -18,6 +21,7 @@ module Api
       rescue_from StandardError do |e|
         Rails.logger.error "[500 Error] #{e.class}: #{e.message}"
         Rails.logger.error e.backtrace&.first(20)&.join("\n")
+        report_unexpected_exception(e)
         render json: { error: 'Internal Server Error', message: e.message }, status: :internal_server_error
       end
 

--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -174,6 +174,7 @@ module Api
       rescue StandardError => e
         Rails.logger.error "[IMPORT] Import failed: #{e.class}: #{e.message}"
         Rails.logger.error e.backtrace&.first(10)&.join("\n")
+        report_unexpected_exception(e, phase: 'import_create')
         render json: { error: 'Import failed due to an unexpected error. Please try again.' }, status: :unprocessable_content
       end
 
@@ -216,6 +217,7 @@ module Api
           render json: { message: 'Weapon gamedata updated successfully' }, status: :ok
         rescue StandardError => e
           Rails.logger.error "[IMPORT] Failed to update weapon gamedata: #{e.message}"
+          report_unexpected_exception(e, phase: 'gamedata_update')
           render json: { error: e.message }, status: :unprocessable_content
         end
       end
@@ -259,6 +261,7 @@ module Api
           render json: { message: 'Summon gamedata updated successfully' }, status: :ok
         rescue StandardError => e
           Rails.logger.error "[IMPORT] Failed to update summon gamedata: #{e.message}"
+          report_unexpected_exception(e, phase: 'gamedata_update')
           render json: { error: e.message }, status: :unprocessable_content
         end
       end
@@ -306,6 +309,7 @@ module Api
           render json: { message: 'Character gamedata updated successfully' }, status: :ok
         rescue StandardError => e
           Rails.logger.error "[IMPORT] Failed to update character gamedata: #{e.message}"
+          report_unexpected_exception(e, phase: 'gamedata_update')
           render json: { error: e.message }, status: :unprocessable_content
         end
       end

--- a/app/controllers/concerns/sentry_reportable.rb
+++ b/app/controllers/concerns/sentry_reportable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Reports unexpected exceptions to Sentry with request/user context.
+#
+# Wired only into the catch-all rescue handlers (ApiController's global
+# `rescue_from StandardError` and ImportController's local rescue) so that
+# genuine bugs — which those handlers would otherwise swallow before Sentry's
+# middleware could see them — are still reported. Expected/user-facing errors
+# have their own rescue_from handlers and never reach this method; the Sentry
+# initializer's excluded_exceptions list is a second safety net.
+module SentryReportable
+  extend ActiveSupport::Concern
+
+  private
+
+  # Report an unexpected exception to Sentry with request/user context.
+  # No-op when Sentry isn't initialized (e.g. development/test, or no DSN).
+  #
+  # @param exception [Exception] the exception to report
+  # @param extra [Hash] optional extra context attached under "details"
+  # @return [void]
+  def report_unexpected_exception(exception, extra = {})
+    return unless defined?(Sentry) && Sentry.initialized?
+
+    Sentry.with_scope do |scope|
+      scope.set_user(id: current_user&.id) if respond_to?(:current_user)
+      scope.set_context('request', {
+                          controller: controller_name,
+                          action: action_name,
+                          path: request&.path,
+                          method: request&.request_method
+                        })
+      scope.set_context('details', extra) if extra.present?
+      Sentry.capture_exception(exception)
+    end
+  end
+end

--- a/app/services/processors/base_processor.rb
+++ b/app/services/processors/base_processor.rb
@@ -33,12 +33,21 @@ module Processors
     attr_reader :party, :data, :options
 
     ##
-    # Logs a message to Rails.logger.
+    # Logs a message to Rails.logger, and records it as a Sentry breadcrumb when
+    # Sentry is active. Breadcrumbs add zero standalone noise — they only ship
+    # attached to an exception that actually gets captured — but give the full
+    # processor step trail for the next unexpected import failure.
     #
     # @param message [String] the message to log.
     # @return [void]
     def log(message)
       Rails.logger.info "[PROCESSOR][#{self.class.name}] #{message}"
+
+      return unless defined?(Sentry) && Sentry.initialized?
+
+      Sentry.add_breadcrumb(
+        Sentry::Breadcrumb.new(category: 'processor', message: "[#{self.class.name}] #{message}", level: 'info')
+      )
     end
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,84 @@
 # frozen_string_literal: true
 
-Sentry.init do |config|
-  config.breadcrumbs_logger = [:active_support_logger]
-  config.dsn = ENV['SENTRY_DSN']
-  config.enable_tracing = true
+# Sentry is only configured when a DSN is present. Skipping Sentry.init entirely
+# (rather than initializing with a blank/invalid DSN) is what keeps short-lived
+# processes quiet: an uninitialized SDK never installs the at_exit flush hook,
+# so it can't dump transport-error backtraces to stdout.
+sentry_dsn = ENV['SENTRY_DSN'].presence
+
+# Don't initialize in one-off interactive/debug processes (console, `rails
+# runner`). They install the same at_exit flush hook, which raises a noisy
+# Sentry::ExternalError backtrace on any transport hiccup, and they almost never
+# need error reporting. The web server, Sidekiq, and rake tasks still init
+# normally. Rails loads the matching command class to dispatch the invocation
+# (before initializers run), so its presence is a reliable signal; the server
+# process never loads these. Set SENTRY_ENABLE_IN_CLI=true to force-enable when
+# debugging Sentry itself.
+one_off_process = ENV['SENTRY_ENABLE_IN_CLI'].blank? && (
+  defined?(Rails::Console) ||
+  defined?(Rails::Command::ConsoleCommand) ||
+  defined?(Rails::Command::RunnerCommand)
+)
+
+if sentry_dsn && !one_off_process
+  # Expected / user-facing exceptions that must never be reported as bugs.
+  # excluded_exceptions matches subclasses, so a base class covers its leaves
+  # (e.g. Api::V1::GranblueError covers FavoriteAlreadyExistsError, etc.).
+  ignored_exceptions = %w[
+    ActiveRecord::RecordNotFound
+    ActiveRecord::RecordInvalid
+    ActiveRecord::RecordNotSaved
+    ActiveRecord::RecordNotDestroyed
+    ActiveRecord::RecordNotUnique
+    ActionController::ParameterMissing
+    ActionController::RoutingError
+    ActionController::UnknownFormat
+    Api::V1::GranblueError
+    Api::V1::UnauthorizedError
+    CollectionErrors::CollectionError
+    CrewErrors::CrewError
+    PartyShareErrors::PartyShareError
+  ].freeze
+
+  Sentry.init do |config|
+    config.dsn = sentry_dsn
+
+    # Environment label on each event. Prefer an explicit var so Railway prod and
+    # staging are distinguishable; fall back to the Rails environment.
+    config.environment = ENV.fetch('SENTRY_ENVIRONMENT', Rails.env.to_s)
+
+    # Hard gate: even if a DSN leaks into another environment, only these actually
+    # transmit events.
+    config.enabled_environments = %w[production staging]
+
+    config.breadcrumbs_logger = [:active_support_logger]
+
+    # Sample performance traces instead of sending one per request. Set the env
+    # var to 0 to disable tracing entirely without a deploy.
+    config.traces_sample_rate = ENV.fetch('SENTRY_TRACES_SAMPLE_RATE', '0.1').to_f
+
+    # Drop expected / user-facing exceptions (append; the SDK pre-seeds this list
+    # with framework noise, so use += rather than reassigning).
+    config.excluded_exceptions += ignored_exceptions
+
+    # Keep the SDK's own logging quiet so a transient transport error never dumps
+    # an HTTPTransport backtrace to application stdout.
+    config.debug = false
+    if config.respond_to?(:sdk_logger)
+      config.sdk_logger = Logger.new($stdout).tap { |l| l.level = Logger::WARN }
+    end
+
+    # Belt-and-suspenders: drop the same exceptions if one is wrapped/re-raised
+    # under a class the excluded_exceptions ancestry check misses.
+    config.before_send = lambda do |event, hint|
+      exception = hint[:exception]
+      next event unless exception
+
+      dropped = ignored_exceptions.any? do |name|
+        klass = name.safe_constantize
+        klass && exception.is_a?(klass)
+      end
+      dropped ? nil : event
+    end
+  end
 end


### PR DESCRIPTION
## what

found this while chasing the "Import failed" extension bug: prod is basically blind. two problems stacked on top of each other —

1. **sentry rejects everything** — every event comes back `403 "event submission rejected with_reason: ProjectId"`, so nothing lands. (the DSN itself is an ops fix, see below.)
2. **even with a working DSN, real bugs never reach sentry** — `ApiController`'s `rescue_from StandardError` and `ImportController`'s `rescue` catch exceptions before sentry-rails' middleware can see them. that's exactly how a real `NoMethodError` in the import flow (`summon_processor.rb` calling `filter_map` on nil) stayed completely invisible.
3. **noise** — `Sentry.init` runs in every process, so every `rails runner`/console dumps a full transport backtrace at exit.

## changes

- **`config/initializers/sentry.rb`** rewritten:
  - init only when `SENTRY_DSN` is present and not a one-off process (console/`runner`) → no more at-exit backtrace spam. `SENTRY_ENABLE_IN_CLI=true` overrides.
  - `enabled_environments = [production, staging]`, explicit `environment`
  - `traces_sample_rate = 0.1` (env-overridable) instead of blanket tracing
  - `excluded_exceptions` + `before_send` to drop expected/user-facing errors (RecordNotFound/Invalid, RoutingError, ParameterMissing, the `GranblueError` family, Crew/PartyShare/Collection errors)
  - `debug=false` + WARN-level `sdk_logger`
- **`SentryReportable` concern** (new) — `report_unexpected_exception` with user + request context, no-op when sentry isn't initialized
- **`ApiController`** — catch-all rescue now reports to sentry
- **`ImportController`** — reports the swallowed exception in `create` + the gamedata actions
- **`base_processor`** — `log` also drops a sentry breadcrumb (only ships attached to a real captured event)

## needs ops (not in this PR)

- fix `SENTRY_DSN` on the API service (currently 403s), set `SENTRY_ENVIRONMENT`
- set `RAILS_LOG_TO_STDOUT=true` — this is why `Rails.logger`/`[IMPORT]` lines never reach `railway logs` (only SQL does)

## not included

the actual import bug (nil-safe `process_summons` + the `[JOB] Missing job data` signal) — pinned separately.

## testing

- syntax + rubocop clean
- verified: DSN-in-runner stays uninitialized; forced init gives `env=production, traces=0.1`, exclusions applied, before_send set
- import + processor specs green (57); full request suite green except 2 pre-existing flaky conflict-resolution specs (pass in isolation, fail with these changes reverted too)