### PR TITLE
Fix broken null-element character images in gallery grid reps

### DIFF
--- a/app/blueprints/api/v1/character_blueprint.rb
+++ b/app/blueprints/api/v1/character_blueprint.rb
@@ -83,9 +83,11 @@ module Api
                  :style_swap, :style_name, :base_character
       end
 
-      # Minimal view for party list cards — just enough for image rendering
+      # Minimal view for party list cards — just enough for image rendering.
+      # Keep :element: null-element characters (e.g. Lyria, Gran/Djeeta) need it to
+      # build the element-suffixed image filename in grid reps.
       view :list do
-        excludes :name, :character_id, :rarity, :element, :gender, :special, :season,
+        excludes :name, :character_id, :rarity, :gender, :special, :season,
                  :season_name, :series, :series_names, :uncap, :race, :proficiency,
                  :style_name, :base_character
       end


### PR DESCRIPTION
## Problem

Null-element characters (Lyria, Gran/Djeeta — Granblue ID `3030182000`) render a **broken image** in grid reps on gallery/list pages (`/teams/explore`, profiles, crew teams), e.g.:

```
https://siero-img.s3-us-west-2.amazonaws.com/characters/main/3030182000_03.jpg
```

…while the same character renders correctly in the Party-page segmented control.

## Root cause

Both contexts render through the **same** frontend component (`CharacterRep.svelte`), so this is a data difference, not a component-logic difference. `CharacterRep` appends the required element suffix only when `characterElement === 0`:

```js
if (characterElement === 0 && (mainWeaponElement || partyElement)) {
    pose = `${pose}_0${element}`
}
```

- The **single party** endpoint uses the `:full` blueprint view, which serializes `character.element` → for Lyria it's `0` → suffix added. ✅
- The **list/favorites** endpoints use the `:list` view, and `CharacterBlueprint`'s `:list` view **excluded `:element`** → it arrived as `undefined`, not `0` → the `=== 0` check failed → no suffix → broken URL. ❌

The mainhand weapon's element was already serialized in the list view, so the only missing field was the character's own `element`. This must be fixed API-side: the frontend can't treat `undefined` as `0` without wrongly suffixing every other character's image.

## Fix

Stop excluding `:element` from `CharacterBlueprint`'s `:list` view (one field, the comment on that view already states it's "just enough for image rendering"). The frontend `CharacterSchema` already parses `element`, so no frontend change is needed.

## Verification

Reload a gallery page containing a party with FLB Lyria and confirm the request now hits `.../characters/main/3030182000_03_0<element>.jpg`.