### PR TITLE
add rack-attack: bot-path blocklist + per-token rate limiting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 ruby '3.4.4'
 
 gem 'bootsnap'
+gem 'rack-attack'
 gem 'rack-cors'
 gem 'rails'
 gem 'sprockets-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.9)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-session (2.1.0)
@@ -492,6 +494,7 @@ DEPENDENCIES
   prosopite
   pry
   puma
+  rack-attack
   rack-cors
   rails
   redis

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Rack::Attack blocks scanner/bot probe paths and rate-limits the API.
+#
+# Topology notes:
+# - The API sits behind Cloudflare, so the authoritative client address is the
+#   CF-Connecting-IP header (Cloudflare sets it and overwrites spoofed values).
+# - The SvelteKit SSR frontend proxies many users' requests from one egress IP,
+#   so authenticated traffic is throttled per access token (= per user), never
+#   per IP. Per-IP limiting of public/unauthenticated traffic is left to
+#   Cloudflare, which can exempt the SSR origin.
+class Rack::Attack
+  # Shared counter store so limits hold across all app instances: Redis in real
+  # environments, in-memory locally. (Disabled entirely in test, see bottom.)
+  cache.store =
+    if Rails.env.local?
+      ActiveSupport::Cache::MemoryStore.new
+    else
+      ActiveSupport::Cache::RedisCacheStore.new(url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0'))
+    end
+
+  def self.bearer_token(req)
+    req.get_header('HTTP_AUTHORIZATION')&.slice(/\ABearer\s+(.+)\z/i, 1)
+  end
+
+  # Real client IP behind Cloudflare; falls back to Rack's IP for direct hits.
+  def self.client_ip(req)
+    req.get_header('HTTP_CF_CONNECTING_IP').presence || req.ip
+  end
+
+  ### Allowlist — never block or throttle the platform healthcheck. (The route
+  # prefix is /v1 in production and /api/v1 elsewhere, hence end_with?.)
+  safelist('healthcheck') { |req| req.path.end_with?('/version') }
+
+  ### Blocklist — scanner/bot probe paths, answered 404 before routing.
+  BOT_PATHS = %r{
+    \A/(?:wp-admin|wp-login|wp-content|wp-includes|wp-json|phpmyadmin|cgi-bin|administrator)
+    | \A/\.(?:env|git)
+    | \.php\z
+    | /favicon\.ico\z
+    | /sitemap\.xml\z
+  }xi
+  blocklist('bot probes') { |req| BOT_PATHS.match?(req.path) }
+
+  ### Throttle — authenticated requests per access token (= per user).
+  # Limit is env-tunable so it can be adjusted without a deploy.
+  throttle('api/token', limit: ->(_req) { ENV.fetch('RACK_ATTACK_TOKEN_LIMIT', '300').to_i }, period: 1.minute) do |req|
+    bearer_token(req)
+  end
+
+  ### Responses
+  self.blocklisted_responder = lambda do |_req|
+    [404, { 'content-type' => 'application/json' }, [%({"error":"Not found"})]]
+  end
+
+  self.throttled_responder = lambda do |req|
+    period = req.env.dig('rack.attack.match_data', :period)
+    headers = { 'content-type' => 'application/json' }
+    headers['retry-after'] = period.to_s if period
+    [429, headers, [%({"error":"Rate limit exceeded. Please try again later."})]]
+  end
+end
+
+# Throttling would otherwise interfere with the test suite; specs that exercise
+# Rack::Attack enable it explicitly.
+Rack::Attack.enabled = false if Rails.env.test?

--- a/spec/requests/api/v1/rack_attack_spec.rb
+++ b/spec/requests/api/v1/rack_attack_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Rack::Attack is disabled in the test env by default (so throttling can't
+# interfere with the rest of the suite); this spec enables it around its
+# examples and clears the counter store between them.
+RSpec.describe 'Rack::Attack', type: :request do
+  let(:user) { create(:user) }
+  let(:token) do
+    Doorkeeper::AccessToken.create!(resource_owner_id: user.id, expires_in: 30.days, scopes: 'public').token
+  end
+
+  around do |example|
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store.clear
+    example.run
+  ensure
+    Rack::Attack.enabled = false
+    Rack::Attack.cache.store.clear
+  end
+
+  describe 'bot-path blocklist' do
+    it 'answers 404 for scanner probes before they reach the app' do
+      get '/wp-login.php'
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'blocks any path ending in .php' do
+      get '/api/v1/whatever/x.php'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'per-token throttle' do
+    it 'returns 429 once a token exceeds its limit, scoped to that token' do
+      original = ENV.fetch('RACK_ATTACK_TOKEN_LIMIT', nil)
+      ENV['RACK_ATTACK_TOKEN_LIMIT'] = '2'
+      headers = { 'Authorization' => "Bearer #{token}" }
+
+      2.times do
+        get '/api/v1/users/me', headers: headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      get '/api/v1/users/me', headers: headers
+      expect(response).to have_http_status(:too_many_requests)
+
+      # A different token is unaffected.
+      other = Doorkeeper::AccessToken.create!(resource_owner_id: create(:user).id, expires_in: 30.days,
+                                              scopes: 'public').token
+      get '/api/v1/users/me', headers: { 'Authorization' => "Bearer #{other}" }
+      expect(response).to have_http_status(:ok)
+    ensure
+      ENV['RACK_ATTACK_TOKEN_LIMIT'] = original
+    end
+  end
+end


### PR DESCRIPTION
## what

Adds `rack-attack` for (1) blocking scanner/bot probe paths and (2) real rate limiting — the two things we'd otherwise be missing on a public API.

## config (`config/initializers/rack_attack.rb`)

- **Blocklist** scanner paths (`wp-admin`, `wp-login`, `*.php`, `.env`, `.git`, `sitemap.xml`, `favicon.ico`, …) → **404 before routing**, so they stop triggering the `AccessToken` + `User` lookups that the bot-probe 500s did (those are separately fixed in #445; this short-circuits even earlier).
- **Throttle authenticated requests per access token** (= per user), `300/min`, tunable at runtime via `RACK_ATTACK_TOKEN_LIMIT`. → **429** with `Retry-After`.
- **Per-token, not per-IP, by design:** the SvelteKit SSR frontend proxies every user's request from a single egress IP, so per-IP throttling would lump all SSR traffic together and 429 real users. Per-IP limiting of public/unauthenticated traffic is left to **Cloudflare**, which can exempt the SSR origin.
- Counters in **Redis** (`REDIS_URL`) so limits hold across instances. `CF-Connecting-IP` helper resolves the real client IP behind Cloudflare.
- Healthcheck (`…/version`) safelisted. Disabled in the test env so it can't interfere with the suite.

## testing

- New spec: bot paths → 404; a token over its (lowered) limit → 429, scoped to that token (a different token is unaffected).
- Full request suite green (854 examples, 0 failures); RuboCop clean.

## follow-ups (not in this PR)

- Tune `RACK_ATTACK_TOKEN_LIMIT` once we see real traffic.
- The existing `rate_limit by: request.remote_ip` on `search#suggestions` likely lumps everyone under the Cloudflare edge IP (no trusted-proxy config) — worth switching to `CF-Connecting-IP` or trusting Cloudflare ranges.
- Consider routing SSR→API over Railway's internal network so that traffic bypasses both Cloudflare and these limits entirely.