### PR TITLE
Weapon skill families payload + release-date collection sort

### DIFF
--- a/app/controllers/api/v1/collection_characters_controller.rb
+++ b/app/controllers/api/v1/collection_characters_controller.rb
@@ -291,6 +291,10 @@ module Api
           scope.order(proficiency1: :asc)
         when 'proficiency_desc'
           scope.order(proficiency1: :desc)
+        when 'release_date_desc'
+          scope.order(Arel.sql('latest_date DESC NULLS LAST'), id: :asc)
+        when 'release_date_asc'
+          scope.order(Arel.sql('latest_date ASC NULLS LAST'), id: :asc)
         else
           scope.order(latest_date: :desc, id: :asc)
         end

--- a/app/controllers/api/v1/collection_summons_controller.rb
+++ b/app/controllers/api/v1/collection_summons_controller.rb
@@ -348,6 +348,10 @@ module Api
           scope.order(element: :asc)
         when 'element_desc'
           scope.order(element: :desc)
+        when 'release_date_desc'
+          scope.order(Arel.sql('latest_date DESC NULLS LAST'), id: :asc)
+        when 'release_date_asc'
+          scope.order(Arel.sql('latest_date ASC NULLS LAST'), id: :asc)
         else
           scope.order(latest_date: :desc, id: :asc)
         end

--- a/app/controllers/api/v1/collection_weapons_controller.rb
+++ b/app/controllers/api/v1/collection_weapons_controller.rb
@@ -362,6 +362,10 @@ module Api
           scope.order(proficiency: :asc)
         when 'proficiency_desc'
           scope.order(proficiency: :desc)
+        when 'release_date_desc'
+          scope.order(Arel.sql('latest_date DESC NULLS LAST'), id: :asc)
+        when 'release_date_asc'
+          scope.order(Arel.sql('latest_date ASC NULLS LAST'), id: :asc)
         else
           scope.order(latest_date: :desc, id: :asc)
         end

--- a/app/controllers/api/v1/weapon_skill_families_controller.rb
+++ b/app/controllers/api/v1/weapon_skill_families_controller.rb
@@ -32,7 +32,7 @@ module Api
           weapon_skill_family: {
             modifier: modifier,
             display_name: display_name(versions),
-            icon_stem: versions.filter_map(&:icon_stem).first,
+            icon_stems: versions.filter_map(&:icon_stem).uniq,
             data: WeaponSkillDatumBlueprint.render_as_hash(data),
             effects: WeaponSkillEffectBlueprint.render_as_hash(all_effects),
             versions: versions_payload(versions),
@@ -58,6 +58,7 @@ module Api
                                                  Arel.sql('COUNT(DISTINCT weapon_skills.weapon_granblue_id)'))
                                           .to_h { |mod, versions, weapons| [mod, { versions: versions, weapons: weapons }] }
         names = family_display_names
+        icon_stems = family_icon_stems
 
         modifiers = (data_rows.map(&:modifier) + effect_rows.map(&:modifier) + version_stats.keys).compact.uniq
         modifiers.map do |mod|
@@ -67,6 +68,7 @@ module Api
           {
             modifier: mod,
             display_name: names[mod],
+            icon_stems: icon_stems[mod] || [],
             boost_types: (d.map(&:boost_type) + e.map(&:boost_type)).uniq.sort,
             series: (d.filter_map(&:series) + e.filter_map(&:series)).uniq.sort,
             sizes: d.filter_map(&:size).uniq.sort,
@@ -78,15 +80,35 @@ module Api
         end
       end
 
-      # Most common linked skill name per family (fallback: the modifier itself).
+      # Linked skill name per family, but only when every version agrees on one —
+      # names like "Tsunami's Aegis" / "Mountain's Aegis" are per-weapon flavor
+      # text for the same mechanical family, so a family spanning several of
+      # them has no single true name (falls back to the modifier instead).
       def family_display_names
         rows = WeaponSkillVersion.joins(:skill)
                                  .where.not(skill_modifier: [nil, ''])
                                  .group(:skill_modifier, 'skills.name_en', 'skills.name_jp')
-                                 .order(Arel.sql('COUNT(*) DESC'))
                                  .pluck(:skill_modifier, 'skills.name_en', 'skills.name_jp')
-        rows.each_with_object({}) do |(mod, en, ja), out|
-          out[mod] ||= { en: en, ja: ja }
+        rows.group_by { |mod, _, _| mod }.each_with_object({}) do |(mod, entries), out|
+          next unless entries.size == 1
+
+          (_, en, ja) = entries.first
+          out[mod] = { en: en, ja: ja }
+        end
+      end
+
+      # All distinct resolvable icon stems per family — a family can carry more than
+      # one when versions resolve to different element/type art (e.g. Aegis's
+      # per-element icons), and the frontend cycles through them for those.
+      def family_icon_stems
+        versions = WeaponSkillVersion.joins(weapon_skill: :weapon)
+                                     .where.not(skill_modifier: [nil, ''])
+                                     .includes(weapon_skill: :weapon)
+        versions.each_with_object(Hash.new { |h, k| h[k] = [] }) do |v, out|
+          stem = v.icon_stem
+          next if stem.blank?
+
+          out[v.skill_modifier] << stem unless out[v.skill_modifier].include?(stem)
         end
       end
 
@@ -106,10 +128,13 @@ module Api
         families
       end
 
+      # Same "only when every version agrees" rule as family_display_names,
+      # applied to one family's already-loaded versions.
       def display_name(versions)
-        counts = versions.group_by { |v| [v.name_en, v.name_jp] }
-                         .transform_values(&:size)
-        (en, ja) = counts.max_by { |_, c| c }&.first
+        distinct = versions.map { |v| [v.name_en, v.name_jp] }.uniq
+        return { en: params[:modifier], ja: nil } unless distinct.size == 1
+
+        (en, ja) = distinct.first
         { en: en || params[:modifier], ja: ja }
       end
 
@@ -120,7 +145,10 @@ module Api
             id: v.id,
             skill_id: v.skill_id,
             weapon: weapon && { granblue_id: weapon.granblue_id, name_en: weapon.name_en,
-                                element: weapon.element }
+                                element: weapon.element, rarity: weapon.rarity,
+                                proficiency: weapon.proficiency,
+                                weapon_series_id: weapon.weapon_series_id,
+                                latest_date: weapon.latest_date }
           )
         end
       end

--- a/app/models/collection_character.rb
+++ b/app/models/collection_character.rb
@@ -52,6 +52,10 @@ class CollectionCharacter < ApplicationRecord
       joins(:character).order('characters.proficiency1 ASC')
     when 'proficiency_desc'
       joins(:character).order('characters.proficiency1 DESC')
+    when 'release_date_desc'
+      joins(:character).order(Arel.sql('characters.latest_date DESC NULLS LAST'))
+    when 'release_date_asc'
+      joins(:character).order(Arel.sql('characters.latest_date ASC NULLS LAST'))
     else
       order(created_at: :desc) # Default: newest first
     end

--- a/app/models/collection_summon.rb
+++ b/app/models/collection_summon.rb
@@ -46,6 +46,10 @@ class CollectionSummon < ApplicationRecord
       joins(:summon).order(uncap_level: :asc)
                     .order(Arel.sql('summons.transcendence ASC'))
                     .order(transcendence_step: :asc)
+    when 'release_date_desc'
+      joins(:summon).order(Arel.sql('summons.latest_date DESC NULLS LAST'))
+    when 'release_date_asc'
+      joins(:summon).order(Arel.sql('summons.latest_date ASC NULLS LAST'))
     else
       order(created_at: :desc)
     end

--- a/app/models/collection_weapon.rb
+++ b/app/models/collection_weapon.rb
@@ -71,6 +71,10 @@ class CollectionWeapon < ApplicationRecord
       joins(:weapon).order('weapons.proficiency ASC')
     when 'proficiency_desc'
       joins(:weapon).order('weapons.proficiency DESC')
+    when 'release_date_desc'
+      joins(:weapon).order(Arel.sql('weapons.latest_date DESC NULLS LAST'))
+    when 'release_date_asc'
+      joins(:weapon).order(Arel.sql('weapons.latest_date ASC NULLS LAST'))
     else
       order(created_at: :desc)
     end


### PR DESCRIPTION
## Summary

Backend changes supporting the Weapon Skills database redesign (frontend: **jedmund/hensei-web#887**).

### `weapon_skill_families` payload
- Return **all distinct `icon_stems`** per family (was a single stem) so the UI can cycle a family's element/type icon variants.
- Only surface a family `display_name` when **every version agrees on one**. Element-flavored names like "Tsunami's Aegis" are per-weapon, so a multi-name family now falls back to the bare modifier ("Aegis") instead of arbitrarily picking the most common flavor.
- Include `rarity`, `proficiency`, `weapon_series_id`, and `latest_date` on each version's weapon, so the "Carried by" list can filter and sort.

### Release-date collection sort
- Add `release_date_asc` / `release_date_desc` sort keys to the weapon, character, and summon collection endpoints — both the owned scopes and the unowned/browse sorts — ordered by the generated `latest_date` column, NULLs last.

## Testing

- `ruby -c` on all touched files.
- Verified `/api/v1/weapon_skill_families` (and `/:modifier`) return the new fields against local seeded data, including the fallback display-name behavior for multi-flavor families like Aegis.