### PR TITLE
fix N+1 in parties update/grid_update render

### DIFF
--- a/app/controllers/api/v1/parties_controller.rb
+++ b/app/controllers/api/v1/parties_controller.rb
@@ -104,7 +104,7 @@ module Api
         end
         @party.last_updated = Time.current
         if @party.save
-          render json: PartyBlueprint.render(@party, view: :full, root: :party)
+          render json: PartyBlueprint.render(load_full_party(@party.id), view: :full, root: :party)
         else
           render_validation_error_response(@party)
         end
@@ -273,7 +273,7 @@ module Api
         @party.mark_updated!
 
         render json: {
-          party: PartyBlueprint.render_as_hash(@party.reload, view: :full),
+          party: PartyBlueprint.render_as_hash(load_full_party(@party.id), view: :full),
           operations_applied: changes.count,
           changes: changes
         }, status: :ok
@@ -399,7 +399,20 @@ module Api
 
       # Loads the party by its shortcode.
       def set_from_slug
-        @party = Party.includes(
+        @party = Party.includes(full_party_preloads).find_by(shortcode: params[:id])
+
+        return render_not_found_response('party') unless @party
+
+        # Most parties have zero substitutes; a single EXISTS lookup is far cheaper
+        # than the three collection-ownership queries `preload_substitute_grids!` runs.
+        preload_substitute_grids!(@party.characters + @party.weapons + @party.summons) if @party.has_substitutions?
+      end
+
+      # Associations the PartyBlueprint :full view touches. Eager-loaded by every
+      # action that serializes a full party (show / update / grid_update) so the
+      # response renders without N+1 queries over the grid items.
+      def full_party_preloads
+        [
           :user, :job, { raid: :group },
           { characters: GridCharacter::NESTED_BLUEPRINT_PRELOADS + [{ substitutions: :substitute_grid }] },
           { weapons: GridWeapon::NESTED_BLUEPRINT_PRELOADS + [{ substitutions: :substitute_grid }] },
@@ -409,13 +422,19 @@ module Api
           { remixes: [{ characters: :character }, { weapons: :weapon }, { summons: :summon }] },
           :skill0, :skill1, :skill2, :skill3, :accessory,
           { party_shares: :shareable }
-        ).find_by(shortcode: params[:id])
+        ]
+      end
 
-        return render_not_found_response('party') unless @party
+      # Re-fetches a party by id with all blueprint associations (and substitute
+      # collection data) preloaded, for rendering a full-view response without
+      # N+1s. The mutating actions (update, grid_update) hold a non-eager-loaded
+      # @party, so they round-trip through this before serializing.
+      def load_full_party(id)
+        party = Party.includes(full_party_preloads).find_by(id: id)
+        return party unless party&.has_substitutions?
 
-        # Most parties have zero substitutes; a single EXISTS lookup is far cheaper
-        # than the three collection-ownership queries `preload_substitute_grids!` runs.
-        preload_substitute_grids!(@party.characters + @party.weapons + @party.summons) if @party.has_substitutions?
+        preload_substitute_grids!(party.characters + party.weapons + party.summons)
+        party
       end
 
       # Loads the party by its id.

--- a/spec/requests/api/v1/parties_n_plus_one_spec.rb
+++ b/spec/requests/api/v1/parties_n_plus_one_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression for the N+1 Sentry caught in PartiesController#update: rendering the
+# full PartyBlueprint over a non-eager-loaded party ran a summon (+ series +
+# substitution + collection) query per grid item. update and grid_update now
+# re-fetch through load_full_party, which eager-loads everything.
+RSpec.describe 'Api::V1::Parties N+1', type: :request do
+  let(:user) { create(:user) }
+  let(:access_token) do
+    Doorkeeper::AccessToken.create!(resource_owner_id: user.id, expires_in: 30.days, scopes: 'public')
+  end
+  let(:headers) do
+    { 'Authorization' => "Bearer #{access_token.token}", 'Content-Type' => 'application/json' }
+  end
+
+  # Collects single-row `summons WHERE id = ?` SELECTs run during the block —
+  # the signature of the per-grid-summon N+1. Eager loading uses `WHERE id IN
+  # (...)` instead, so this should be empty once the response is preloaded.
+  def per_summon_id_queries
+    queries = []
+    sub = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+      sql = payload[:sql]
+      queries << sql if sql.include?('FROM "summons"') && sql.include?('"summons"."id" =')
+    end
+    yield
+    queries
+  ensure
+    ActiveSupport::Notifications.unsubscribe(sub)
+  end
+
+  it 'does not run a query per grid summon when rendering the update response' do
+    party = create(:party, user: user)
+    # Distinct summons so the eager-load batches them into one `WHERE id IN`,
+    # while the unfixed N+1 would emit one `WHERE id = ?` per grid summon.
+    4.times { |i| create(:grid_summon, party: party, position: i, summon: create(:summon)) }
+
+    queries = per_summon_id_queries do
+      put "/api/v1/parties/#{party.id}",
+          params: { party: { name: 'Renamed' } }.to_json,
+          headers: headers
+    end
+
+    expect(response).to have_http_status(:ok)
+    expect(queries.size).to eq(0),
+                            "expected no per-summon SELECTs during render, got #{queries.size}:\n#{queries.join("\n")}"
+  end
+end


### PR DESCRIPTION
## what

Sentry's performance tracing flagged an N+1 in `PartiesController#update`: a repeating 4-query pattern per grid summon

```
summons WHERE id = ?
summon_series WHERE id = ?
substitutions EXISTS WHERE grid_id = ? AND grid_type = 'GridSummon'
collection_summons WHERE id = ?
```

`update` (and `grid_update`) load the party via `before_action :set` → `Party.where(...).first` with **no eager-loading**, then render the full `PartyBlueprint`, which walks every grid item. `set_from_slug` (used by `show`) already eager-loads all of this; the mutating actions didn't.

## fix

- Extract `set_from_slug`'s include list into `full_party_preloads`, and add a `load_full_party(id)` helper that re-fetches with those preloads + the substitute-grid preload.
- `update` and `grid_update` now render through `load_full_party(@party.id)` (replacing the bare `@party` / `@party.reload`), so the response serializes from one batched, eager-loaded query.
- No behavior change to the response shape — same `PartyBlueprint` `:full` view, just preloaded.

## testing

- New query-counting regression spec: counts per-grid-summon `summons WHERE id = ?` SELECTs during an update. **Fails on `main` (4), passes with the fix (0)** — the eager load batches into a single `WHERE id IN (...)`.
- Party request suite green (142 examples, 0 failures); RuboCop clean.

Found via the Sentry tracing we just turned on (#440).