### PR TITLE
fix search 500 on jp locale

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -20,7 +20,7 @@ module Api
       }.freeze
 
       def all
-        locale = search_params[:locale] || 'en'
+        locale = search_locale
 
         case locale
         when 'en'
@@ -57,7 +57,7 @@ module Api
 
       def characters
         filters = search_params[:filters]
-        locale = search_params[:locale] || 'en'
+        locale = search_locale
         exclude = search_params[:exclude]
         conditions = {}
 
@@ -119,7 +119,7 @@ module Api
 
       def weapons
         filters = search_params[:filters]
-        locale = search_params[:locale] || 'en'
+        locale = search_locale
         conditions = {}
 
         if filters
@@ -167,7 +167,7 @@ module Api
 
       def summons
         filters = search_params[:filters]
-        locale = search_params[:locale] || 'en'
+        locale = search_locale
         conditions = {}
 
         if filters
@@ -214,7 +214,7 @@ module Api
 
         # Set up basic parameters we'll use
         job = Job.find(search_params[:job])
-        locale = search_params[:locale] || 'en'
+        locale = search_locale
 
         # Set the conditions based on the group requested
         conditions = {}
@@ -295,7 +295,7 @@ module Api
 
       def jobs
         filters = search_params[:filters]
-        locale = search_params[:locale] || 'en'
+        locale = search_locale
         conditions = {}
 
         if filters
@@ -390,13 +390,20 @@ module Api
         params.require(:search).permit!
       end
 
+      # Normalizes the requested locale to a supported search scope. Clients send
+      # either "ja" or "jp" for Japanese; the models define en_search / ja_search
+      # and name_en / name_jp. Anything else falls back to English.
+      def search_locale
+        %w[ja jp].include?(search_params[:locale].to_s) ? 'ja' : 'en'
+      end
+
       # Apply sorting based on column name and order
       def apply_sort(scope, column, order, locale)
         sort_dir = order == 'desc' ? :desc : :asc
 
         case column
         when 'name'
-          name_col = locale == 'ja' ? :name_ja : :name_en
+          name_col = locale == 'ja' ? :name_jp : :name_en
           scope.order(name_col => sort_dir, id: :asc)
         when 'element'
           scope.order(element: sort_dir, id: :asc)
@@ -415,7 +422,7 @@ module Api
 
         case column
         when 'name'
-          name_col = locale == 'ja' ? :name_ja : :name_en
+          name_col = locale == 'ja' ? :name_jp : :name_en
           scope.order(name_col => sort_dir, id: :asc)
         when 'row'
           scope.order(row: sort_dir, order: :asc, id: :asc)

--- a/spec/requests/api/v1/search_spec.rb
+++ b/spec/requests/api/v1/search_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe 'Api::V1::Search', type: :request do
       expect(response.parsed_body['results']).to be_an(Array)
     end
 
+    # Regression: sorting by name in a Japanese locale must order by the real
+    # name_jp column (was a 500: PG undefined column name_ja).
+    it 'does not error when sorting by name in ja locale' do
+      create(:character)
+      post '/api/v1/search/characters',
+           params: { search: { page: 1, locale: 'ja', sort: 'name', order: 'asc' } }.to_json,
+           headers: { 'Content-Type' => 'application/json' }
+      expect(response).to have_http_status(:ok)
+    end
+
     it 'filters by element and returns only matching results' do
       post '/api/v1/search/characters',
            params: { search: { filters: { element: [1] }, page: 1 } }.to_json,
@@ -96,6 +106,20 @@ RSpec.describe 'Api::V1::Search', type: :request do
            params: { search: { page: 1 } }.to_json,
            headers: { 'Content-Type' => 'application/json' }
       expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    # Regression: clients send "jp" for Japanese, but the search scope is
+    # ja_search. The locale must normalize so it doesn't call a missing
+    # jp_search scope (was a 500: NameError undefined method 'jp_search').
+    it 'does not error when given a jp locale with a query' do
+      base = create(:job)
+      job = create(:job, base_job: base)
+      create(:job_skill, job: job)
+      post '/api/v1/search/job_skills',
+           params: { search: { job: job.id, locale: 'jp', query: 'skill' } }.to_json,
+           headers: { 'Content-Type' => 'application/json' }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['results']).to be_an(Array)
     end
   end
 


### PR DESCRIPTION
## what

Sentry caught a 500 (event `9f9a8df6…`): **`POST /v1/search/job_skills` with `locale: "jp"` + a query → `NameError: undefined method 'jp_search'`**.

`job_skills` was the one search action that built its scope name dynamically — `JobSkill.method("#{locale}_search")` — but the model scope is `ja_search`. Clients send `"jp"` for Japanese, so it called a nonexistent `jp_search`. Latent for a while; only became visible now that Sentry actually reports (see #440).

## changes

- Add a `search_locale` helper that normalizes `jp`/`ja` → `ja` (else `en`), and use it in **all 6** search actions. Fixes the `job_skills` 500 **and** a quieter bug: the sibling searches (characters/weapons/summons/jobs) only checked `== "ja"`, so `"jp"` clients were silently getting **English** results.
- Fix `:name_ja` → `:name_jp` in both sort helpers. `name_ja` isn't a real column (it's `name_jp`), so once `jp` normalizes to `ja`, sorting by name in Japanese would have become a *new* 500.

## testing

- Reproduced the original 500 against prod (`locale=jp` → 500; `en`/`ja` → 200).
- 2 regression tests added — both **fail on the unfixed controller** (`jp_search` NameError / `name_ja` PG undefined-column) and pass with the fix.
- Full request suite green (846 examples, 0 failures); RuboCop clean.

Separate from #440 (the Sentry work) — this is the bug that PR's reporting surfaced.