### PR TITLE
fix users#info 500 -> 404 for unknown usernames

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,7 +5,10 @@ module Api
     class UsersController < Api::V1::ApiController
       class ForbiddenError < StandardError; end
 
-      before_action :set, except: %w[create check_email check_username me search deposit_edit_keys]
+      # update looks the user up by id (set_by_id); the rest look up by username
+      # (set). update must be excluded from set so its id isn't treated as a
+      # username (which now 404s on miss).
+      before_action :set, except: %w[create check_email check_username me search deposit_edit_keys update]
       before_action :set_by_id, only: %w[update]
       before_action :doorkeeper_authorize!, only: %w[me search deposit_edit_keys]
 
@@ -293,9 +296,12 @@ module Api
         'visibility = 1' if current_user != @user
       end
 
-      # Specify whitelisted properties that can be modified.
+      # Loads the user named in the path. 404s for unknown usernames so bot
+      # probes (sitemap.xml, favicon.ico, ...) don't render a nil user through
+      # the blueprint and 500.
       def set
         @user = User.includes(active_crew_membership: :crew).find_by('lower(username) = ?', params[:id].downcase)
+        render_not_found_response('user') unless @user
       end
 
       def set_by_id
@@ -304,6 +310,7 @@ module Api
         else
           @user = User.includes(active_crew_membership: :crew).find_by('id = ?', params[:id])
         end
+        render_not_found_response('user') unless @user
       end
 
       def user_params

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe 'Api::V1::Users', type: :request do
       expect(json['username']).to eq(user.username)
     end
 
+    # Regression: unknown usernames (bot probes like sitemap/favicon.ico) used
+    # to render a nil user through the blueprint -> 500. Now they 404.
+    it 'returns 404 for an unknown username instead of 500' do
+      get '/api/v1/users/info/sitemap', params: { check_collection: 'true', check_support_summons: 'true' }
+      expect(response).to have_http_status(:not_found)
+    end
+
     context 'with check_collection=true' do
       let(:private_user) { create(:user, collection_privacy: :private_collection) }
 


### PR DESCRIPTION
## what

Sentry caught a `NoMethodError: undefined method 'id' for nil` in `UsersController#info`, from a bot hitting `/v1/users/info/sitemap.xml`:

```
object.public_send(field_name)   # object (the user) is nil
```

`set` (the before_action for `info`, `show`, `parties`, …) looks the user up by username with `find_by` and never nil-checked it. So any unknown username — bot probes like `sitemap.xml`, `favicon.ico`, etc. — left `@user = nil`, which then rendered through the blueprint and 500'd. These should be 404s.

## fix

- `set` (and `set_by_id`) now `render_not_found_response('user')` when the lookup misses → unknown usernames/ids return **404** instead of 500.
- `set` was also (wastefully) running for `update`, whose path `:id` is a user **id**, not a username — previously harmless because `set_by_id` overwrote `@user`, but the new 404 guard would bail first. Excluded `update` from `set` so only `set_by_id` handles it.

## testing

- Regression test: `GET /users/info/sitemap?check_collection=true&check_support_summons=true` → **404** (fails on `main` with 500).
- Full request suite green (852 examples, 0 failures); RuboCop clean. Verified `update` and the username-based actions still work.