### PR TITLE
Weapon data corrections: Taisai series, Exo Heliocentrum duplicate, awakening flags

### DIFF
--- a/db/data/20260704130000_reclassify_taisai_spirit_bow.rb
+++ b/db/data/20260704130000_reclassify_taisai_spirit_bow.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Taisai Spirit Bow (1040708700) is a Grand weapon but was imported under the
+# generic gacha series. Its weapon_awakenings rows made gacha look like an
+# awakening-bearing series to the flag sync that follows.
+class ReclassifyTaisaiSpiritBow < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      UPDATE weapons
+      SET weapon_series_id = (SELECT id FROM weapon_series WHERE slug = 'grand')
+      WHERE granblue_id = '1040708700'
+        AND weapon_series_id = (SELECT id FROM weapon_series WHERE slug = 'gacha')
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE weapons
+      SET weapon_series_id = (SELECT id FROM weapon_series WHERE slug = 'gacha')
+      WHERE granblue_id = '1040708700'
+    SQL
+  end
+end

--- a/db/data/20260704140000_merge_duplicate_exo_heliocentrum.rb
+++ b/db/data/20260704140000_merge_duplicate_exo_heliocentrum.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Exo Heliocentrum exists twice under granblue_id 1040424300. The keeper
+# (d7c0cf3d) carries the weapon_awakenings links and ~95% of usage (14 grids,
+# 356 collection rows) but a NULL max_awakening_level; the duplicate (3639d531)
+# has max_awakening_level 10 and light usage (1 grid, 24 collection rows).
+# Copy the max level onto the keeper, repoint every reference, delete the dup.
+#
+# collection_weapons (user_id, weapon_id) is intentionally non-unique (players
+# own multiple copies) and no (user_id, game_id) pairs collide across the two
+# rows, so repointing cannot violate constraints.
+class MergeDuplicateExoHeliocentrum < ActiveRecord::Migration[8.0]
+  KEEPER = "d7c0cf3d-7652-48a1-831b-4bd5b6448e1d"
+  DUPLICATE = "3639d531-05fb-4402-8c00-8542c5de410e"
+
+  def up
+    return unless duplicate_exists?
+
+    execute <<~SQL
+      UPDATE weapons k
+      SET max_awakening_level = d.max_awakening_level
+      FROM weapons d
+      WHERE k.id = '#{KEEPER}' AND d.id = '#{DUPLICATE}'
+        AND k.max_awakening_level IS NULL
+    SQL
+
+    %w[grid_weapons collection_weapons weapon_awakenings].each do |table|
+      execute "UPDATE #{table} SET weapon_id = '#{KEEPER}' WHERE weapon_id = '#{DUPLICATE}'"
+    end
+
+    execute "DELETE FROM weapons WHERE id = '#{DUPLICATE}'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def duplicate_exists?
+    select_value("SELECT 1 FROM weapons WHERE id = '#{DUPLICATE}'").present?
+  end
+end

--- a/db/data/20260704150000_sync_weapon_series_awakening_flags.rb
+++ b/db/data/20260704150000_sync_weapon_series_awakening_flags.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# weapon_series.has_awakening was seeded from a hardcoded five-series list, but
+# grand, ennead, and class-champion also contain weapons with weapon_awakenings
+# rows (e.g. Fist of Destruction), so the frontend's Edit-weapon pane — which
+# gates on the series flag — never offered their awakenings. Sync the flag from
+# the data in both directions: a series has awakenings iff one of its weapons
+# does. Weapons without awakenings in a flagged series still hide the pane via
+# the per-weapon max_awakening_level > 0 check.
+#
+# Runs after the Taisai reclassification so gacha (whose only awakening-bearing
+# weapon was the misclassified Taisai Spirit Bow) correctly stays false.
+class SyncWeaponSeriesAwakeningFlags < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      UPDATE weapon_series ws
+      SET has_awakening = EXISTS (
+        SELECT 1 FROM weapons w
+        JOIN weapon_awakenings wa ON wa.weapon_id = w.id
+        WHERE w.weapon_series_id = ws.id
+      )
+      WHERE ws.has_awakening != EXISTS (
+        SELECT 1 FROM weapons w
+        JOIN weapon_awakenings wa ON wa.weapon_id = w.id
+        WHERE w.weapon_series_id = ws.id
+      )
+    SQL
+  end
+
+  def down
+    # Restore the seed's original explicit list.
+    execute <<~SQL
+      UPDATE weapon_series SET has_awakening = (slug IN ('revans', 'celestial', 'exo', 'proven', 'world'))
+    SQL
+  end
+end


### PR DESCRIPTION
Three data migrations (data_migrate), deployable independently of #434:

1. **Reclassify Taisai Spirit Bow** (`1040708700`) from `gacha` to `grand` — it's a Grand weapon that was imported under the generic gacha series.

2. **Merge the duplicate Exo Heliocentrum** (`granblue_id 1040424300`): two weapon rows existed for the same weapon. The keeper (`d7c0cf3d`, 14 grids / 356 collection rows / the `weapon_awakenings` links) gets the duplicate's `max_awakening_level` (10); grids, collections, and awakenings are repointed off the duplicate (`3639d531`, 1 grid / 24 collection rows) before it's deleted. No `(user_id, game_id)` collisions exist between the two rows, and `(user_id, weapon_id)` is non-unique by design, so repointing is constraint-safe. Note: 4 users hold copies under both rows; after the merge they'll see those as multiple copies of the same weapon, which may be accurate (multiple ownership) or may need manual dedupe.

3. **Sync `weapon_series.has_awakening` from the data, both directions** — the seed hardcoded five series (revans, celestial, exo, proven, world), but grand, ennead, and class-champion also contain weapons with awakenings, so the Edit-weapon pane never offered them (e.g. Fist of Destruction). A series is flagged iff one of its weapons has `weapon_awakenings` rows. Weapons without awakenings in a flagged series still hide the pane via the per-weapon `max_awakening_level > 0` gate. Ordered after the Taisai fix so gacha correctly stays unflagged.

Verified locally: Taisai resolves to grand, flags = celestial/class-champion/ennead/exo/grand/proven/revans/world, single Heliocentrum row with merged usage (15 grids, 380 collections, 2 awakenings, max 10), and the API serves Fist of Destruction with `has_awakening: true` + both awakening options.