### PR TITLE
fix job_skills search 500 for jobs with no base_job

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -232,58 +232,28 @@ module Api
           end
         end
 
-        # Perform the query
-        skills = if search_params[:query].present? && search_params[:query].length >= 2
-                   JobSkill.joins(:job)
-                           .method("#{locale}_search").call(search_params[:query])
-                           .where(conditions)
-                           .where(job: job.id, main: false)
-                           .or(
-                             JobSkill.joins(:job)
-                                     .method("#{locale}_search").call(search_params[:query])
-                                     .where(conditions)
-                                     .where(sub: true)
-                                     .where.not(job: job.id)
-                           )
-                           .or(
-                             JobSkill.joins(:job)
-                                     .method("#{locale}_search").call(search_params[:query])
-                                     .where(conditions)
-                                     .where(job: { base_job: job.base_job.id }, emp: true)
-                                     .where.not(job: job.id)
-                           )
-                           .or(
-                             JobSkill.joins(:job)
-                                     .method("#{locale}_search").call(search_params[:query])
-                                     .where(conditions)
-                                     .where(job: { base_job: job.base_job.id }, base: true)
-                                     .where.not(job: job.id)
-                           )
-                 else
-                   JobSkill.all
-                           .joins(:job)
-                           .where(conditions)
-                           .where(job: job.id, main: false)
-                           .or(
-                             JobSkill.all
-                                     .where(conditions)
-                                     .where(sub: true)
-                                     .where.not(job: job.id)
-                           )
-                           .or(
-                             JobSkill.all
-                                     .where(conditions)
-                                     .where(job: job.base_job.id, base: true)
-                                     .where.not(job: job.id)
-                           )
-                           .or(
-                             JobSkill.all
-                                     .where(conditions)
-                                     .joins(:job)
-                                     .where(job: { base_job: job.base_job.id }, emp: true)
-                                     .where.not(job: job.id)
-                           )
-                 end
+        # Perform the query. The base_job clauses only apply when the job has a
+        # base job; base jobs themselves have none (job.base_job is nil), so they
+        # drop out via compact instead of dereferencing job.base_job.id (was a 500).
+        relations =
+          if search_params[:query].present? && search_params[:query].length >= 2
+            base = JobSkill.joins(:job).method("#{locale}_search").call(search_params[:query]).where(conditions)
+            [
+              base.where(job: job.id, main: false),
+              base.where(sub: true).where.not(job: job.id),
+              job.base_job && base.where(job: { base_job: job.base_job.id }, emp: true).where.not(job: job.id),
+              job.base_job && base.where(job: { base_job: job.base_job.id }, base: true).where.not(job: job.id)
+            ]
+          else
+            [
+              JobSkill.all.joins(:job).where(conditions).where(job: job.id, main: false),
+              JobSkill.all.where(conditions).where(sub: true).where.not(job: job.id),
+              job.base_job && JobSkill.all.where(conditions).where(job: job.base_job.id, base: true).where.not(job: job.id),
+              job.base_job && JobSkill.all.where(conditions).joins(:job).where(job: { base_job: job.base_job.id }, emp: true).where.not(job: job.id)
+            ]
+          end
+
+        skills = relations.compact.reduce(:or)
 
         count = skills.length
         paginated = skills.paginate(page: search_params[:page], per_page: search_page_size)

--- a/spec/requests/api/v1/search_spec.rb
+++ b/spec/requests/api/v1/search_spec.rb
@@ -121,6 +121,28 @@ RSpec.describe 'Api::V1::Search', type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body['results']).to be_an(Array)
     end
+
+    # Regression: a job with no base_job (e.g. a base job itself) made the query
+    # dereference job.base_job.id on nil -> 500 NoMethodError. Both branches.
+    it 'does not error for a job without a base_job (empty query)' do
+      job = create(:job, base_job: nil)
+      create(:job_skill, job: job)
+      post '/api/v1/search/job_skills',
+           params: { search: { job: job.id, locale: 'en', query: '' } }.to_json,
+           headers: { 'Content-Type' => 'application/json' }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['results']).to be_an(Array)
+    end
+
+    it 'does not error for a job without a base_job (with query)' do
+      job = create(:job, base_job: nil)
+      create(:job_skill, job: job)
+      post '/api/v1/search/job_skills',
+           params: { search: { job: job.id, locale: 'en', query: 'skill' } }.to_json,
+           headers: { 'Content-Type' => 'application/json' }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['results']).to be_an(Array)
+    end
   end
 
   describe 'POST /api/v1/search/guidebooks' do


### PR DESCRIPTION
## what

Sentry caught a `NoMethodError: undefined method 'id' for nil` in `SearchController#job_skills`:

```
.where(job: job.base_job.id, base: true)
                     ^^^
```

All four query clauses dereference `job.base_job.id`, but a job with **no base job** (a base job itself) has `job.base_job == nil` → 500. The reported request had an empty query (the `else` branch), but the search branch had the same flaw.

This is **separate from #441** (which fixed the `jp`-locale `jp_search` scope crash in the same action).

## fix

The base/emp clauses only make sense when the job *has* a base job, so they now drop out (`compact`) when `job.base_job` is nil, instead of dereferencing it. The job/sub clauses are unchanged. Same query semantics for jobs that do have a base job (verified the search and empty-query branches still return cross-job skills).

## testing

- Two regression tests (no-base_job, empty query **and** with query) — both **fail on `main` (500)**, pass with the fix.
- The existing base_job-present tests still pass. Search suite green (31 examples, 0 failures); RuboCop clean.