### PR TITLE
Data accuracy: stat audit, JP wiki improvements, and wiki_raw_jp for weapons

### DIFF
--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,10 +1,11 @@
 Rails.application.config.after_initialize do
+  next if defined?(Rake) && Rake.application.top_level_tasks.any?
+
   Rails.logger.info "Initializing AWS Service..."
   begin
     AwsService.new
     Rails.logger.info "AWS Service initialized successfully"
-  rescue => e
-    Rails.logger.error "Failed to initialize AWS Service: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
+  rescue StandardError => e
+    Rails.logger.warn "Skipping AWS Service: #{e.message}"
   end
 end

--- a/db/migrate/20260706000000_add_wiki_raw_jp_to_weapons.rb
+++ b/db/migrate/20260706000000_add_wiki_raw_jp_to_weapons.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWikiRawJpToWeapons < ActiveRecord::Migration[8.0]
+  def change
+    add_column :weapons, :wiki_raw_jp, :text, comment: 'Raw HTML from gbf-wiki.com (Japanese)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_05_133001) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_06_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -1489,6 +1489,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_05_133001) do
     t.integer "bullet_slots", default: [], null: false, array: true
     t.virtual "latest_date", type: :date, as: "GREATEST(release_date, flb_date, ulb_date, transcendence_date)", stored: true
     t.datetime "wiki_raw_fetched_at"
+    t.text "wiki_raw_jp", comment: "Raw HTML from gbf-wiki.com (Japanese)"
     t.index ["forge_chain_id"], name: "index_weapons_on_forge_chain_id"
     t.index ["forged_from"], name: "index_weapons_on_forged_from"
     t.index ["gacha"], name: "index_weapons_on_gacha"

--- a/lib/granblue/downloaders/jp_wiki_downloader.rb
+++ b/lib/granblue/downloaders/jp_wiki_downloader.rb
@@ -3,53 +3,139 @@
 module Granblue
   module Downloaders
     # Fetches and caches raw HTML from the Japanese wiki (gbf-wiki.com) into
-    # <record>.wiki_raw_jp. Works for any model with wiki_ja + wiki_raw_jp
-    # (characters, summons). Once cached, parsing iterates offline with no
-    # further network calls. The JP wiki has no API, so the batch backfill is
-    # throttled to stay polite.
+    # <record>.wiki_raw_jp. Works for any model with name_jp + wiki_raw_jp
+    # (characters, summons, weapons). Once cached, parsing iterates offline
+    # with no further network calls. The JP wiki has no API, so the batch
+    # backfill is throttled to stay polite.
     class JpWikiDownloader
       DEFAULT_THROTTLE = 1.0 # seconds between requests
 
+      RARITY_SUFFIX = {
+        1 => '(R)',
+        2 => '(SR)',
+        3 => '(SSR)'
+      }.freeze
+
       # Backfill wiki_raw_jp for a model. Skips rows already cached unless force.
+      # Uses wiki_ja when it's clean Japanese; falls back to name_jp + rarity
+      # suffix when wiki_ja is blank or a legacy percent-encoded path.
       def self.backfill(model:, limit: nil, throttle: DEFAULT_THROTTLE, force: false, debug: false)
-        scope = model.where.not(wiki_ja: [nil, ''])
-        scope = scope.where(wiki_raw_jp: [nil, '']) unless force
+        scope = model.where.not(wiki_raw_jp: [nil, '']) if force
+        scope ||= eligible_scope(model)
         scope = scope.limit(limit) if limit
 
-        client = Granblue::Parsers::JpWiki.new(debug: debug)
         total = scope.count
+        puts "Downloading JP wiki pages for #{total} #{model.name.downcase}s" \
+             "#{' (missing only)' unless force}...\n\n"
+
+        client = Granblue::Parsers::JpWiki.new(debug: debug)
         downloaded = 0
-        errors = []
+        errored = []
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
         scope.find_each.with_index do |record, index|
-          new(record, client: client).download(force: force)
+          progress = index + 1
+          title = resolve_title(record)
+          new(record, client: client, jp_title: title).download(force: force)
           downloaded += 1
-          puts "#{index + 1}/#{total} #{label(record)}" if debug
-          sleep(throttle) if throttle&.positive?
+          print_progress(progress, total, label(record), 'OK', start_time)
         rescue StandardError => e
-          errors << "#{record.id}: #{e.message}"
-          Rails.logger.error "[JP_WIKI] #{record.id}: #{e.message}"
+          errored << { name: label(record), title: title, error: e.message }
+          print_progress(progress, total, label(record), "ERR: #{e.message}", start_time)
+        ensure
+          sleep(throttle) if throttle&.positive?
         end
 
-        { downloaded: downloaded, skipped: total - downloaded - errors.size, errors: errors }
+        print_summary(downloaded, errored, total, start_time)
+        { downloaded: downloaded, skipped: total - downloaded - errored.size, errors: errored }
+      end
+
+      # Records eligible for JP wiki download: have a clean wiki_ja, or have
+      # name_jp (so we can construct the title ourselves).
+      def self.eligible_scope(model)
+        clean_wiki_ja = model.where.not(wiki_ja: [nil, '']).where.not('wiki_ja LIKE ?', '%{%')
+        with_name_jp = model.where(wiki_ja: [nil, '']).where.not(name_jp: [nil, ''])
+        model.where(id: clean_wiki_ja).or(model.where(id: with_name_jp))
+      end
+
+      # Resolve the JP wiki page title for a record.
+      #   - Percent-encoded wiki_ja: pass through (JpWiki decodes it)
+      #   - Clean wiki_ja (plain Japanese): use as-is
+      #   - Otherwise: construct from name_jp + rarity suffix
+      # Weapons get a 武器/ prefix on gbf-wiki.com; characters/summons do not.
+      def self.resolve_title(record)
+        wiki_ja = record.wiki_ja.to_s
+        return wiki_ja if wiki_ja.present? && wiki_ja.match?(/%[0-9A-Fa-f]{2}/)
+
+        title = if wiki_ja.present?
+                  wiki_ja
+                else
+                  name_jp = record.name_jp.to_s
+                  return nil if name_jp.blank?
+
+                  suffix = RARITY_SUFFIX[record.rarity] || ''
+                  "#{name_jp} #{suffix}".strip
+                end
+
+        record.is_a?(Weapon) && !title.start_with?('武器/') ? "武器/#{title}" : title
+      end
+
+      def self.print_progress(current, total, name, status, start_time)
+        pct = format('%5.1f%%', (current.to_f / total * 100))
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        eta = current > 1 ? format_eta((elapsed / current) * (total - current)) : '?'
+        marker = status == 'OK' ? 'OK' : 'ERR'
+        suffix = status == 'OK' ? '' : " (#{status})"
+        line = "[#{current}/#{total}] #{pct}  [#{marker}] #{name}#{suffix}"
+        line += "  elapsed: #{format_eta(elapsed)}  eta: #{eta}"
+        puts line
+      end
+
+      def self.print_summary(downloaded, errored, total, start_time)
+        elapsed = format_eta(Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time)
+
+        puts "\n#{'=' * 60}"
+        puts "Done in #{elapsed}"
+        puts "  Downloaded: #{downloaded}"
+        puts "  Errors:     #{errored.size}"
+        puts "  Skipped:    #{total - downloaded - errored.size}"
+
+        return if errored.empty?
+
+        puts "\nErrors:"
+        errored.each { |e| puts "  #{e[:name]} (#{e[:title]}) — #{e[:error]}" }
+      end
+
+      def self.format_eta(seconds)
+        return '<1s' if seconds < 1
+
+        s = seconds.to_i
+        return "#{s}s" if s < 60
+
+        m, s = s.divmod(60)
+        return "#{m}m#{s}s" if m < 60
+
+        h, m = m.divmod(60)
+        "#{h}h#{m}m"
       end
 
       def self.label(record)
         record.try(:name_en).presence || record.try(:granblue_id) || record.id
       end
 
-      def initialize(record, client: nil)
+      def initialize(record, client: nil, jp_title: nil)
         @record = record
         @client = client || Granblue::Parsers::JpWiki.new
+        @jp_title = jp_title || self.class.resolve_title(record)
       end
 
-      # Fetches the JP wiki page and caches it. Returns the HTML, or nil when the
-      # record has no JP title. No-op if already cached unless force.
+      # Fetches the JP wiki page and caches it. Returns the HTML, or nil when
+      # no title could be resolved. No-op if already cached unless force.
       def download(force: false)
         return @record.wiki_raw_jp if @record.wiki_raw_jp.present? && !force
-        return if @record.wiki_ja.blank?
+        return if @jp_title.blank?
 
-        html = @client.fetch(@record.wiki_ja)
+        html = @client.fetch(@jp_title)
         @record.update!(wiki_raw_jp: html)
         html
       end

--- a/lib/granblue/parsers/jp_wiki.rb
+++ b/lib/granblue/parsers/jp_wiki.rb
@@ -52,13 +52,32 @@ module Granblue
         URI.encode_www_form_component(title)
       end
 
+      # gbf-wiki.com sometimes returns a 200 with a "Runtime error" HTML page
+      # (NG word filter, IP restriction, etc.). Detect and reject it so the
+      # caller treats it as an error rather than caching garbage HTML.
+      RUNTIME_ERROR_MARKERS = [
+        '<h1 class="title">Runtime error</h1>',
+        '<title>Runtime error'
+      ].freeze
+
       def handle_response(response, title)
         case response.code
-        when 200 then response.body
+        when 200
+          body = response.body
+          if runtime_error?(body)
+            raise WikiError.new(code: 200, message: 'Runtime error page returned', page: title)
+          end
+
+          body
         when 404 then raise WikiError.new(code: 404, message: 'Page not found', page: title)
         when 500...600 then raise WikiError.new(code: response.code, message: 'Server error', page: title)
         else raise WikiError.new(code: response.code, message: 'Unexpected response', page: title)
         end
+      end
+
+      def runtime_error?(body)
+        text = body.to_s
+        RUNTIME_ERROR_MARKERS.any? { |marker| text.include?(marker) }
       end
     end
   end

--- a/lib/granblue/wiki_error.rb
+++ b/lib/granblue/wiki_error.rb
@@ -2,18 +2,19 @@
 
 module Granblue
   class WikiError < StandardError
+    attr_reader :code, :page
+
     def initialize(code: nil, page: nil, message: nil)
-      super
+      super(message)
       @code = code
       @page = page
-      @message = message
     end
 
     def to_hash
       {
-        message: @message,
-        code: @code,
-        page: @page
+        message: message,
+        code: code,
+        page: page
       }
     end
   end

--- a/lib/tasks/jp_wiki.rake
+++ b/lib/tasks/jp_wiki.rake
@@ -3,20 +3,23 @@
 namespace :granblue do
   desc <<~DESC
     Download Japanese wiki (gbf-wiki.com) HTML into wiki_raw_jp. Throttled.
+
     Usage:
       rake granblue:download_jp_wiki                         # characters, missing only
       rake granblue:download_jp_wiki model=summon limit=50
+      rake granblue:download_jp_wiki model=weapon            # weapons (now supported)
       rake granblue:download_jp_wiki force=true throttle=2
   DESC
   task download_jp_wiki: :environment do
+    ActiveRecord::Base.logger.level = Logger::WARN unless ENV['debug'] == 'true'
+
     model = (ENV['model'].presence || 'character').classify.constantize
-    result = Granblue::Downloaders::JpWikiDownloader.backfill(
+    Granblue::Downloaders::JpWikiDownloader.backfill(
       model: model,
       limit: ENV['limit']&.to_i,
       throttle: (ENV['throttle'] || Granblue::Downloaders::JpWikiDownloader::DEFAULT_THROTTLE).to_f,
       force: ENV['force'] == 'true',
-      debug: true
+      debug: ENV['debug'] == 'true'
     )
-    puts "Downloaded: #{result[:downloaded]}  Skipped: #{result[:skipped]}  Errors: #{result[:errors].size}"
   end
 end

--- a/lib/tasks/stat_audit.rake
+++ b/lib/tasks/stat_audit.rake
@@ -1,0 +1,479 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+# ===========================================================================
+# JP wiki stat parser (gbf-wiki.com HTML)
+#
+# The stat table has header rows containing <strong>MinHP</strong>,
+# <strong>MaxHP</strong>, <strong>MinATK</strong>, <strong>MaxATK</strong>.
+# The row immediately after each header row holds the corresponding values.
+# Max values may appear as "1500 / 1877" (base / FLB).
+# ===========================================================================
+module Granblue
+  module StatAudit
+    module JpWikiStatParser
+      module_function
+
+      def parse(html)
+        doc = Nokogiri::HTML(html)
+        rows = doc.css('div#body table.style_table tr').to_a
+        stats = {}
+
+        rows.each_with_index do |row, index|
+          text = row.text
+
+          if text.include?('MinHP')
+            merge_stat(stats, :min_hp, :max_hp, :max_hp_flb, row_values(rows[index + 1]))
+          end
+
+          if text.include?('MinATK')
+            merge_stat(stats, :min_atk, :max_atk, :max_atk_flb, row_values(rows[index + 1]))
+          end
+        end
+
+        stats
+      end
+
+      # Extract numeric values from a data row.
+      # Returns [min_value, max_base, max_flb] where max_flb may be nil.
+      def row_values(row)
+        return [] unless row
+
+        cells = row.css('td').map { |td| td.text.strip }
+
+        # Min value is the second-to-last cell; max value is the last cell.
+        min_text = cells[-2].to_s
+        max_text = cells[-1].to_s
+
+        min_val = min_text[/\A(\d+)\z/, 1]&.to_i
+        max_base = max_text[%r{\A(\d+)\s*/\s*(\d+)}, 1]&.to_i || max_text[/\A(\d+)\z/, 1]&.to_i
+        max_flb = max_text[%r{\A\d+\s*/\s*(\d+)}, 1]&.to_i
+
+        [min_val, max_base, max_flb]
+      end
+
+      def merge_stat(stats, min_key, max_key, flb_key, values)
+        return if values.empty?
+
+        stats[min_key] = values[0] if values[0]&.positive?
+        stats[max_key] = values[1] if values[1]&.positive?
+        stats[flb_key] = values[2] if values[2]&.positive?
+      end
+    end
+
+    # =========================================================================
+    # Repopulation logic
+    # =========================================================================
+
+    class StatFixer
+      STAT_COLUMNS = %i[min_hp max_hp max_hp_flb min_atk max_atk max_atk_flb].freeze
+
+      attr_reader :source
+
+      def initialize(source:)
+        @source = source
+      end
+
+      # @return [Hash] patch with :action, :source, and any changed columns
+      def fix(record, model)
+        parsed = source == 'jp' ? parse_jp(record, model) : parse_en(record, model)
+        return { action: 'SKIP (no wiki data)', source: source } if parsed.nil?
+        return { action: 'SKIP (parse failed)', source: source } if parsed.empty?
+
+        updates = diff(record, parsed)
+        return { action: 'OK (already matches)', source: source } if updates.empty?
+
+        apply_updates(record, updates)
+        # Use string keys so they don't clobber the symbol keys holding the
+        # original values in the entry hash — the reporter checks for the
+        # string key to render an "old->new" diff.
+        { action: 'UPDATED', source: source }.merge(
+          updates.transform_keys(&:to_s).transform_values(&:last)
+        )
+      end
+
+      private
+
+      def diff(record, parsed)
+        updates = {}
+        STAT_COLUMNS.each do |col|
+          next unless parsed.key?(col)
+
+          new_val = parsed[col]
+          old_val = record.public_send(col)
+          next if new_val.to_i == old_val.to_i
+
+          updates[col] = [old_val, new_val.to_i]
+        end
+        updates
+      end
+
+      def apply_updates(record, updates)
+        updates.each do |col, pair|
+          record.public_send(:"#{col}=", pair.last)
+        end
+        record.save!(validate: false)
+      rescue ActiveRecord::RecordInvalid => e
+        warn "  Save failed for #{record.class} #{record.granblue_id}: #{e.message}"
+      end
+
+      # --- EN wiki: parse wiki_raw template text via WikiDataParser ---
+
+      def parse_en(record, _model)
+        return nil if record.wiki_raw.blank?
+
+        case record
+        when Character then Granblue::Parsers::WikiDataParser.parse_character(record.wiki_raw)
+        when Weapon    then Granblue::Parsers::WikiDataParser.parse_weapon(record.wiki_raw)
+        when Summon    then Granblue::Parsers::WikiDataParser.parse_summon(record.wiki_raw)
+        end
+      end
+
+      # --- JP wiki: parse wiki_raw_jp HTML (characters & summons only) ---
+
+      def parse_jp(record, model)
+        html = record.wiki_raw_jp
+        return nil if html.blank?
+
+        return {} unless [Character, Summon].include?(model)
+
+        JpWikiStatParser.parse(html)
+      end
+    end
+
+    # =========================================================================
+    # Report rendering
+    # =========================================================================
+
+    class StatReporter
+      HEADERS = %w[Type Name GranblueID min_hp min_atk max_hp max_atk Match Wiki Action].freeze
+
+      attr_reader :coverage
+
+      def initialize
+        @sections = Hash.new { |h, k| h[k] = [] }
+        @coverage = Hash.new { |h, k| h[k] = { total: 0, en: 0, jp: 0, jp_title: 0 } }
+      end
+
+      def add_section(name)
+        @sections[name] ||= []
+      end
+
+      def add_entry(section, entry)
+        @sections[section] << entry
+
+        cov = @coverage[section]
+        cov[:total] += 1
+        cov[:en] += 1 if entry[:has_en_raw]
+        cov[:jp] += 1 if entry[:has_jp_raw]
+        cov[:jp_title] += 1 if entry[:has_ja_title]
+      end
+
+      def total_count
+        @sections.values.sum(&:size)
+      end
+
+      def print(export: false)
+        if total_count.zero?
+          puts 'No suspicious records found (min_hp==min_atk or max_hp==max_atk).'
+          return
+        end
+
+        puts "Found #{total_count} suspicious record(s):\n\n"
+
+        lines = render_table
+        lines.concat(render_coverage)
+
+        return unless export
+
+        dir = Rails.root.join('export')
+        path = dir.join('stat-audit-report.txt')
+        FileUtils.mkdir_p(dir)
+        File.write(path, "#{lines.join("\n")}\n")
+        puts "Report written to #{path}"
+      end
+
+      private
+
+      def render_table
+        lines = []
+
+        @sections.each do |section, entries|
+          next if entries.empty?
+
+          rows = entries.map { |e| format_row(e) }
+          widths = compute_widths(rows)
+
+          border = "+#{HEADERS.map { |h| '-' * (widths[h] + 2) }.join('+')}+"
+
+          lines << ''
+          lines << "#{section} (#{entries.size})"
+          lines << border
+          lines << format_header_row(widths)
+          lines << border
+          rows.each { |r| lines << format_data_row(r, widths) }
+          lines << border
+          lines << ''
+        end
+
+        puts lines.join("\n")
+        lines
+      end
+
+      def render_coverage
+        lines = ['', 'Wiki data coverage for suspicious records:']
+        @coverage.each do |section, cov|
+          next if cov[:total].zero?
+
+          jp_col = jp_column_name(section)
+          lines << "  #{section} (#{cov[:total]}): " \
+                   "EN wiki #{cov[:en]}/#{cov[:total]}, " \
+                   "#{jp_col} #{cov[:jp]}/#{cov[:total]} " \
+                   "(#{cov[:jp_title]} have JP page title)"
+        end
+
+        actionable = actionable_hints
+        lines.concat(actionable) if actionable.any?
+
+        puts lines.join("\n")
+        lines
+      end
+
+      def actionable_hints
+        hints = ['']
+        @coverage.each do |section, cov|
+          model = section.downcase
+          if cov[:jp] < cov[:total] && model != 'weapon'
+            missing = cov[:total] - cov[:jp]
+            hints << "  #{missing} #{model}s missing JP wiki HTML — run: " \
+                     "rake granblue:download_jp_wiki model=#{model}"
+          end
+          next unless cov[:en] < cov[:total]
+
+          missing = cov[:total] - cov[:en]
+          hints << "  #{missing} #{model}s missing EN wiki text — run: " \
+                   "rake granblue:fetch_wiki_data type=#{model.capitalize}"
+        end
+        hints
+      end
+
+      def jp_column_name(section)
+        section == 'Weapon' ? 'JP(n/a)' : 'JP wiki'
+      end
+
+      def format_row(entry)
+        {
+          'Type'       => entry[:model],
+          'Name'       => entry[:name].to_s.slice(0, 40),
+          'GranblueID' => entry[:granblue_id].to_s,
+          'min_hp'     => format_change(entry, :min_hp),
+          'min_atk'    => format_change(entry, :min_atk),
+          'max_hp'     => format_change(entry, :max_hp),
+          'max_atk'    => format_change(entry, :max_atk),
+          'Match'      => entry[:matches],
+          'Wiki'       => format_wiki_status(entry),
+          'Action'     => entry[:action].to_s
+        }
+      end
+
+      def format_wiki_status(entry)
+        en = entry[:has_en_raw] ? 'Y' : 'N'
+        jp = if entry[:jp_column]
+               entry[:has_jp_raw] ? 'Y' : 'N'
+             else
+               '-'
+             end
+        "EN#{en} JP#{jp}"
+      end
+
+      # Shows "old -> new" when a value was changed, otherwise just the value.
+      def format_change(entry, key)
+        str_key = key.to_s
+        old = entry[key]
+
+        if entry.key?(str_key)
+          "#{old}->#{entry[str_key]}"
+        else
+          old.to_s
+        end
+      end
+
+      def compute_widths(rows)
+        widths = {}
+        HEADERS.each do |h|
+          widths[h] = [h.length, *rows.map { |r| r[h].length }].max
+        end
+        widths
+      end
+
+      def format_header_row(widths)
+        cells = HEADERS.map { |h| " #{h.ljust(widths[h])}" }
+        "|#{cells.join('|')}|"
+      end
+
+      def format_data_row(row, widths)
+        cells = HEADERS.map { |h| " #{row[h].ljust(widths[h])}" }
+        "|#{cells.join('|')}|"
+      end
+    end
+  end
+end
+
+# ===========================================================================
+# Rake task
+# ===========================================================================
+
+namespace :granblue do
+  desc <<~DESC
+    Find characters, weapons, and summons where min_hp == min_atk or
+    max_hp == max_atk (likely bad/placeholder data), and optionally
+    repopulate the stat columns from stored wiki data.
+
+    The EN wiki source parses wiki_raw (gbf.wiki template text) via
+    WikiDataParser. The JP wiki source parses wiki_raw_jp (gbf-wiki.com
+    HTML); it is only available on characters and summons.
+
+    Usage:
+      rake granblue:audit_stats                              # Scan all types, report only
+      rake granblue:audit_stats type=character               # Scan one type
+      rake granblue:audit_stats type=weapon                  #   character | weapon | summon
+      rake granblue:audit_stats repopulate=true              # Fix values from EN wiki (default)
+      rake granblue:audit_stats repopulate=true source=jp    # Fix values from JP wiki
+      rake granblue:audit_stats export=true                  # Also write report to export/
+  DESC
+  task audit_stats: :environment do
+    type       = ENV['type'].presence || 'all'
+    repopulate = ENV['repopulate'] == 'true'
+    source     = ENV['source'].presence || 'en'
+    export     = ENV['export'] == 'true'
+
+    valid_types = %w[all character weapon summon]
+    unless valid_types.include?(type)
+      warn "Invalid type '#{type}'. Must be one of: #{valid_types.join(', ')}"
+      exit 1
+    end
+
+    unless %w[en jp].include?(source)
+      warn "Invalid source '#{source}'. Must be 'en' or 'jp'."
+      exit 1
+    end
+
+    models = case type
+             when 'all'       then [Character, Weapon, Summon]
+             when 'character' then [Character]
+             when 'weapon'    then [Weapon]
+             when 'summon'    then [Summon]
+             end
+
+    reporter = Granblue::StatAudit::StatReporter.new
+    fixer    = Granblue::StatAudit::StatFixer.new(source: source)
+
+    models.each do |model|
+      reporter.add_section(model.name)
+
+      suspicious_scope(model).find_each do |record|
+        matches = detect_matches(record)
+        next if matches.empty?
+
+        entry = build_entry(model.name, record, matches)
+        reporter.add_entry(model.name, entry)
+
+        next unless repopulate
+
+        entry.merge!(fixer.fix(record, model))
+      end
+    end
+
+    reporter.print(export: export)
+  end
+
+  desc <<~DESC
+    Report wiki data coverage (wiki_raw / wiki_raw_jp / wiki_ja) for all
+    characters, weapons, and summons. Helps identify which records need
+    wiki data fetched before audit_stats repopulation can work.
+
+    Usage:
+      rake granblue:wiki_coverage                    # All types
+      rake granblue:wiki_coverage type=character     # One type
+  DESC
+  task wiki_coverage: :environment do
+    type = ENV['type'].presence || 'all'
+
+    models = case type
+             when 'all'       then [Character, Weapon, Summon]
+             when 'character' then [Character]
+             when 'weapon'    then [Weapon]
+             when 'summon'    then [Summon]
+             end
+
+    puts 'Wiki data coverage report'
+    puts '=' * 60
+
+    models.each do |model|
+      total      = model.count
+      has_en_raw = model.where.not(wiki_raw: [nil, '']).count
+      has_ja     = model.where.not(wiki_ja: [nil, '']).count
+      has_jp_raw = model.column_names.include?('wiki_raw_jp') ? model.where.not(wiki_raw_jp: [nil, '']).count : nil
+
+      jp_display = has_jp_raw.nil? ? 'n/a' : "#{has_jp_raw}/#{total}"
+
+      puts ""
+      puts "#{model.name} (#{total} total):"
+      puts "  wiki_raw  (EN template text): #{has_en_raw}/#{total}" \
+           "#{'  <-- MISSING' if has_en_raw < total}"
+      puts "  wiki_ja   (JP page title):    #{has_ja}/#{total}" \
+           "#{'  <-- MISSING' if has_ja < total}"
+      puts "  wiki_raw_jp (JP HTML):        #{jp_display}" \
+           "#{has_jp_raw && has_jp_raw < total ? '  <-- MISSING' : ''}"
+
+      next unless has_jp_raw && has_jp_raw < total && has_ja.positive?
+
+      puts ""
+      puts "  To fetch missing JP wiki HTML for #{has_ja - has_jp_raw} records:"
+      puts "    rake granblue:download_jp_wiki model=#{model.name.downcase}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+
+  # Scope that catches both conditions (min_hp==min_atk OR max_hp==max_atk).
+  # Zero values are excluded — they indicate unpopulated rows, not corruption.
+  def suspicious_scope(model)
+    model
+      .where('min_hp IS NOT NULL AND min_atk IS NOT NULL AND min_hp = min_atk AND min_hp > 0')
+      .or(model.where('max_hp IS NOT NULL AND max_atk IS NOT NULL AND max_hp = max_atk AND max_hp > 0'))
+  end
+
+  # Returns [:min, :max, [] — which conditions matched for this record.
+  def detect_matches(record)
+    matches = []
+    if record.min_hp.present? && record.min_atk.present? &&
+       record.min_hp.positive? && record.min_hp == record.min_atk
+      matches << :min
+    end
+    if record.max_hp.present? && record.max_atk.present? &&
+       record.max_hp.positive? && record.max_hp == record.max_atk
+      matches << :max
+    end
+    matches
+  end
+
+  def build_entry(model_name, record, matches)
+    {
+      model:        model_name,
+      name:         record.name_en.presence || record.name_jp.presence || '(unnamed)',
+      granblue_id:  record.granblue_id,
+      min_hp:       record.min_hp,
+      min_atk:      record.min_atk,
+      max_hp:       record.max_hp,
+      max_atk:      record.max_atk,
+      matches:      matches.map(&:to_s).join('+'),
+      action:       '—',
+      has_en_raw:   record.wiki_raw.present?,
+      has_jp_raw:   record.respond_to?(:wiki_raw_jp) && record.wiki_raw_jp.present?,
+      has_ja_title: record.respond_to?(:wiki_ja) && record.wiki_ja.present?,
+      jp_column:    record.respond_to?(:wiki_raw_jp)
+    }
+  end
+end


### PR DESCRIPTION
## Summary

Identifies and repairs corrupted HP/ATK data (where min_hp == min_atk) by repopulating from stored EN/JP wiki data. Improves the JP wiki downloader to handle weapons, detect error pages, and provide clear progress output.

## Changes

### New rake tasks
- **`granblue:audit_stats`** — Finds characters, weapons, and summons where `min_hp == min_atk` or `max_hp == max_atk`. Can optionally repopulate stats from stored wiki data (`repopulate=true source=en|jp`). Shows per-record wiki data status and actionable coverage gaps.
- **`granblue:wiki_coverage`** — Reports `wiki_raw` / `wiki_raw_jp` / `wiki_ja` coverage across all models to identify what needs fetching.

### JP wiki downloader improvements
- Add `wiki_raw_jp` column to weapons (migration `20260706000000`)
- Resolve JP wiki titles from `name_jp + rarity suffix` when `wiki_ja` is blank
- Add `武器/` prefix for weapon pages on gbf-wiki.com
- Detect and reject "Runtime error" pages (prevents caching garbage HTML)
- Human-friendly progress output with percentage, elapsed time, and ETA
- SQL log suppression (unless `debug=true`)

### Bugfixes
- Fix `WikiError#message` to return a readable string instead of a raw hash dump
- Suppress AWS initialization errors during rake tasks

## Usage

```bash
# Scan for suspicious stats
rake granblue:audit_stats

# Fix from EN wiki (default)
rake granblue:audit_stats repopulate=true source=en

# Fix from JP wiki (after downloading)
rake granblue:audit_stats repopulate=true source=jp

# Check wiki data coverage
rake granblue:wiki_coverage

# Download JP wiki HTML
rake granblue:download_jp_wiki model=weapon
```

## Test plan
- [x] `rake granblue:audit_stats` correctly identifies 685 suspicious records
- [x] `repopulate=true source=en` fixes stats from `wiki_raw` via WikiDataParser
- [x] `repopulate=true source=jp` fixes stats from `wiki_raw_jp` via Nokogiri parser
- [x] `rake granblue:download_jp_wiki model=weapon` downloads with correct `武器/` prefix
- [x] Runtime error pages are rejected, not cached
- [x] `rake granblue:wiki_coverage` reports accurate coverage gaps
- [x] Rubocop passes on all changed files
